### PR TITLE
Fix some minor issues in dispatch install

### DIFF
--- a/pkg/functions/builder_test.go
+++ b/pkg/functions/builder_test.go
@@ -35,7 +35,7 @@ func TestImageName(t *testing.T) {
 func mockDockerClient(t *testing.T, doer func(*http.Request) (*http.Response, error)) *docker.Client {
 	mockHttp := newMockClient(doer)
 	if _, ok := mockHttp.Transport.(http.RoundTripper); !ok {
-		t.Errorf("mockHttp is not transport: %b", ok)
+		t.Errorf("mockHttp is not transport: %t", ok)
 	}
 
 	// TODO(karol): This line fails because we're using old docker client which expects http.Client.Transport


### PR DESCRIPTION
* Remove hostname validator for `host` field in openfaasRepo config
When using Google Container Registry, the container "base" is: `gcr.io/PROJECT_NAME/`. This does not validate as a proper hostname for function images registry. The follow-up question is, should the attribute be still named `host`.

* Remove `required` field from email attribute
Email is not required when authenticating with docker registry.

* create authentication string using `json.Marshal`
In some cases, username or password may contain characters that should be escaped (example: `"`). Without `json.Marshal`, those characters are passed as-is to the JSON string, causing parsing errors down the line.



Testing done: Run e2e on GKE