### PR TITLE
Support dispatch installation with User-Provided Certs

### DIFF
--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -54,12 +54,19 @@ type postgresConfig struct {
 	Persistence bool         `json:"persistence,omitempty" validate:"omitempty"`
 }
 
+type tlsConfig struct {
+	CertFile   string `json:"certFile,omitempty"`
+	PrivateKey string `json:"privateKey,omitempty"`
+	CertSecret string `json:"certSecret,omitempty" validate:"required"`
+}
+
 type apiGatewayConfig struct {
 	Chart       *chartConfig `json:"chart,omitempty" validate:"required"`
 	ServiceType string       `json:"serviceType,omitempty" validate:"required,eq=NodePort|eq=LoadBalancer|eq=ClusterIP"`
 	Database    string       `json:"database,omitempty" validate:"required"`
 	Hostname    string       `json:"hostname,omitempty" validate:"required,hostname"`
 	CertSecret  string       `json:"certSecret,omitempty" validate:"required"`
+	TLS         *tlsConfig   `json:"tls,omitempty"`
 }
 
 type openfaasConfig struct {
@@ -86,7 +93,6 @@ type dispatchInstallConfig struct {
 	Chart        *chartConfig       `json:"chart,omitempty" validate:"required"`
 	Hostname     string             `json:"hostname,omitempty" validate:"required,hostname"`
 	Port         int                `json:"port,omitempty" validate:"required"`
-	CertSecret   string             `json:"certSecret,omitempty" validate:"required"`
 	Organization string             `json:"organization,omitempty" validate:"required"`
 	Image        *imageConfig       `json:"image,omitempty" validate:"required"`
 	Debug        bool               `json:"debug,omitempty" validate:"omitempty"`
@@ -95,6 +101,7 @@ type dispatchInstallConfig struct {
 	PersistData  bool               `json:"persistData,omitempty" validate:"omitempty"`
 	OpenFaasRepo openFaasRepoConfig `json:"openfaasRepository,omitempty" validate:"required"`
 	OAuth2Proxy  *oauth2ProxyConfig `json:"oauth2Proxy,omitempty" validate:"required"`
+	TLS          *tlsConfig         `json:"tls,omitempty"`
 }
 
 type installConfig struct {
@@ -147,22 +154,33 @@ func NewCmdInstall(out io.Writer, errOut io.Writer) *cobra.Command {
 	return cmd
 }
 
-func makeSSLCert(out, errOut io.Writer, configDir, namespace, domain, certName string) error {
-	subject := fmt.Sprintf("/CN=%s/O=%s", domain, domain)
-	key := path.Join(configDir, fmt.Sprintf("%s.key", domain))
-	cert := path.Join(configDir, fmt.Sprintf("%s.crt", domain))
-	var err error
-	// If cert and key exist, reuse them
-	if _, err = os.Stat(key); os.IsNotExist(err) {
-		if _, err = os.Stat(cert); os.IsNotExist(err) {
-			openssl := exec.Command(
-				"openssl", "req", "-x509", "-nodes", "-days", "365", "-newkey", "rsa:2048",
-				"-keyout", key,
-				"-out", cert,
-				"-subj", subject)
-			opensslOut, err := openssl.CombinedOutput()
-			if err != nil {
-				return errors.Wrapf(err, string(opensslOut))
+func installCert(out, errOut io.Writer, configDir, namespace, domain, certName string, tls *tlsConfig) error {
+	var key, cert string
+	if tls != nil {
+		if tls.PrivateKey == "" || tls.CertFile == "" {
+			return errors.New("Error installing certificate: both private key & cert file must be provided")
+
+		}
+		key = tls.PrivateKey
+		cert = tls.CertFile
+	} else {
+		// make a new key and cert.
+		subject := fmt.Sprintf("/CN=%s/O=%s", domain, domain)
+		key = path.Join(configDir, fmt.Sprintf("%s.key", domain))
+		cert = path.Join(configDir, fmt.Sprintf("%s.crt", domain))
+		var err error
+		// If cert and key exist, reuse them
+		if _, err = os.Stat(key); os.IsNotExist(err) {
+			if _, err = os.Stat(cert); os.IsNotExist(err) {
+				openssl := exec.Command(
+					"openssl", "req", "-x509", "-nodes", "-days", "365", "-newkey", "rsa:2048",
+					"-keyout", key,
+					"-out", cert,
+					"-subj", subject)
+				opensslOut, err := openssl.CombinedOutput()
+				if err != nil {
+					return errors.Wrapf(err, string(opensslOut))
+				}
 			}
 		}
 	}
@@ -368,13 +386,13 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 	}
 
 	if installService("certs") || !installDryRun {
-		err = makeSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Hostname, config.DispatchConfig.CertSecret)
+		err = installCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Hostname, config.DispatchConfig.CertSecret, config.DispatchConfig.TLS)
 		if err != nil {
-			return errors.Wrapf(err, "Error creating ssl cert %s", installConfigFile)
+			return errors.Wrapf(err, "Error installing cert for %s", config.DispatchConfig.Hostname)
 		}
-		err = makeSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Hostname, config.APIGateway.CertSecret)
+		err = installCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Hostname, config.APIGateway.CertSecret, config.APIGateway.TLS)
 		if err != nil {
-			return errors.Wrapf(err, "Error creating ssl cert %s", installConfigFile)
+			return errors.Wrapf(err, "Error installing  cert for %s", config.APIGateway.Hostname)
 		}
 	}
 	if installChartsDir == "dispatch" {

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -34,7 +34,8 @@ apiGateway:
   serviceType: NodePort
   database: postgres
   hostname: api.dev.dispatch.vmware.com
-  certSecret: api-dispatch-tls
+  tls:
+    secretName: api-dispatch-tls
 openfaas:
   chart:
     chart: openfaas
@@ -49,7 +50,8 @@ dispatch:
   organization: dispatch
   hostname: dev.dispatch.vmware.com
   port: 443
-  certSecret: dispatch-tls
+  tls:
+    secretName: dispatch-tls
   image:
     host: vmware
     tag: v0.1.2

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -142,11 +142,11 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 	configDir, err := homedir.Expand(configDest)
 
 	if uninstallService("certs") || !uninstallDryRun {
-		err = uninstallSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Hostname, config.DispatchConfig.CertSecret)
+		err = uninstallSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Hostname, config.DispatchConfig.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}
-		err = uninstallSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Hostname, config.APIGateway.CertSecret)
+		err = uninstallSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Hostname, config.APIGateway.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}


### PR DESCRIPTION
Currently, we generate the required certs for tls in `dispatch install`. We do this for both the dispatch ingress endpoint and the api-gateway.

This patch adds support for securing the endpoints with user-provided certs.

The README will be enhanced later since we are missing instructions to customize the dispatch install's `config.yaml` and the file format is in flux.
  