### PR TITLE
Use FunctionIDs rather than name

### DIFF
--- a/pkg/function-manager/gen/models/run.go
+++ b/pkg/function-manager/gen/models/run.go
@@ -33,6 +33,10 @@ type Run struct {
 	// Read Only: true
 	FinishedTime int64 `json:"finishedTime,omitempty"`
 
+	// function Id
+	// Read Only: true
+	FunctionID string `json:"functionId,omitempty"`
+
 	// function name
 	// Read Only: true
 	FunctionName string `json:"functionName,omitempty"`
@@ -51,8 +55,14 @@ type Run struct {
 	// Read Only: true
 	Output interface{} `json:"output,omitempty"`
 
+	// reason
+	Reason []string `json:"reason"`
+
 	// secrets
 	Secrets []string `json:"secrets"`
+
+	// status
+	Status Status `json:"status,omitempty"`
 }
 
 /* polymorph Run blocking false */
@@ -60,6 +70,8 @@ type Run struct {
 /* polymorph Run executedTime false */
 
 /* polymorph Run finishedTime false */
+
+/* polymorph Run functionId false */
 
 /* polymorph Run functionName false */
 
@@ -71,7 +83,11 @@ type Run struct {
 
 /* polymorph Run output false */
 
+/* polymorph Run reason false */
+
 /* polymorph Run secrets false */
+
+/* polymorph Run status false */
 
 // Validate validates this run
 func (m *Run) Validate(formats strfmt.Registry) error {
@@ -82,7 +98,17 @@ func (m *Run) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateReason(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateSecrets(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateStatus(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -102,10 +128,35 @@ func (m *Run) validateLogs(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Run) validateReason(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Reason) { // not required
+		return nil
+	}
+
+	return nil
+}
+
 func (m *Run) validateSecrets(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Secrets) { // not required
 		return nil
+	}
+
+	return nil
+}
+
+func (m *Run) validateStatus(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Status) { // not required
+		return nil
+	}
+
+	if err := m.Status.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("status")
+		}
+		return err
 	}
 
 	return nil

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -545,6 +545,10 @@ func init() {
           "type": "integer",
           "readOnly": true
         },
+        "functionId": {
+          "type": "string",
+          "readOnly": true
+        },
         "functionName": {
           "type": "string",
           "readOnly": true
@@ -567,11 +571,20 @@ func init() {
           "type": "object",
           "readOnly": true
         },
+        "reason": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "secrets": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "status": {
+          "$ref": "#/definitions/Status"
         }
       }
     },

--- a/pkg/function-manager/handlers_test.go
+++ b/pkg/function-manager/handlers_test.go
@@ -182,7 +182,7 @@ func Test_runModelToEntitySecret(t *testing.T) {
 	runModel0 := models.Run{Secrets: []string{}}
 	bs, _ := json.Marshal(runModel0)
 	secrets := []string{"x", "y", "z"}
-	f := Function{Secrets: secrets}
+	f := functions.Function{Secrets: secrets}
 	var runModel models.Run
 	json.Unmarshal(bs, &runModel)
 	assert.NotNil(t, runModel.Secrets)

--- a/pkg/functions/entities.go
+++ b/pkg/functions/entities.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///////////////////////////////////////////////////////////////////////
 
-package functionmanager
+package functions
 
 // NO TESTS
 
@@ -34,28 +34,29 @@ type Schema struct {
 type FnRun struct {
 	entitystore.BaseEntity
 	FunctionName string      `json:"functionName"`
+	FunctionID   string      `json:"functionID"`
 	Blocking     bool        `json:"blocking"`
 	Input        interface{} `json:"input,omitempty"`
 	Output       interface{} `json:"output,omitempty"`
 	Secrets      []string    `json:"secrets,omitempty"`
 	Logs         []string    `json:"logs,omitempty"`
 
-	waitChan chan struct{}
+	WaitChan chan struct{} `json:"-"`
 }
 
-func (r *FnRun) wait() {
+func (r *FnRun) Wait() {
 	defer trace.Trace("")()
 
-	if r.waitChan != nil {
-		<-r.waitChan
+	if r.WaitChan != nil {
+		<-r.WaitChan
 	}
 }
 
-func (r *FnRun) done() {
+func (r *FnRun) Done() {
 	defer trace.Trace("")()
 
 	defer func() {
 		recover()
 	}()
-	close(r.waitChan)
+	close(r.WaitChan)
 }

--- a/pkg/functions/entities_test.go
+++ b/pkg/functions/entities_test.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///////////////////////////////////////////////////////////////////////
 
-package functionmanager
+package functions
 
 import (
 	"testing"
@@ -11,16 +11,16 @@ import (
 
 func TestFnRun_doneNoPanicByDefault(t *testing.T) {
 	f := new(FnRun)
-	f.wait()
-	f.done()
+	f.Wait()
+	f.Done()
 }
 
 func TestFnRun_waitDone(t *testing.T) {
 	f := new(FnRun)
-	f.waitChan = make(chan struct{})
+	f.WaitChan = make(chan struct{})
 
 	go func() {
-		f.done()
+		f.Done()
 	}()
-	f.wait()
+	f.Wait()
 }

--- a/pkg/functions/mocks/faa_s_driver.go
+++ b/pkg/functions/mocks/faa_s_driver.go
@@ -9,13 +9,13 @@ type FaaSDriver struct {
 	mock.Mock
 }
 
-// Create provides a mock function with given fields: name, exec
-func (_m *FaaSDriver) Create(name string, exec *functions.Exec) error {
-	ret := _m.Called(name, exec)
+// Create provides a mock function with given fields: f, exec
+func (_m *FaaSDriver) Create(f *functions.Function, exec *functions.Exec) error {
+	ret := _m.Called(f, exec)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *functions.Exec) error); ok {
-		r0 = rf(name, exec)
+	if rf, ok := ret.Get(0).(func(*functions.Function, *functions.Exec) error); ok {
+		r0 = rf(f, exec)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -23,13 +23,13 @@ func (_m *FaaSDriver) Create(name string, exec *functions.Exec) error {
 	return r0
 }
 
-// Delete provides a mock function with given fields: name
-func (_m *FaaSDriver) Delete(name string) error {
-	ret := _m.Called(name)
+// Delete provides a mock function with given fields: f
+func (_m *FaaSDriver) Delete(f *functions.Function) error {
+	ret := _m.Called(f)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(name)
+	if rf, ok := ret.Get(0).(func(*functions.Function) error); ok {
+		r0 = rf(f)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -37,13 +37,13 @@ func (_m *FaaSDriver) Delete(name string) error {
 	return r0
 }
 
-// GetRunnable provides a mock function with given fields: name
-func (_m *FaaSDriver) GetRunnable(name string) functions.Runnable {
-	ret := _m.Called(name)
+// GetRunnable provides a mock function with given fields: e
+func (_m *FaaSDriver) GetRunnable(e *functions.FunctionExecution) functions.Runnable {
+	ret := _m.Called(e)
 
 	var r0 functions.Runnable
-	if rf, ok := ret.Get(0).(func(string) functions.Runnable); ok {
-		r0 = rf(name)
+	if rf, ok := ret.Get(0).(func(*functions.FunctionExecution) functions.Runnable); ok {
+		r0 = rf(e)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(functions.Runnable)

--- a/pkg/functions/openfaas/driver_test.go
+++ b/pkg/functions/openfaas/driver_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/vmware/dispatch/pkg/entity-store"
+
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -73,7 +75,7 @@ func TestOfDriver_GetRunnable(t *testing.T) {
 	d := driver()
 	defer d.Shutdown()
 
-	f := d.GetRunnable("hello")
+	f := d.GetRunnable(&functions.FunctionExecution{Name: "hello", ID: "deadbeef"})
 	ctx := functions.Context{}
 	r, err := f(ctx, map[string]interface{}{"name": "Me", "place": "Here"})
 
@@ -89,7 +91,14 @@ func TestDriver_Create(t *testing.T) {
 	d := driver()
 	defer d.Shutdown()
 
-	err := d.Create("hello", &functions.Exec{
+	f := functions.Function{
+		BaseEntity: entitystore.BaseEntity{
+			Name: "hello",
+			ID:   "deadbeef",
+		},
+	}
+
+	err := d.Create(&f, &functions.Exec{
 		Image:    "vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1",
 		Language: "nodejs6",
 		Code: `
@@ -117,6 +126,12 @@ func TestOfDriver_Delete(t *testing.T) {
 	d := driver()
 	defer d.Shutdown()
 
-	err := d.Delete("hello")
+	f := functions.Function{
+		BaseEntity: entitystore.BaseEntity{
+			Name: "hello",
+			ID:   "deadbeef",
+		},
+	}
+	err := d.Delete(&f)
 	assert.NoError(t, err)
 }

--- a/pkg/functions/openwhisk/driver.go
+++ b/pkg/functions/openwhisk/driver.go
@@ -38,9 +38,9 @@ func New(config *Config) (functions.FaaSDriver, error) {
 	return &wskDriver{client}, nil
 }
 
-func (d *wskDriver) Create(id string, exec *functions.Exec) error {
+func (d *wskDriver) Create(f *functions.Function, exec *functions.Exec) error {
 	action := &whisk.Action{
-		Name: id,
+		Name: f.ID,
 		Exec: &whisk.Exec{
 			Code:  &exec.Code,
 			Main:  exec.Main,
@@ -52,8 +52,8 @@ func (d *wskDriver) Create(id string, exec *functions.Exec) error {
 	return err
 }
 
-func (d *wskDriver) Delete(id string) error {
-	_, err := d.client.Actions.Delete(id)
+func (d *wskDriver) Delete(f *functions.Function) error {
+	_, err := d.client.Actions.Delete(f.ID)
 	return err
 }
 
@@ -62,9 +62,9 @@ type ctxAndIn struct {
 	Input   interface{}       `json:"input"`
 }
 
-func (d *wskDriver) GetRunnable(id string) functions.Runnable {
+func (d *wskDriver) GetRunnable(e *functions.FunctionExecution) functions.Runnable {
 	return func(ctx functions.Context, in interface{}) (interface{}, error) {
-		result, _, err := d.client.Actions.Invoke(id, ctxAndIn{Context: ctx, Input: in}, true, true)
+		result, _, err := d.client.Actions.Invoke(e.ID, ctxAndIn{Context: ctx, Input: in}, true, true)
 		if err != nil {
 			return nil, err // TODO err should be JSON-serializable and usable (e.g. invalid arg vs runtime error)
 		}

--- a/pkg/functions/openwhisk/driver_test.go
+++ b/pkg/functions/openwhisk/driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	entitystore "github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/functions"
 	"github.com/vmware/dispatch/pkg/testing/dev"
 )
@@ -28,7 +29,7 @@ func init() {
 
 func TestWskDriver_GetRunnable(t *testing.T) {
 	dev.EnsureLocal(t)
-	f := driver.GetRunnable("hello")
+	f := driver.GetRunnable(&functions.FunctionExecution{Name: "hello", ID: "deadbeef"})
 	r, err := f(functions.Context{}, map[string]interface{}{})
 
 	assert.NoError(t, err)
@@ -37,13 +38,25 @@ func TestWskDriver_GetRunnable(t *testing.T) {
 
 func TestWskDriver_Delete(t *testing.T) {
 	dev.EnsureLocal(t)
-	err := driver.Delete("hello")
+	f := functions.Function{
+		BaseEntity: entitystore.BaseEntity{
+			Name: "hello",
+			ID:   "deadbeef",
+		},
+	}
+	err := driver.Delete(&f)
 	assert.NoError(t, err)
 }
 
 func TestWskDriver_Create(t *testing.T) {
 	dev.EnsureLocal(t)
-	err := driver.Create("hello", &functions.Exec{
+	f := functions.Function{
+		BaseEntity: entitystore.BaseEntity{
+			Name: "hello",
+			ID:   "deadbeef",
+		},
+	}
+	err := driver.Create(&f, &functions.Exec{
 		Image: "imikushin/nodejs6action",
 		Code: `
 function main(ctx, params) {

--- a/pkg/functions/runner/runner.go
+++ b/pkg/functions/runner/runner.go
@@ -22,8 +22,8 @@ func New(config *Config) functions.Runner {
 	return &impl{*config}
 }
 
-func (r *impl) Run(fn *functions.Function, in interface{}) (interface{}, error) {
-	f := r.Faas.GetRunnable(fn.Name)
+func (r *impl) Run(fn *functions.FunctionExecution, in interface{}) (interface{}, error) {
+	f := r.Faas.GetRunnable(fn)
 	m := Compose(
 		r.Validator.GetMiddleware(fn.Schemas),
 		r.SecretInjector.GetMiddleware(fn.Secrets, fn.Cookie),

--- a/pkg/functions/runner/runner_test.go
+++ b/pkg/functions/runner/runner_test.go
@@ -34,14 +34,22 @@ func TestRun(t *testing.T) {
 	v := &mocks.Validator{}
 	injector := &mocks.SecretInjector{}
 	testSchemas := &functions.Schemas{SchemaIn: testSchemaIn, SchemaOut: testSchemaOut}
+	fe := &functions.FunctionExecution{
+		Context: functions.Context{},
+		ID:      "",
+		Name:    testF0,
+		Schemas: testSchemas,
+		Secrets: []string{},
+		Cookie:  "cookie",
+	}
 
-	faas.On("GetRunnable", testF0).Return(functions.Runnable(runnable0))
+	faas.On("GetRunnable", fe).Return(functions.Runnable(runnable0))
 	v.On("GetMiddleware", testSchemas).Return(functions.Middleware(mw0(validation)))
 	injector.On("GetMiddleware", []string{}, "cookie").Return(functions.Middleware(mw0(injection)))
 
 	testRunner := New(&Config{faas, v, injector})
 
-	fn := &functions.Function{
+	fn := &functions.FunctionExecution{
 		Context: functions.Context{},
 		Name:    testF0,
 		Schemas: testSchemas,

--- a/pkg/functions/types.go
+++ b/pkg/functions/types.go
@@ -29,10 +29,11 @@ type Schemas struct {
 	SchemaOut interface{}
 }
 
-type Function struct {
+type FunctionExecution struct {
 	Context Context
 
 	Name string
+	ID   string
 
 	Exec    *Exec
 	Schemas *Schemas
@@ -44,19 +45,19 @@ type FaaSDriver interface {
 	// Create creates (or updates, if is already exists) the function in the FaaS implementation.
 	// name is the name of the function.
 	// exec defines the function implementation.
-	Create(name string, exec *Exec) error
+	Create(f *Function, exec *Exec) error
 
 	// Delete deletes the function in the FaaS implementation.
 	// name is the name of the function.
-	Delete(name string) error
+	Delete(f *Function) error
 
 	// GetRunnable returns a callable representation of a function.
 	// name is the name of the function.
-	GetRunnable(name string) Runnable
+	GetRunnable(e *FunctionExecution) Runnable
 }
 
 type Runner interface {
-	Run(fn *Function, in interface{}) (interface{}, error)
+	Run(fn *FunctionExecution, in interface{}) (interface{}, error)
 }
 
 type Validator interface {

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestTrace(t *testing.T) {
+	tracingEnabled = true
 	var buf bytes.Buffer
 	Logger.Out = &buf
 	Logger.SetLevel(logrus.DebugLevel)

--- a/swagger/function-manager.yaml
+++ b/swagger/function-manager.yaml
@@ -383,6 +383,9 @@ definitions:
       functionName:
         type: string
         readOnly: true
+      functionId:
+        type: string
+        readOnly: true
       executedTime:
         type: integer
         readOnly: true
@@ -401,6 +404,12 @@ definitions:
         items:
           type: string
       secrets:
+        type: array
+        items:
+          type: string
+      status:
+        $ref: '#/definitions/Status'
+      reason:
         type: array
         items:
           type: string


### PR DESCRIPTION
* avoid FaaS restrictions on names
* avoid issues around function name reuse
	- needs to deal with orphans
* add status and reason to runs API
* changed driver interface to accept entities rather than just
  names.  Then it is up to the driver to choose what to use.
	- moved entites.go into functions to avoid circular
          dependency issues
* added back config.dev.json to fix unit tests
* fixed trace_test.go

Fixes #27