### PR TITLE
Add healthz endpoint to services

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -247,6 +247,12 @@
   revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/justinas/alice"
+  packages = ["."]
+  revision = "03f45bd4b7dad4734bc4620e46a35789349abb20"
+
+[[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
@@ -500,6 +506,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "252e57a82a15f97bd52db27d07349c565372b8b9eab126215b807e524fcde344"
+  inputs-digest = "c9750af9507c0ba89825b90df93f8184f391ac8ca82e25711812e25807465f32"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/charts/dispatch/charts/api-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/api-manager/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
             httpGet:
-              path: /v1/api
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie
@@ -55,7 +55,7 @@ spec:
             periodSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/api
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie

--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - containerPort: 443
           livenessProbe:
             httpGet:
-              path: /v1/event/subscriptions
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie
@@ -60,7 +60,7 @@ spec:
             periodSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/event/subscriptions
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - containerPort: 443
           livenessProbe:
             httpGet:
-              path: /v1/function
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie
@@ -57,7 +57,7 @@ spec:
             periodSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/function
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie

--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -50,15 +50,24 @@ spec:
                 configMapKeyRef:
                   name: {{ template "fullname" . }}
                   key: organization
-          # TODO: Enable a "status" endpoint for health check
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: {{ .Values.service.internalPort }}
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.internalPort }}
+              httpHeaders:
+              - name: Cookie
+                value: cookie
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.internalPort }}
+              httpHeaders:
+              - name: Cookie
+                value: cookie
+            initialDelaySeconds: 10
+            periodSeconds: 3
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
             httpGet:
-              path: /v1/image
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie
@@ -52,7 +52,7 @@ spec:
             periodSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/image
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie

--- a/charts/dispatch/charts/secret-store/templates/deployment.yaml
+++ b/charts/dispatch/charts/secret-store/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
             httpGet:
-              path: /v1/secret
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie
@@ -53,7 +53,7 @@ spec:
             periodSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v1/secret
+              path: /healthz
               port: {{ .Values.service.internalPort }}
               httpHeaders:
               - name: Cookie

--- a/cmd/event-manager/main.go
+++ b/cmd/event-manager/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/swag"
 	"github.com/jessevdk/go-flags"
+	"github.com/justinas/alice"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/vmware/dispatch/pkg/client"
@@ -25,6 +26,7 @@ import (
 	"github.com/vmware/dispatch/pkg/event-manager/gen/restapi"
 	"github.com/vmware/dispatch/pkg/event-manager/gen/restapi/operations"
 	"github.com/vmware/dispatch/pkg/events/rabbitmq"
+	"github.com/vmware/dispatch/pkg/middleware"
 	"github.com/vmware/dispatch/pkg/trace"
 )
 
@@ -149,6 +151,17 @@ func main() {
 	}
 
 	handlers.ConfigureHandlers(api)
+
+	healthChecker := func() error {
+		// TODO: implement service-specific healthchecking
+		return nil
+	}
+
+	handler := alice.New(
+		middleware.NewHealthCheckMW("", healthChecker),
+	).Then(api.Serve(nil))
+
+	server.SetHandler(handler)
 
 	defer server.Shutdown()
 	if err := server.Serve(); err != nil {

--- a/cmd/image-manager/main.go
+++ b/cmd/image-manager/main.go
@@ -12,16 +12,18 @@ import (
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
-	loads "github.com/go-openapi/loads"
+	"github.com/go-openapi/loads"
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/swag"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
+	"github.com/justinas/alice"
 	log "github.com/sirupsen/logrus"
 
-	entitystore "github.com/vmware/dispatch/pkg/entity-store"
-	imagemanager "github.com/vmware/dispatch/pkg/image-manager"
+	"github.com/vmware/dispatch/pkg/entity-store"
+	"github.com/vmware/dispatch/pkg/image-manager"
 	"github.com/vmware/dispatch/pkg/image-manager/gen/restapi"
 	"github.com/vmware/dispatch/pkg/image-manager/gen/restapi/operations"
+	"github.com/vmware/dispatch/pkg/middleware"
 	"github.com/vmware/dispatch/pkg/trace"
 )
 
@@ -120,6 +122,17 @@ func main() {
 	go bib.Run()
 
 	handlers.ConfigureHandlers(api)
+
+	healthChecker := func() error {
+		// TODO: implement service-specific healthchecking
+		return nil
+	}
+
+	handler := alice.New(
+		middleware.NewHealthCheckMW("", healthChecker),
+	).Then(api.Serve(nil))
+
+	server.SetHandler(handler)
 
 	if err := server.Serve(); err != nil {
 		log.Fatalln(err)

--- a/pkg/middleware/health.go
+++ b/pkg/middleware/health.go
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package middleware
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/justinas/alice"
+)
+
+// NO TESTS
+
+// HealthChecker is executed to verify health of the service.
+type HealthChecker func() error
+
+// HealthCheck is a middleware that serves healthcheck information
+type HealthCheck struct {
+	basePath string
+	checker  HealthChecker
+	next     http.Handler
+}
+
+// NewHealthCheckMW creates a new health check middleware at the specified path
+func NewHealthCheckMW(basePath string, checker HealthChecker) alice.Constructor {
+	return func(next http.Handler) http.Handler {
+		return NewHealthCheck(basePath, checker, next)
+	}
+}
+
+// NewHealthCheck creates a new health check middleware at the specified path
+func NewHealthCheck(basePath string, checker HealthChecker, next http.Handler) *HealthCheck {
+	if basePath == "" {
+		basePath = "/"
+	}
+
+	return &HealthCheck{
+		basePath: basePath,
+		checker:  checker,
+		next:     next,
+	}
+}
+
+// ServeHTTP is the middleware interface implementation
+func (h *HealthCheck) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, filepath.Join(h.basePath, "healthz")) {
+		h.next.ServeHTTP(rw, r)
+		return
+	}
+
+	var err error
+	if h.checker != nil {
+		err = h.checker()
+	}
+
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		rw.Write([]byte(err.Error()))
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	rw.Write([]byte("OK"))
+}

--- a/vendor/github.com/justinas/alice/.travis.yml
+++ b/vendor/github.com/justinas/alice/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+matrix:
+  include:
+    - go: 1.0.x
+    - go: 1.1.x
+    - go: 1.2.x
+    - go: 1.3.x
+    - go: 1.4.x
+    - go: 1.5.x
+    - go: 1.6.x
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: tip
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/justinas/alice/LICENSE
+++ b/vendor/github.com/justinas/alice/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Justinas Stankevicius
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/justinas/alice/README.md
+++ b/vendor/github.com/justinas/alice/README.md
@@ -1,0 +1,98 @@
+# Alice 
+
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/justinas/alice)
+[![Build Status](https://travis-ci.org/justinas/alice.svg?branch=master)](https://travis-ci.org/justinas/alice)
+[![Coverage](http://gocover.io/_badge/github.com/justinas/alice)](http://gocover.io/github.com/justinas/alice)
+
+Alice provides a convenient way to chain 
+your HTTP middleware functions and the app handler.
+
+In short, it transforms
+
+```go
+Middleware1(Middleware2(Middleware3(App)))
+```
+
+to
+
+```go
+alice.New(Middleware1, Middleware2, Middleware3).Then(App)
+```
+
+### Why?
+
+None of the other middleware chaining solutions
+behaves exactly like Alice.
+Alice is as minimal as it gets:
+in essence, it's just a for loop that does the wrapping for you.
+
+Check out [this blog post](http://justinas.org/alice-painless-middleware-chaining-for-go/)
+for explanation how Alice is different from other chaining solutions.
+
+### Usage
+
+Your middleware constructors should have the form of
+
+```go
+func (http.Handler) http.Handler
+```
+
+Some middleware provide this out of the box.
+For ones that don't, it's trivial to write one yourself.
+
+```go
+func myStripPrefix(h http.Handler) http.Handler {
+    return http.StripPrefix("/old", h)
+}
+```
+
+This complete example shows the full power of Alice.
+
+```go
+package main
+
+import (
+    "net/http"
+    "time"
+
+    "github.com/throttled/throttled"
+    "github.com/justinas/alice"
+    "github.com/justinas/nosurf"
+)
+
+func timeoutHandler(h http.Handler) http.Handler {
+    return http.TimeoutHandler(h, 1*time.Second, "timed out")
+}
+
+func myApp(w http.ResponseWriter, r *http.Request) {
+    w.Write([]byte("Hello world!"))
+}
+
+func main() {
+    th := throttled.Interval(throttled.PerSec(10), 1, &throttled.VaryBy{Path: true}, 50)
+    myHandler := http.HandlerFunc(myApp)
+
+    chain := alice.New(th.Throttle, timeoutHandler, nosurf.NewPure).Then(myHandler)
+    http.ListenAndServe(":8000", chain)
+}
+```
+
+Here, the request will pass [throttled](https://github.com/PuerkitoBio/throttled) first,
+then an http.TimeoutHandler we've set up,
+then [nosurf](https://github.com/justinas/nosurf)
+and will finally reach our handler.
+
+Note that Alice makes **no guarantees** for
+how one or another piece of  middleware will behave.
+Once it passes the execution to the outer layer of middleware,
+it has no saying in whether middleware will execute the inner handlers.
+This is intentional behavior.
+
+Alice works with Go 1.0 and higher.
+
+### Contributing
+
+0. Find an issue that bugs you / open a new one.
+1. Discuss.
+2. Branch off, commit, test.
+3. Make a pull request / attach the commits to the issue.

--- a/vendor/github.com/justinas/alice/chain.go
+++ b/vendor/github.com/justinas/alice/chain.go
@@ -1,0 +1,112 @@
+// Package alice provides a convenient way to chain http handlers.
+package alice
+
+import "net/http"
+
+// A constructor for a piece of middleware.
+// Some middleware use this constructor out of the box,
+// so in most cases you can just pass somepackage.New
+type Constructor func(http.Handler) http.Handler
+
+// Chain acts as a list of http.Handler constructors.
+// Chain is effectively immutable:
+// once created, it will always hold
+// the same set of constructors in the same order.
+type Chain struct {
+	constructors []Constructor
+}
+
+// New creates a new chain,
+// memorizing the given list of middleware constructors.
+// New serves no other function,
+// constructors are only called upon a call to Then().
+func New(constructors ...Constructor) Chain {
+	return Chain{append(([]Constructor)(nil), constructors...)}
+}
+
+// Then chains the middleware and returns the final http.Handler.
+//     New(m1, m2, m3).Then(h)
+// is equivalent to:
+//     m1(m2(m3(h)))
+// When the request comes in, it will be passed to m1, then m2, then m3
+// and finally, the given handler
+// (assuming every middleware calls the following one).
+//
+// A chain can be safely reused by calling Then() several times.
+//     stdStack := alice.New(ratelimitHandler, csrfHandler)
+//     indexPipe = stdStack.Then(indexHandler)
+//     authPipe = stdStack.Then(authHandler)
+// Note that constructors are called on every call to Then()
+// and thus several instances of the same middleware will be created
+// when a chain is reused in this way.
+// For proper middleware, this should cause no problems.
+//
+// Then() treats nil as http.DefaultServeMux.
+func (c Chain) Then(h http.Handler) http.Handler {
+	if h == nil {
+		h = http.DefaultServeMux
+	}
+
+	for i := range c.constructors {
+		h = c.constructors[len(c.constructors)-1-i](h)
+	}
+
+	return h
+}
+
+// ThenFunc works identically to Then, but takes
+// a HandlerFunc instead of a Handler.
+//
+// The following two statements are equivalent:
+//     c.Then(http.HandlerFunc(fn))
+//     c.ThenFunc(fn)
+//
+// ThenFunc provides all the guarantees of Then.
+func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
+	if fn == nil {
+		return c.Then(nil)
+	}
+	return c.Then(fn)
+}
+
+// Append extends a chain, adding the specified constructors
+// as the last ones in the request flow.
+//
+// Append returns a new chain, leaving the original one untouched.
+//
+//     stdChain := alice.New(m1, m2)
+//     extChain := stdChain.Append(m3, m4)
+//     // requests in stdChain go m1 -> m2
+//     // requests in extChain go m1 -> m2 -> m3 -> m4
+func (c Chain) Append(constructors ...Constructor) Chain {
+	newCons := make([]Constructor, 0, len(c.constructors)+len(constructors))
+	newCons = append(newCons, c.constructors...)
+	newCons = append(newCons, constructors...)
+
+	return Chain{newCons}
+}
+
+// Extend extends a chain by adding the specified chain
+// as the last one in the request flow.
+//
+// Extend returns a new chain, leaving the original one untouched.
+//
+//     stdChain := alice.New(m1, m2)
+//     ext1Chain := alice.New(m3, m4)
+//     ext2Chain := stdChain.Extend(ext1Chain)
+//     // requests in stdChain go  m1 -> m2
+//     // requests in ext1Chain go m3 -> m4
+//     // requests in ext2Chain go m1 -> m2 -> m3 -> m4
+//
+// Another example:
+//  aHtmlAfterNosurf := alice.New(m2)
+// 	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
+// 		csrf := nosurf.New(h)
+// 		csrf.SetFailureHandler(aHtmlAfterNosurf.ThenFunc(csrfFail))
+// 		return csrf
+// 	}).Extend(aHtmlAfterNosurf)
+//		// requests to aHtml hitting nosurfs success handler go m1 -> nosurf -> m2 -> target-handler
+//		// requests to aHtml hitting nosurfs failure handler go m1 -> nosurf -> m2 -> csrfFail
+func (c Chain) Extend(chain Chain) Chain {
+	return c.Append(chain.constructors...)
+}


### PR DESCRIPTION
Adds dedicated `/healthz` endpoint to each service via Middleware. Currently runs a no-op health-checker, but in future it can be extended to perform check on dependent services like DB, etc.

**Testing done**
* successful local e2e