### PR TITLE
Make Image Registry host optional and some README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ $ chmod +x dispatch-darwin
 ```
 
 ### Configure and install Dispatch:
-Dispatch requires a Docker registry to build and push images for your functions. If you don't have a
-docker registry, you can always use Docker Hub by specifying your credentials.
+Dispatch requires a container registry to build and push images for your functions. If you don't have a
+container registry, you can always use DockerHub by specifying your credentials.
 
 Configure the installation by substituting docker credentials and OAuth2 client details.
 ```
@@ -70,9 +70,11 @@ dispatch:
     host: vmware
     tag: v0.1.2
   debug: true
-  openfaasRepository:
-    # Server Hostname for Docker registry. You can skip this if using docker hub.
-    host: <docker repo>
+  imageRegistry:
+    # The registry name format varies by the container registry provider.
+    # For dockerhub, use docker.io/<username>
+    # For Google Container Registry, use gcr.io/[GCR-PROJECT-ID]
+    name: <registry name>
     # Username for Docker registry authentication
     username: <docker username>
     # Password for Docker registry authentication
@@ -187,7 +189,6 @@ $ curl -k "https://api.dispatch.local:32611/hello" -H "Content-Type: application
 ```
 
 ### Install Dispatch UI
-Want to add the UI? 
 
 ```
 helm install dispatch/ui --namespace dispatch --name ui --debug

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	dispatchHelmRepositoryURL = "https://s3-us-west-2.amazonaws.com/dispatch-charts"
+	dispatchImageRegistryHost string
 )
 
 type chartConfig struct {
@@ -80,7 +81,7 @@ type imageConfig struct {
 type oauth2ProxyConfig struct {
 	ClientID     string `json:"clientID,omitempty" validate:"required"`
 	ClientSecret string `json:"clientSecret,omitempty" validate:"required"`
-	CookieSecret string `json:"cookieSecret,omitmepty" validate:"omitempty"`
+	CookieSecret string `json:"cookieSecret,omitempty" validate:"omitempty"`
 }
 type openFaasRepoConfig struct {
 	Host     string `json:"host,omitempty" validate:"required"`
@@ -388,6 +389,13 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 
 	if config.HelmRepositoryURL != "" {
 		dispatchHelmRepositoryURL = config.HelmRepositoryURL
+	}
+
+	if config.DispatchConfig.OpenFaasRepo.Host != "" {
+		dispatchImageRegistryHost = config.DispatchConfig.OpenFaasRepo.Host
+	} else {
+		// Assume it's docker hub and set imageRegistry same as username.
+		dispatchImageRegistryHost = config.DispatchConfig.OpenFaasRepo.Username
 	}
 
 	if installDebug {

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -33,7 +33,7 @@ apiGateway:
     release: api-gateway
   serviceType: NodePort
   database: postgres
-  hostname: api.dev.dispatch.example.com
+  hostname: api.dev.dispatch.local
   tls:
     secretName: api-dispatch-tls
 openfaas:
@@ -48,7 +48,7 @@ dispatch:
     namespace: dispatch
     release: dispatch
   organization: dispatch
-  hostname: dev.dispatch.example.com
+  hostname: dev.dispatch.local
   port: 443
   tls:
     secretName: dispatch-tls
@@ -59,8 +59,8 @@ dispatch:
   debug: true
   trace: true
   persistData: false
-  openfaasRepository:
-    host:
+  imageRegistry:
+    name:
     username: <username>
     email: <email>@vmware.com
     password: <password>

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -33,7 +33,7 @@ apiGateway:
     release: api-gateway
   serviceType: NodePort
   database: postgres
-  hostname: api.dev.dispatch.vmware.com
+  hostname: api.dev.dispatch.example.com
   tls:
     secretName: api-dispatch-tls
 openfaas:
@@ -48,7 +48,7 @@ dispatch:
     namespace: dispatch
     release: dispatch
   organization: dispatch
-  hostname: dev.dispatch.vmware.com
+  hostname: dev.dispatch.example.com
   port: 443
   tls:
     secretName: dispatch-tls
@@ -60,7 +60,7 @@ dispatch:
   trace: true
   persistData: false
   openfaasRepository:
-    host: <host>
+    host:
     username: <username>
     email: <email>@vmware.com
     password: <password>


### PR DESCRIPTION
If you are using dockerhub, the image registry host must be specified the same as your username. This is kind of confusing to the end user. We can make it optional and default it to the username
if not specified (i.e assume docker hub).

Some other changes include changing the domain to example.com and
formatting the README's QuickStart.

Partially addresses #80 