### PR TITLE
Extend the default timeouts for running functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ ./dispatch-darwin get images
    NAME   |                    URL                     |  BASEIMAGE   |   STATUS    |         CREATED DATE
 --------------------------------------------------------------------------------------------------------------
   nodejs6 | vmware/dispatch-openfaas-nodejs6-base:0.0.2-dev1 | nodejs6-base | READY       | Wed Dec  6 14:28:30 PST 2017
-  python3 | vmware/dispatch-openfaas-python3-base:0.0.4-dev1 | python3-base | INITIALIZED | Wed Dec  6 14:28:30 PST 2017
+  python3 | vmware/dispatch-openfaas-python-base:0.0.4-dev1 | python3-base | INITIALIZED | Wed Dec  6 14:28:30 PST 2017
 $ ./dispatch-darwin get functions
     NAME   |  IMAGE  | STATUS |         CREATED DATE
 ---------------------------------------------------------

--- a/examples/seed.yaml
+++ b/examples/seed.yaml
@@ -1,6 +1,6 @@
 kind: base-image
 name: nodejs6-base
-dockerUrl: vmware/vs-openfaas-nodejs6-base:0.0.2-dev1
+dockerUrl: vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1
 language: nodejs6
 public: true
 tags:
@@ -9,7 +9,7 @@ tags:
 ---
 kind: base-image
 name: python3-base
-dockerUrl: vmware/vs-openfaas-python3-base:0.0.4-dev1
+dockerUrl: vmware/dispatch-openfaas-python-base:0.0.5-dev1
 language: python3
 public: true
 tags:

--- a/images/openfaas/deps-image-node/Dockerfile
+++ b/images/openfaas/deps-image-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/vs-openfaas-watchdog:rev2d268d9
+FROM vmware/dispatch-openfaas-watchdog:revbf667b8
 FROM vmware/photon:2.0
 COPY --from=0 /go/src/github.com/openfaas/faas/watchdog/watchdog /usr/bin/fwatchdog
 

--- a/images/openfaas/deps-image-node/build.sh
+++ b/images/openfaas/deps-image-node/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e -x
 
-docker build -t vmware/vs-openfaas-nodejs6-base:0.0.2-dev1 .
+cd $(dirname $0)
+
+docker build -t vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 .

--- a/images/openfaas/deps-image-python3-vmomi/Dockerfile
+++ b/images/openfaas/deps-image-python3-vmomi/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/vs-openfaas-watchdog:rev2d268d9
+FROM vmware/dispatch-openfaas-watchdog:revbf667b8
 FROM vmware/photon:2.0
 COPY --from=0 /go/src/github.com/openfaas/faas/watchdog/watchdog /usr/bin/fwatchdog
 

--- a/images/openfaas/deps-image-python3/Dockerfile
+++ b/images/openfaas/deps-image-python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/vs-openfaas-watchdog:rev2d268d9
+FROM vmware/dispatch-openfaas-watchdog:revbf667b8
 FROM vmware/photon:2.0
 COPY --from=0 /go/src/github.com/openfaas/faas/watchdog/watchdog /usr/bin/fwatchdog
 

--- a/images/openfaas/deps-image-python3/build.sh
+++ b/images/openfaas/deps-image-python3/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e -x
 
-docker build -t vmware/vs-openfaas-python3-base:0.0.4-dev1 .
+cd $(dirname $0)
+
+docker build -t vmware/dispatch-openfaas-python-base:0.0.5-dev1 .

--- a/pkg/functions/openfaas/driver_test.go
+++ b/pkg/functions/openfaas/driver_test.go
@@ -90,7 +90,7 @@ func TestDriver_Create(t *testing.T) {
 	defer d.Shutdown()
 
 	err := d.Create("hello", &functions.Exec{
-		Image:    "vmware/vs-openfaas-nodejs-base:0.0.2-dev1",
+		Image:    "vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1",
 		Language: "nodejs6",
 		Code: `
 module.exports = function (context, input) {

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -54,10 +54,10 @@ vs get base-image
 #   NAME | URL | STATUS | CREATED DATE
 # ---------------------------------
 
-vs create base-image photon-nodejs6 vmware/vs-openfaas-nodejs-base:0.0.2-dev1 --language nodejs6 --public
+vs create base-image photon-nodejs6 vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 --language nodejs6 --public
 # Created base image: photon-nodejs6
 test $(vs get base-image photon-nodejs6 --json | jq -r .status) = INITIALIZED
-vs create base-image photon-python3 vmware/vs-openfaas-python3-base:0.0.4-dev1 --language python3 --public
+vs create base-image photon-python3 vmware/dispatch-openfaas-python-base:0.0.5-dev1 --language python3 --public
 # Created base image: photon-python3
 test $(vs get base-image photon-python3 --json | jq -r .status) = INITIALIZED
 # Wait for image to be pulled (or attempted)
@@ -66,7 +66,7 @@ retry_test "vs get base-image photon-nodejs6 --json | jq -r .status" READY
 retry_test "vs get base-image photon-python3 --json | jq -r .status" READY
 
 
-vs create base-image photon-nodejs6-to-delete vmware/vs-openfaas-nodejs-base:0.0.2-dev1 --language nodejs6 --public
+vs create base-image photon-nodejs6-to-delete vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 --language nodejs6 --public
 # Created base image: photon-nodejs6-to-delete
 test $(vs get base-image --json | jq '. | length') = 3
 
@@ -81,8 +81,8 @@ vs get base-images
 #             NAME           |                                      URL                                           | STATUS |         CREATED DATE
 # ------------------------------------------------------------------------------------------------------------------------------------------------
 #   missing-image            | missing/image:latest                                                               | ERROR  | Thu Oct 19 14:44:54 PDT 2017
-#   photon-nodejs6           | vmware/vs-openfaas-nodejs-base:0.0.2-dev1 | READY  | Tue Oct 17 16:51:27 PDT 2017
-#   photon-nodejs6-to-delete | vmware/vs-openfaas-nodejs-base:0.0.2-dev1 | READY  | Tue Oct 17 16:55:30 PDT 2017
+#   photon-nodejs6           | vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 | READY  | Tue Oct 17 16:51:27 PDT 2017
+#   photon-nodejs6-to-delete | vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 | READY  | Tue Oct 17 16:55:30 PDT 2017
 
 vs delete base-image photon-nodejs6-to-delete
 # Deleted base image: photon-nodejs6-to-delete
@@ -91,7 +91,7 @@ retry_test "vs get base-image --json | jq '. | length'" 3
 vs get base-image
 #             NAME           |                                      URL                                           | STATUS |         CREATED DATE
 # ------------------------------------------------------------------------------------------------------------------------------------------------
-#   photon-nodejs6           | vmware/vs-openfaas-nodejs-base:0.0.2-dev1 | READY  | Tue Oct 17 16:51:27 PDT 2017
+#   photon-nodejs6           | vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 | READY  | Tue Oct 17 16:51:27 PDT 2017
 
 vs create image base-node photon-nodejs6
 # created image: base-node
@@ -103,7 +103,7 @@ test $(vs get image base-python3 --json | jq -r .status) = READY
 vs get image
 #     NAME    |                                      URL                                           |   BASEIMAGE    | STATUS |         CREATED DATE
 # -------------------------------------------------------------------------------------------------------------------------------------------------
-#   base-node | vmware/vs-openfaas-nodejs-base:0.0.2-dev1 | photon-nodejs6 | READY  | Thu Oct 19 15:26:01 PDT 2017
+#   base-node | vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 | photon-nodejs6 | READY  | Thu Oct 19 15:26:01 PDT 2017
 
 test -e ../examples/nodejs6/hello.js
 


### PR DESCRIPTION
Bump the OpenFaaS watchdog revision: 

Both http.Server.ReadTimeout and http.Server.WriteTimeout were set to 5s
by default in the OpenFaaS watchdog. This revision changes these defaults to 5 minutes. 