### PR TITLE
Add bats e2e tests replacing demo.sh

### DIFF
--- a/charts/dispatch/charts/api-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/api-manager/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
             - "--function-manager={{ .Release.Name }}-function-manager.{{ .Release.Namespace }}"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
             - "--tls-key=/data/tls/tls.key"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
             - "--tls-key=/data/tls/tls.key"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             - "--tls-key=/data/tls/tls.key"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
             - "--tls-key=/data/tls/tls.key"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/charts/secret-store/templates/deployment.yaml
+++ b/charts/dispatch/charts/secret-store/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             - "--namespace={{ .Release.Namespace }}"
             {{- if .Values.global.debug }}
             - "--debug"
+            {{- end }}
+            {{- if .Values.global.trace }}
             - "--trace"
             {{- end }}
           ports:

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -8,6 +8,7 @@ global:
     tag: latest
     host: vmware
   debug: true
+  trace: false
   data:
     persist: false
   host: dispatch.vmware.com

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Wrapper script to run bats tests for various drivers.
+# Usage: ./run-e2e.sh [subtest]
+
+function quiet_run () {
+    if [[ "$VERBOSE" == "1" ]]; then
+        "$@"
+    else
+        "$@" &>/dev/null
+    fi
+}
+
+function bring_dispatch_up {
+  OS=`uname`
+  echo "   Installing dispatch..."
+  dispatch install --file ${DISPATCH_CONFIG} --charts-dir ${DISPATCH_ROOT}/charts --destination ${DISPATCH_ROOT} --debug
+}
+
+function cleanup_dispatch {
+  echo " - Cleaning up dispatch"
+}
+
+function dispatch() {
+    OS=`uname`
+    ${DISPATCH_ROOT}/bin/${DISPATCH_BIN_NAME}-${OS,,} --config ${DISPATCH_ROOT}/${DISPATCH_CLI_CONFIG} "$@"
+}
+
+function run_bats() {
+    if [[ $INSTALL_DISPATCH == 1 ]]; then
+        bring_dispatch_up
+    fi
+
+    echo "=> running clean first"
+    # BATS returns non-zero to indicate the tests have failed, we shouldn't
+    # necessarily bail in this case, so that's the reason for the e toggle.
+    set +e
+    bats "e2e/tests/clean.bats"
+
+    for bats_file in $(find "$1" -name \*.bats | grep -v clean); do
+        echo "=> $bats_file"
+        bats "$bats_file"
+        if [[ $? -ne 0 ]]; then
+            EXIT_STATUS=1
+        fi
+        echo
+    done
+    set -e
+
+    if [[ $INSTALL_DISPATCH == 1 ]]; then
+        cleanup_dispatch
+    fi
+}
+
+# Set this ourselves in case bats call fails
+EXIT_STATUS=0
+export BATS_FILE="$1"
+export DISPATCH_CONFIG="$2"
+: ${INSTALL_DISPATCH:=1}
+
+# Check we're not running bash 3.x
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    echo "Bash 4.1 or later is required to run these tests"
+    exit 1
+fi
+
+# If bash 4.x, check the minor version is 1 or later
+if [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -lt 1 ]; then
+    echo "Bash 4.1 or later is required to run these tests"
+    exit 1
+fi
+
+if [[ -z "$BATS_FILE" ]]; then
+    echo "You must specify a bats test to run."
+    exit 1
+fi
+
+if [[ ! -e "$BATS_FILE" ]]; then
+    echo "Requested bats file or directory not found: $BATS_FILE"
+    exit 1
+fi
+
+if [[ -z "$DISPATCH_CONFIG" && $INSTALL_DISPATCH == 1 ]]; then
+    echo "You must specify a dispatch config file if installing dispatch (default)."
+    exit 1
+fi
+
+if [[ ! -e "$DISPATCH_CONFIG" && $INSTALL_DISPATCH == 1 ]]; then
+    echo "Requested dispatch config file not found: $DISPATCH_CONFIG"
+    exit 1
+fi
+
+# TODO: Should the script bail out if these are set already?
+export BASE_TEST_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+export DISPATCH_ROOT="$BASE_TEST_DIR/../.."
+export DISPATCH_BIN_NAME=dispatch
+# By default the CLI config is the generated .dispatch.json in the DISPATCH_ROOT.
+# If running e2e against a cluster brought up separately, you can point to a
+# different location (i.e. $HOME/.dispatch.json)
+export DISPATCH_CLI_CONFIG=${DISPATCH_CLI_CONFIG:-"${DISPATCH_ROOT}/.dispatch.json"}
+
+export RUN_ID=$RANDOM
+
+if [ "${CI}" = true ] ; then
+  export TEST_ID="d${IMAGE_TAG}"
+  export BATS_LOG="/logs/bats.log"
+else
+  export TEST_ID="t-$(date +%s | shasum | base64 | head -c 5)"
+  export BATS_LOG="$DISPATCH_ROOT/bats.log"
+fi
+
+# This function gets used in the integration tests, so export it.
+export -f dispatch
+
+> "$BATS_LOG"
+
+run_bats "$BATS_FILE"
+echo "finished"
+
+exit ${EXIT_STATUS}

--- a/e2e/tests/clean.bats
+++ b/e2e/tests/clean.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Clean all" {
+    cleanup
+}

--- a/e2e/tests/events.bats
+++ b/e2e/tests/events.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create node function with schema" {
+    run dispatch create function nodejs6 node-hello-subscribe-${RUN_ID} ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-subscribe-${RUN_ID} --json | jq -r .status" "READY" 6 5
+}
+
+@test "Create subscription" {
+    run dispatch create subscription test.event node-hello-subscribe-${RUN_ID}
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get subscription test_event_node-hello-subscribe-${RUN_ID} --json | jq -r .status" "READY" 4 5
+}
+
+@test "Emit event" {
+    run dispatch emit test.event --payload='{"name": "Jon", "place": "Winterfell"}'
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get runs node-hello-subscribe-${RUN_ID} --json | jq -r .[0].output.myField" "Hello, Jon from Winterfell" 4 5
+}
+
+@test "Delete subscription" {
+    run dispatch delete subscription test_event_node-hello-subscribe-${RUN_ID}
+    echo_to_log
+    assert_success
+}
+
+@test "Cleanup" {
+    cleanup
+}
+
+

--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create node function no schema" {
+
+    run dispatch create function nodejs6 node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Execute node function no schema" {
+    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .myField" "Hello, Jon from Winterfell" 0 0
+}
+
+@test "Create python function no schema" {
+    run dispatch create function python3 python-hello-no-schema ${DISPATCH_ROOT}/examples/python3/hello.py
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function python-hello-no-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Execute python function no schema" {
+    run_with_retry "dispatch exec python-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .myField" "Hello, Jon from Winterfell" 0 0
+}
+
+@test "Create node function with schema" {
+    run dispatch create function nodejs6 node-hello-with-schema ${DISPATCH_ROOT}/examples/nodejs6/hello.js --schema-in ${DISPATCH_ROOT}/examples/nodejs6/hello.schema.in.json --schema-out ${DISPATCH_ROOT}/examples/nodejs6/hello.schema.out.json
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-with-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Execute node function with schema" {
+    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .myField" "Hello, Jon from Winterfell" 0 0
+}
+
+@test "Validate schema errors" {
+    skip "schema validation only returns null"
+}
+
+@test "Delete functions" {
+    delete_functions
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests/helpers.bash
+++ b/e2e/tests/helpers.bash
@@ -1,0 +1,291 @@
+#!/bin/bash
+
+### COMMON FUNCTIONS ###
+
+# retry_timeout takes 2 args: command [timeout (secs)]
+retry_timeout () {
+  count=0
+  while [[ ! `eval $1` ]]; do
+    sleep 1
+    count=$((count+1))
+    if [[ "$count" -gt $2 ]]; then
+      return 1
+    fi
+  done
+}
+
+# values_equal takes 2 values, both must be non-null and equal
+values_equal () {
+  if [[ "X$1" != "X" ]] || [[ "X$2" != "X" ]] && [[ $1 == $2 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# min_value_met takes 2 values, both must be non-null and 2 must be equal or greater than 1
+min_value_met () {
+  if [[ "X$1" != "X" ]] || [[ "X$2" != "X" ]] && [[ $2 -ge $1 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function echo_to_log {
+  echo "$output" >> ${BATS_LOG}
+}
+
+function setup {
+  echo "$BATS_TEST_NAME
+----------
+" >> ${BATS_LOG}
+}
+
+function teardown {
+  echo "
+----------
+
+" >> ${BATS_LOG}
+}
+
+function errecho {
+  >&2 echo "$@"
+}
+
+function only_if_env {
+  if [[ ${!1} != "$2" ]]; then
+      errecho "This test requires the $1 environment variable to be set to $2. Skipping..."
+      skip
+  fi
+}
+
+function require_env {
+  if [[ -z ${!1} ]]; then
+      errecho "This test requires the $1 environment variable to be set in order to run."
+      exit 1
+  fi
+}
+
+flunk() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } >&2
+  return 1
+}
+
+fatal() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } >&2
+  exit 1
+}
+
+assert_success() {
+  if [ "$status" -ne 0 ]; then
+    flunk "command failed with exit status $status: $output"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_success_or_fatal() {
+  if [ "$status" -ne 0 ]; then
+    fatal "command failed with exit status $status: $output"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_failure() {
+  if [ "$status" -ne 1 ]; then
+    flunk $(printf "expected failed exit status=1, got status=%d" $status)
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    { echo "expected: $1"
+      echo "actual:   $2"
+    } | flunk
+  fi
+}
+
+assert_output() {
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal "$expected" "$output"
+}
+
+assert_matches() {
+  local pattern="${1}"
+  local actual="${2}"
+
+  if [ $# -eq 1 ]; then
+    actual="$(cat -)"
+  fi
+
+  if ! grep -q "${pattern}" <<<"${actual}"; then
+    { echo "pattern: ${pattern}"
+      echo "actual:  ${actual}"
+    } | flunk
+  fi
+}
+
+assert_not_matches() {
+  local pattern="${1}"
+  local actual="${2}"
+
+  if [ $# -eq 1 ]; then
+    actual="$(cat -)"
+  fi
+
+  if grep -q "${pattern}" <<<"${actual}"; then
+    { echo "pattern: ${pattern}"
+      echo "actual:  ${actual}"
+    } | flunk
+  fi
+}
+
+assert_empty() {
+  local actual="${1}"
+
+  if [ $# -eq 0 ]; then
+    actual="$(cat -)"
+  fi
+
+  if [ -n "${actual}" ]; then
+    { echo "actual: ${actual}"
+    } | flunk
+  fi
+}
+
+assert_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    assert_equal "$2" "$(collapse_ws ${lines[$1]})"
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$(collapse_ws $line)" = "$1" ]; then return 0; fi
+    done
+    flunk "expected line \`$1'"
+  fi
+}
+
+refute_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    local num_lines="${#lines[@]}"
+    if [ "$1" -lt "$num_lines" ]; then
+      flunk "output has $num_lines lines"
+    fi
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$line" = "$1" ]; then
+        flunk "expected to not find line \`$line'"
+      fi
+    done
+  fi
+}
+
+assert() {
+  if ! "$@"; then
+    flunk "failed: $@"
+  fi
+}
+
+# Run an arbitrary bash command and validate the output.
+#
+# usage: run_with_retry <bash command> <success output> <retries> <sleep interval>
+#
+# example: validate the number of subnets for a given cell ID (success output is 1, retry is 2, sleep is 30s)
+#   run_with_retry "aws ec2 describe-subnets --region=$DEFAULT_AWS_REGION --filters 'Name=tag:CellID,Values=${TEST_ID}' | jq '.Subnets[].CidrBlock' | wc -l" 1 2 30
+run_with_retry() {
+  for i in $(seq 1 ${3}); do
+      run bash -c "${1}"
+      assert_success
+      echo_to_log
+      if [[ ${output} =~ "${2}" ]]; then
+          break
+      fi
+      sleep ${4}
+  done
+  echo ${1}
+  echo $output
+  [[ ${output} =~ "${2}" ]]
+}
+
+batch_create_images() {
+  run dispatch create --file ${BATS_TEST_DIRNAME}/${1}
+  assert_success
+  run bash -c "dispatch get images --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run_with_retry "dispatch get image $i --json | jq -r .status" "READY" 6 30
+  done
+}
+
+batch_delete_images() {
+  run dispatch delete --file ${BATS_TEST_DIRNAME}/${1}
+  assert_success
+  run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+delete_base_images() {
+  run bash -c "dispatch get base-images --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run dispatch delete base-image $i
+  done
+  run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+delete_images() {
+  run bash -c "dispatch get images --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run dispatch delete image $i
+  done
+  run_with_retry "dispatch get images --json | jq '. | length'" 0 4 5
+}
+
+delete_functions() {
+  run bash -c "dispatch get functions --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run dispatch delete function $i
+  done
+  run_with_retry "dispatch get functions --json | jq '. | length'" 0 4 5
+}
+
+delete_secrets() {
+  run bash -c "dispatch get secrets --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run dispatch delete secret $i
+  done
+  run_with_retry "dispatch get secrets --json | jq '. | length'" 0 4 5
+}
+
+delete_subscriptions() {
+  run bash -c "dispatch get subscriptions --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run dispatch delete subscription $i
+  done
+  run_with_retry "dispatch get subscriptions --json | jq '. | length'" 0 4 5
+}
+
+cleanup() {
+  delete_subscriptions
+  delete_secrets
+  delete_functions
+  delete_images
+  delete_base_images
+}

--- a/e2e/tests/images.bats
+++ b/e2e/tests/images.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Base image creation" {
+
+    run dispatch get base-image
+    assert_success
+
+    # Create base image "base-nodejs6"
+    run dispatch create base-image base-nodejs6 $DOCKER_REGISTRY/$BASE_IMAGE_NODEJS6 --language nodejs6 --public
+    assert_success
+
+    # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "INITIALIZED" 0 0
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "READY" 4 5
+
+    # Create base image "base-python3"
+    run dispatch create base-image base-python3 $DOCKER_REGISTRY/$BASE_IMAGE_PYTHON3 --language python3 --public
+    assert_success
+
+    # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
+    run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "INITIALIZED" 0 0
+    run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "READY" 4 5
+
+    # Create third image with non-existing image. Check that get operation returns three images. Wait for "ERROR" status for missing image.
+    run dispatch create base-image missing-image missing/image:latest --language nodejs6 --public
+    assert_success
+    run bash -c "dispatch get base-image --json | jq '. | length'"
+    assert_equal 3 $output
+    run_with_retry "dispatch get base-image missing-image --json | jq -r .status" "ERROR" 4 5
+}
+
+@test "Image creation" {
+    run dispatch create image nodejs6 base-nodejs6
+    assert_success
+    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 4 5
+
+    run dispatch create image python3 base-python3
+    assert_success
+    run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 4 5
+}
+
+@test "Delete images" {
+    run bash -c "dispatch get images --json | jq -r .[].name"
+    assert_success
+    for i in $output; do
+        run dispatch delete image $i
+    done
+    run_with_retry "dispatch get images --json | jq '. | length'" 0 4 5
+}
+
+@test "Delete base images" {
+    run bash -c "dispatch get base-images --json | jq -r .[].name"
+    assert_success
+    for i in $output; do
+        run dispatch delete base-image $i
+    done
+    run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+@test "Batch load images" {
+    run dispatch create --file ${BATS_TEST_DIRNAME}/images.yaml
+    assert_success
+    run bash -c "dispatch get images --json | jq -r .[].name"
+    assert_success
+    for i in $output; do
+        run_with_retry "dispatch get image $i --json | jq -r .status" "READY" 6 30
+    done
+}
+
+@test "Batch delete images" {
+    run dispatch delete --file ${BATS_TEST_DIRNAME}/images.yaml
+    assert_success
+    run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests/images.yaml
+++ b/e2e/tests/images.yaml
@@ -1,0 +1,31 @@
+kind: base-image
+name: nodejs6-base
+dockerUrl: vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1
+language: nodejs6
+public: true
+tags:
+  - key: role
+    value: test
+---
+kind: base-image
+name: python3-base
+dockerUrl: vmware/dispatch-openfaas-python-base:0.0.5-dev1
+language: python3
+public: true
+tags:
+  - key: role
+    value: test
+---
+kind: image
+name: nodejs6
+baseImageName: nodejs6-base
+tags:
+  - key: role
+    value: test
+---
+kind: image
+name: python3
+baseImageName: python3-base
+tags:
+  - key: role
+    value: test

--- a/e2e/tests/secrets.bats
+++ b/e2e/tests/secrets.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create secret" {
+    run dispatch create secret open-sesame ${DISPATCH_ROOT}/examples/nodejs6/secret.json
+    echo_to_log
+    assert_success
+}
+
+@test "Create function with a default secret" {
+    run dispatch create function nodejs6 i-have-a-default-secret ${DISPATCH_ROOT}/examples/nodejs6/i-have-a-secret.js --secret open-sesame
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-default-secret --json | jq -r .status" "READY" 4 5
+}
+
+@test "Create function without a default secret" {
+    run dispatch create function nodejs6 i-have-a-secret ${DISPATCH_ROOT}/examples/nodejs6/i-have-a-secret.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-secret --json | jq -r .status" "READY" 4 5
+}
+
+@test "Execute function with a default secret" {
+    run_with_retry "dispatch exec i-have-a-default-secret --wait --json | jq -r .message" "The password is OpenSesame" 0 0
+}
+
+@test "Execute function without a default secret" {
+    run_with_retry "dispatch exec i-have-a-secret --wait --json | jq -r .message" "I know nothing" 0 0
+    run_with_retry "dispatch exec i-have-a-secret --secret open-sesame --wait --json | jq -r .message" "The password is OpenSesame" 0 0
+}
+
+@test "Validate invalid secret errors" {
+    skip "secret validation only returns null"
+}
+
+@test "Delete secrets" {
+    delete_secrets
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+### COMMON VARIABLES ###
+
+: ${DOCKER_REGISTRY:="vmware"}
+: ${BASE_IMAGE_PYTHON3:="dispatch-openfaas-python-base:0.0.5-dev1"}
+: ${BASE_IMAGE_NODEJS6:="dispatch-openfaas-nodejs6-base:0.0.3-dev1"}

--- a/pkg/dispatchcli/cmd/create.go
+++ b/pkg/dispatchcli/cmd/create.go
@@ -148,7 +148,7 @@ func NewCmdCreate(out io.Writer, errOut io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&file, "file", "", "Path to YAML file")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to YAML file")
 
 	cmd.AddCommand(NewCmdCreateBaseImage(out, errOut))
 	cmd.AddCommand(NewCmdCreateImage(out, errOut))

--- a/pkg/dispatchcli/cmd/delete.go
+++ b/pkg/dispatchcli/cmd/delete.go
@@ -57,6 +57,6 @@ func NewCmdDelete(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.AddCommand(NewCmdDeleteSubscription(out, errOut))
 	cmd.AddCommand(NewCmdDeleteEventDriver(out, errOut))
 
-	cmd.Flags().StringVar(&file, "file", "", "Path to YAML file")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Path to YAML file")
 	return cmd
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var tracingEnabled = true
+var tracingEnabled = false
 
 // Enable global tracing.
 func Enable() {


### PR DESCRIPTION
* e2e tests exercise all but the api-manager
	- future commit for that
* charts now accept --trace as well as --debug separately
* run_e2e.sh script kicks off tests (easy to run locally)
* allow -f shortcut on create/delete CLI

Notice there is one failure... it is intermittent and there is an issue created:
```
$ INSTALL_DISPATCH=0 ./e2e/scripts/run-e2e.sh e2e/tests config.yaml
=> running clean first
 ✓ Clean all

1 test, 0 failures
=> e2e/tests/functions.bats
 ✓ Batch load images
 ✓ Create node function no schema
 ✓ Execute node function no schema
 ✓ Create python function no schema
 ✓ Execute python function no schema
 ✓ Create node function with schema
 ✓ Execute node function with schema
 - Validate schema errors (skipped: schema validation only returns null)
 ✓ Delete functions
 ✓ Cleanup

10 tests, 0 failures, 1 skipped

=> e2e/tests/events.bats
 ✓ Batch load images
 ✓ Create node function with schema
 ✓ Create subscription
 ✗ Emit event
   (from function `run_command' in file e2e/tests/helpers.bash, line 226,
    in test file e2e/tests/events.bats, line 33)
     `run_command "dispatch get runs node-hello-subscribe-${RUN_ID} --json | jq -r .[0].output.myField" "Hello, Jon from Winterfell" 4 5' failed
   dispatch get runs node-hello-subscribe-13975 --json | jq -r .[0].output.myField
   null
 ✓ Delete subscription
 ✓ Cleanup

6 tests, 1 failure

=> e2e/tests/secrets.bats
 ✓ Batch load images
 ✓ Create secret
 ✓ Create function with a default secret
 ✓ Create function without a default secret
 ✓ Execute function with a default secret
 ✓ Execute function without a default secret
 - Validate invalid secret errors (skipped: secret validation only returns null)
 ✓ Delete secrets
 ✓ Cleanup

9 tests, 0 failures, 1 skipped

=> e2e/tests/images.bats
 ✓ Base image creation
 ✓ Image creation
 ✓ Delete images
 ✓ Delete base images
 ✓ Batch load images
 ✓ Batch delete images
 ✓ Cleanup

7 tests, 0 failures

finished
```