### PR TITLE
Allow dispatch install to point to charts dir

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -14,4 +14,6 @@ image=${DOCKER_REGISTRY}/vs-${PACKAGE}:${TAG}
 echo $image
 
 docker build -t $image -f images/${PACKAGE}/Dockerfile .
-docker push $image
+if [ -z $NO_PUSH ]; then
+    docker push $image
+fi


### PR DESCRIPTION
* use install to install from charts source dir
* add destination dir for config
* reuse certs instead of recrating
  - helpful if you install certs into the keychain
* allow buiding images without pushing