### PR TITLE
Set correct dispatch port in .dispatch/config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,34 +74,41 @@ oauth2Proxy:
 EOF
 ```
 
-Install and copy the configuration to `$HOME/.dispatch.json`:
+Run Install:
 ```
 $ ./dispatch-darwin install --file config.yaml --service all --debug
 ...
-Copy the following to your $HOME/.dispatch.json
+Config file written to: $HOME/.dispatch/config.json
+```
+Your dispatch config file $HOME/.dispatch/config.json will be generated
+and have the following:-
+```
+cat $HOME/.dispatch/config.json
 {
     "host": "dev.dispatch.vmware.com",
-    "port": 443,
-    "organization": "",
-    "cookie": "",
-    "skipauth": false,
-    "Json": false
-}
-$ cat << EOF > ~/.dispatch.json
-{
-    "host": "dev.dispatch.vmware.com",
-    "port": 443,
+    "port": <port>,
     "organization": "",
     "cookie": "",
     "skipauth": false,
     "Json": false
 }
 ```
+Make a note of the `<port>` as this will be used in the next step.
+
+Update the Callback URL of your OAuth2 Client App:
+
+Dispatch runs on a non-standard https port on minikube since it uses
+NodePort for the ingress controller service. Hence, update the
+Authorization callback URL of your OAuth2 Client App (created by following
+[How to Create OAuth Client App](docs/create-oauth-client-app.md)) from
+`https://dev.dispatch.vmware.com/oauth2` to `https://dev.dispatch.vmware.com:<port>/oauth2`
+where `<port>` can be found in your dispatch config file available at
+$HOME/.dispatch/config.json.
 
 Login (you will be directed to github for authorization):
 ```
 $ ./dispatch-darwin login
-You have successfully logged in, cookie saved to /Users/bjung/.dispatch.json
+You have successfully logged in, cookie saved to /Users/bjung/.dispatch/config.json
 ```
 
 At this point, the environment is up and working.  Let's seed the service

--- a/charts/dispatch/Chart.yaml
+++ b/charts/dispatch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A paltform for deploying serverless applications
+description: A platform for deploying serverless applications
 name: dispatch
 version: 0.1.1

--- a/charts/dispatch/charts/oauth2-proxy/templates/configmap.yaml
+++ b/charts/dispatch/charts/oauth2-proxy/templates/configmap.yaml
@@ -32,7 +32,11 @@ data:
     {{- if .Values.app.redirectPath }}
       ## the OAuth Redirect URL.
       # defaults to the "https://" + requested host header + "/oauth2/callback"
+      {{- if eq (.Values.global.port | toString) "443" }}
       redirect_url = "https://{{ default .Values.global.host .Values.ingress.host }}{{ .Values.app.redirectPath }}"
+      {{- else }}
+      redirect_url = "https://{{ default .Values.global.host .Values.ingress.host }}:{{ .Values.global.port }}{{ .Values.app.redirectPath }}"
+      {{- end }}
     {{- end }}
 
       ## Log requests to stdout

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -12,6 +12,7 @@ global:
   data:
     persist: false
   host: dispatch.vmware.com
+  port: 443
   tls:
     secretName: dispatch-tls
 rabbitmq:

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -82,11 +82,9 @@ spec:
           ports:
             - name: http
               containerPort: 80
-              hostPort: 80
               protocol: TCP
             - name: https
               containerPort: 443
-              hostPort: 443
               protocol: TCP
           {{- if .Values.controller.stats.enabled }}
             - name: stats

--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -73,7 +73,7 @@ func NewCLI(in io.Reader, out, errOut io.Writer) *cobra.Command {
 	}
 	cmds.PersistentFlags().StringVar(&dispatchConfigPath, "config", "", "config file (default is $HOME/.dispatch)")
 	cmds.PersistentFlags().String("host", "dispatch.vmware.com", "VMware Dispatch host to connect to")
-	cmds.PersistentFlags().Int("port", 80, "Port which VMware Dispatch is listening on")
+	cmds.PersistentFlags().Int("port", 443, "Port which VMware Dispatch is listening on")
 	cmds.PersistentFlags().String("organization", "dispatch", "Organization name")
 	cmds.PersistentFlags().Bool("skipauth", false, "skip authentication (only take effect with a SkipAuthMode-enabled server)")
 	cmds.PersistentFlags().BoolVar(&dispatchConfig.Json, "json", false, "Output raw JSON")

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -430,7 +430,7 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 			if err != nil {
 				return errors.Wrapf(err, string(kubectlOut))
 			}
-			servicePort, err =  strconv.Atoi(string(kubectlOut))
+			servicePort, err = strconv.Atoi(string(kubectlOut))
 			if err != nil {
 				return errors.Wrapf(err, "Error fetching nginx-ingress node port")
 			}

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -176,6 +176,7 @@ var (
 	installDryRun     = false
 	installDebug      = false
 	configDest        = i18n.T(``)
+	servicePort       = 443
 
 	defaultInstallConfig = installConfig{
 		Namespace:         "dispatch",
@@ -327,7 +328,7 @@ func helmInstall(out, errOut io.Writer, chart, namespace, release string, option
 func writeConfig(out, errOut io.Writer, configDir string, config installConfig) error {
 	dispatchConfig.Organization = config.Organization
 	dispatchConfig.Host = config.Hostname
-	dispatchConfig.Port = 443
+	dispatchConfig.Port = servicePort
 	b, err := json.MarshalIndent(dispatchConfig, "", "    ")
 	if err != nil {
 		return err
@@ -422,6 +423,18 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 		if err != nil {
 			return errors.Wrapf(err, "Error installing nginx-ingress chart")
 		}
+		if config.ServiceType == "NodePort" {
+			kubectl := exec.Command(
+				"kubectl", "get", "svc", "ingress-nginx-ingress-controller", "-n", "kube-system", "-o", "jsonpath={.spec.ports[?(@.name==\"https\")].nodePort}")
+			kubectlOut, err := kubectl.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, string(kubectlOut))
+			}
+			servicePort, err =  strconv.Atoi(string(kubectlOut))
+			if err != nil {
+				return errors.Wrapf(err, "Error fetching nginx-ingress node port")
+			}
+		}
 	}
 	if installService("openfaas") {
 		chart := path.Join(chartsDir, "openfaas")
@@ -468,6 +481,7 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 			"function-manager.faas.openfaas.registryAuth":  openFaasAuthEncoded,
 			"function-manager.faas.openfaas.imageRegistry": config.Repository.Host,
 			"global.host":                                  config.Hostname,
+			"global.port":                                  strconv.Itoa(servicePort),
 			"global.debug":                                 "true",
 			"global.data.persist":                          strconv.FormatBool(config.PersistData),
 			"oauth2-proxy.app.clientID":                    config.OAuth2Proxy.ClientID,

--- a/pkg/dispatchcli/cmd/login.go
+++ b/pkg/dispatchcli/cmd/login.go
@@ -96,8 +96,7 @@ func login(in io.Reader, out, errOut io.Writer, cmd *cobra.Command, args []strin
 			}.Encode()),
 		},
 	}
-	requestURL := fmt.Sprintf("https://%s%s?%s", dispatchConfig.Host, oauth2Path, vals.Encode())
-
+	requestURL := fmt.Sprintf("https://%s:%d%s?%s", dispatchConfig.Host, dispatchConfig.Port, oauth2Path, vals.Encode())
 	err := webbrowser.Open(requestURL)
 	if err != nil {
 		return errors.Wrap(err, "error opening web browser")


### PR DESCRIPTION
Currently, `dispatch install` always generates the dispatch
`~/.dispatch/config.json` with port `443`. When using NodePort
as the ServiceType, a high port is assigned for the ingress
controller service and that must be used as the port of
the dispatch service.

* This patch fixes the config json by fetching the assigned NodePort.
* The patch removes the hostPort option in the container
  spec for the ingress deployment. Kubernetes doesn't recommend
  using hostPort as it creates scheduling constraints and the port
  may not be available on hosted K8S environments (it's possible
  the apiserver might be using it).
* The patch fixes the redirect_uri of the oauth2proxy configmap
   so that the auth request can be redirected to the appropriate NodePort.
  
Fixes #82 