### PR TITLE
Integrate control loop library with image manager

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -265,16 +265,16 @@
   version = "v1.3.0"
 
 [[projects]]
-  name = "github.com/json-iterator/go"
-  packages = ["."]
-  revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
-  version = "1.0.4"
-
-[[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
   packages = [".","reflectx","types"]
   revision = "de8647470aafe4854c976707c431dbe1eb2822c6"
+
+[[projects]]
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
+  version = "1.0.4"
 
 [[projects]]
   branch = "master"
@@ -494,6 +494,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["semaphore"]
+  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
   revision = "5513e650ab47a692d3a036d49be8fa52ddd09b65"
@@ -555,6 +561,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b181373b7b2f8285100af6f606e9e677f4773ea7ecab05208025f69937805893"
+  inputs-digest = "5353ea148c9ca8778cd474a079f232ba1b127384a891407e95e388069e9c75bf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,3 +92,7 @@
 [[constraint]]
   name = "github.com/streadway/amqp"
   branch = "master"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/sync"

--- a/pkg/api-manager/controller.go
+++ b/pkg/api-manager/controller.go
@@ -91,6 +91,12 @@ func (h *apiEntityHandler) Delete(obj entitystore.Entity) error {
 	return nil
 }
 
+func (h *apiEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return controller.DefaultSync(h.store, h.Type(), organizationID, resyncPeriod)
+}
+
 func (h *apiEntityHandler) Error(obj entitystore.Entity) error {
 	defer trace.Tracef("")()
 
@@ -110,7 +116,7 @@ func (h *apiEntityHandler) Error(obj entitystore.Entity) error {
 func NewController(config *ControllerConfig, store entitystore.EntityStore, gw gateway.Gateway) controller.Controller {
 	defer trace.Trace("")()
 
-	c := controller.NewController(store, controller.Options{
+	c := controller.NewController(controller.Options{
 		OrganizationID: config.OrganizationID,
 		ResyncPeriod:   config.ResyncPeriod,
 	})

--- a/pkg/entity-store/store.go
+++ b/pkg/entity-store/store.go
@@ -51,6 +51,10 @@ const (
 	// you should not use the object until the state is tranfered to READY
 	// or the object is deleted
 	StatusERROR Status = "ERROR"
+
+	// StatusMISSING temporary error state
+	// Used when external resources cannot be found
+	StatusMISSING Status = "MISSING"
 )
 
 // Status represents the current state

--- a/pkg/event-manager/controller.go
+++ b/pkg/event-manager/controller.go
@@ -37,7 +37,7 @@ func NewEventController(manager SubscriptionManager, backend DriverBackend, stor
 		config.ResyncPeriod = DefaultResyncPeriod
 	}
 
-	c := controller.NewController(store, controller.Options{
+	c := controller.NewController(controller.Options{
 		OrganizationID: config.OrganizationID,
 		ResyncPeriod:   config.ResyncPeriod,
 		Workers:        config.WorkerNumber,

--- a/pkg/event-manager/driver_handler.go
+++ b/pkg/event-manager/driver_handler.go
@@ -7,10 +7,12 @@ package eventmanager
 
 import (
 	"reflect"
+	"time"
 
 	ewrapper "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/vmware/dispatch/pkg/controller"
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/trace"
 )
@@ -67,6 +69,12 @@ func (h *driverEntityHandler) Delete(obj entitystore.Entity) error {
 	}
 	log.Infof("driver %s deleted from k8s and the entity store", driver.Name)
 	return nil
+}
+
+func (h *driverEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return controller.DefaultSync(h.store, h.Type(), organizationID, resyncPeriod)
 }
 
 func (h *driverEntityHandler) Error(obj entitystore.Entity) error {

--- a/pkg/event-manager/subscription_handler.go
+++ b/pkg/event-manager/subscription_handler.go
@@ -7,10 +7,12 @@ package eventmanager
 
 import (
 	"reflect"
+	"time"
 
 	ewrapper "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/vmware/dispatch/pkg/controller"
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/trace"
 )
@@ -65,6 +67,12 @@ func (h *subscriptionEntityHandler) Delete(obj entitystore.Entity) error {
 	}
 	log.Infof("subscription %s deactivated and deleted from the entity store", sub.Name)
 	return nil
+}
+
+func (h *subscriptionEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return controller.DefaultSync(h.store, h.Type(), organizationID, resyncPeriod)
 }
 
 func (h *subscriptionEntityHandler) Error(obj entitystore.Entity) error {

--- a/pkg/function-manager/controller.go
+++ b/pkg/function-manager/controller.go
@@ -101,6 +101,12 @@ func (h *funcEntityHandler) Error(obj entitystore.Entity) error {
 	return nil
 }
 
+func (h *funcEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return controller.DefaultSync(h.Store, h.Type(), organizationID, resyncPeriod)
+}
+
 func (h *funcEntityHandler) getImage(imageName string) (*imagemodels.Image, error) {
 	defer trace.Trace("")()
 
@@ -182,6 +188,12 @@ func (h *runEntityHandler) Delete(obj entitystore.Entity) (err error) {
 	return errors.Errorf("deleting runs not supported, fn: '%s'", run.FunctionName)
 }
 
+func (h *runEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return controller.DefaultSync(h.Store, h.Type(), organizationID, resyncPeriod)
+}
+
 func (h *runEntityHandler) Error(obj entitystore.Entity) error {
 	defer trace.Trace("")()
 
@@ -193,7 +205,7 @@ func NewController(config *ControllerConfig, store entitystore.EntityStore, faas
 
 	defer trace.Trace("")()
 
-	c := controller.NewController(store, controller.Options{
+	c := controller.NewController(controller.Options{
 		OrganizationID: FunctionManagerFlags.OrgID,
 		ResyncPeriod:   config.ResyncPeriod,
 		Workers:        1000, // want more functions concurrently? add more workers // TODO configure workers

--- a/pkg/image-manager/controller.go
+++ b/pkg/image-manager/controller.go
@@ -1,0 +1,151 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package imagemanager
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/dispatch/pkg/controller"
+	entitystore "github.com/vmware/dispatch/pkg/entity-store"
+	"github.com/vmware/dispatch/pkg/trace"
+)
+
+type ControllerConfig struct {
+	ResyncPeriod   time.Duration
+	OrganizationID string
+}
+
+type baseImageEntityHandler struct {
+	Store   entitystore.EntityStore
+	Builder *BaseImageBuilder
+}
+
+func (h *baseImageEntityHandler) Type() reflect.Type {
+	defer trace.Trace("")()
+
+	return reflect.TypeOf(&BaseImage{})
+}
+
+func (h *baseImageEntityHandler) Add(obj entitystore.Entity) (err error) {
+	defer trace.Trace("")()
+
+	bi := obj.(*BaseImage)
+
+	defer func() { h.Store.UpdateWithError(bi, err) }()
+
+	bi.Status = entitystore.StatusREADY
+	if err := h.Builder.baseImagePull(bi); err != nil {
+		bi.Status = entitystore.StatusERROR
+		bi.Reason = []string{err.Error()}
+	}
+
+	return
+}
+
+func (h *baseImageEntityHandler) Update(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	return h.Add(obj)
+}
+
+func (h *baseImageEntityHandler) Delete(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	bi := obj.(*BaseImage)
+
+	h.Builder.baseImageDelete(bi)
+
+	var deleted BaseImage
+	err := h.Store.Delete(bi.GetOrganizationID(), bi.GetName(), &deleted)
+	if err != nil {
+		return errors.Wrapf(err, "Error deleting base image entity %s/%s", bi.GetOrganizationID(), bi.GetName())
+	}
+	return nil
+}
+
+func (h *baseImageEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return h.Builder.baseImageStatus()
+}
+
+func (h *baseImageEntityHandler) Error(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	_, err := h.Store.Update(obj.GetRevision(), obj)
+	return err
+}
+
+type imageEntityHandler struct {
+	Store   entitystore.EntityStore
+	Builder *ImageBuilder
+}
+
+func (h *imageEntityHandler) Type() reflect.Type {
+	defer trace.Trace("")()
+
+	return reflect.TypeOf(&Image{})
+}
+
+func (h *imageEntityHandler) Add(obj entitystore.Entity) (err error) {
+	defer trace.Trace("")()
+
+	i := obj.(*Image)
+
+	defer func() { h.Store.UpdateWithError(i, err) }()
+
+	return
+}
+
+func (h *imageEntityHandler) Update(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	return h.Add(obj)
+}
+
+func (h *imageEntityHandler) Delete(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	i := obj.(*Image)
+
+	var deleted BaseImage
+	err := h.Store.Delete(i.GetOrganizationID(), i.GetName(), &deleted)
+	if err != nil {
+		return errors.Wrapf(err, "Error deleting image entity %s/%s", i.GetOrganizationID(), i.GetName())
+	}
+	return nil
+}
+
+func (h *imageEntityHandler) Sync(organizationID string, resyncPeriod time.Duration) ([]entitystore.Entity, error) {
+	defer trace.Trace("")()
+
+	return h.Builder.imageStatus()
+}
+
+func (h *imageEntityHandler) Error(obj entitystore.Entity) error {
+	defer trace.Trace("")()
+
+	_, err := h.Store.Update(obj.GetRevision(), obj)
+	return err
+}
+
+func NewController(config *ControllerConfig, store entitystore.EntityStore, baseImageBuilder *BaseImageBuilder, imageBuilder *ImageBuilder) controller.Controller {
+
+	defer trace.Trace("")()
+
+	c := controller.NewController(controller.Options{
+		OrganizationID: ImageManagerFlags.OrgID,
+		ResyncPeriod:   config.ResyncPeriod,
+		Workers:        10, // want more functions concurrently? add more workers // TODO configure workers
+	})
+
+	c.AddEntityHandler(&baseImageEntityHandler{Store: store, Builder: baseImageBuilder})
+	c.AddEntityHandler(&imageEntityHandler{Store: store, Builder: imageBuilder})
+
+	return c
+}

--- a/pkg/image-manager/handlers_test.go
+++ b/pkg/image-manager/handlers_test.go
@@ -74,7 +74,7 @@ func addImageEntity(t *testing.T, api *operations.ImageManagerAPI, h *Handlers, 
 func TestBaseImageAddBaseImageHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	respBody := addBaseImageEntity(t, api, h, "testEntity", "test/base", true, map[string]string{"role": "test"})
@@ -93,7 +93,7 @@ func TestBaseImageAddBaseImageHandler(t *testing.T) {
 func TestBaseImageGetBaseImageByNameHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBody := addBaseImageEntity(t, api, h, "testEntity", "test/base", true, map[string]string{"role": "test"})
@@ -135,7 +135,7 @@ func TestBaseImageGetBaseImageByNameHandler(t *testing.T) {
 func TestBaseImageGetBaseImagesHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBaseImageEntity(t, api, h, "testEntity1", "test/base", true, map[string]string{"role": "test", "item": "1"})
@@ -156,7 +156,7 @@ func TestBaseImageGetBaseImagesHandler(t *testing.T) {
 func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBaseImageEntity(t, api, h, "testEntity", "test/base", true, map[string]string{"role": "test"})
@@ -190,7 +190,7 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 func TestImageAddImageHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	baseRespBody := addBaseImageEntity(t, api, h, "testBaseImage", "test/base", true, map[string]string{"role": "test"})
@@ -217,7 +217,7 @@ func TestImageAddImageHandler(t *testing.T) {
 func TestImageGetImageByNameHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", true, map[string]string{"role": "test"})
@@ -265,7 +265,7 @@ func TestImageGetImageByNameHandler(t *testing.T) {
 func TestImageGetImagesHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", true, map[string]string{"role": "test"})
@@ -294,7 +294,7 @@ func TestImageGetImagesHandler(t *testing.T) {
 func TestImageDeleteImagesByNameHandler(t *testing.T) {
 	api := operations.NewImageManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := NewHandlers(nil, nil, es)
+	h := NewHandlers(nil, nil, nil, es)
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", true, map[string]string{"role": "test"})

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTING.md
+++ b/vendor/golang.org/x/sync/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Go
+
+Go is an open source project.
+
+It is the work of hundreds of contributors. We appreciate your help!
+
+
+## Filing issues
+
+When [filing an issue](https://golang.org/issue/new), make sure to answer these five questions:
+
+1. What version of Go are you using (`go version`)?
+2. What operating system and processor architecture are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+General questions should go to the [golang-nuts mailing list](https://groups.google.com/group/golang-nuts) instead of the issue tracker.
+The gophers there will answer or ask you to file an issue if you've tripped over a bug.
+
+## Contributing code
+
+Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html)
+before sending patches.
+
+**We do not accept GitHub pull requests**
+(we use [Gerrit](https://code.google.com/p/gerrit/) instead for code review).
+
+Unless otherwise noted, the Go source files are distributed under
+the BSD-style license found in the LICENSE file.
+

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/README.md
+++ b/vendor/golang.org/x/sync/README.md
@@ -1,0 +1,18 @@
+# Go Sync
+
+This repository provides Go concurrency primitives in addition to the
+ones provided by the language and "sync" and "sync/atomic" packages.
+
+## Download/Install
+
+The easiest way to install is to run `go get -u golang.org/x/sync`. You can
+also manually git clone the repository to `$GOPATH/src/golang.org/x/sync`.
+
+## Report Issues / Send Patches
+
+This repository uses Gerrit for code changes. To learn how to submit changes to
+this repository, see https://golang.org/doc/contribute.html.
+
+The main issue tracker for the sync repository is located at
+https://github.com/golang/go/issues. Prefix your issue with "x/sync:" in the
+subject line, so it is easy to find.

--- a/vendor/golang.org/x/sync/codereview.cfg
+++ b/vendor/golang.org/x/sync/codereview.cfg
@@ -1,0 +1,1 @@
+issuerepo: golang/go

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,131 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"sync"
+
+	// Use the old context because packages that depend on this one
+	// (e.g. cloud.google.com/go/...) must run on Go 1.6.
+	// TODO(jba): update to "context" when possible.
+	"golang.org/x/net/context"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking only until ctx
+// is done. On success, returns nil. On failure, returns ctx.Err() and leaves
+// the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: bad release")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
* Add sync method to EntityHandler interface
  - used to fetch work and is configurable for each entity type
  - image manager compares current state with stored state and
    returns list of entities which need work
  - DefaultSync provides existing behavior to services
* Make work queue scale up as opposed to just starting n (1000)
  goroutines by default

Testing Done: ran e2e
Fixes: #41