### PR TITLE
Update README to mention PV requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ two deployment models, minikube and vanilla hosted kubernetes 1.7+.
 
 ### Kubernetes
 
-A kubernetes 1.7+ cluster is required for installing the Dispatch project
+A Kubernetes 1.7+ cluster with PersistentVolume(PV) provisioner support is required for installing the Dispatch project.
 
 #### Minikube
 


### PR DESCRIPTION
Dispatch requires PV dynamic provisioning support in order to
deploy the rabbitmq helm chart [1]. We could also specify existing
PVC on the chart but it will be tedious to get this from the user
during installation.

This is a not a major constraint since for a single-node K8S
installations, the user could use host-path provisioner (similar
to that of minikube environments).

[1] https://github.com/kubernetes/charts/tree/master/stable/rabbitmq