### PR TITLE
riff FaaS driver

### DIFF
--- a/charts/dispatch/charts/function-manager/templates/cluster-role-binding.yaml
+++ b/charts/dispatch/charts/function-manager/templates/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+# The role binding to combine the secret-access service account and role
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fullname" . }}-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "fullname" . }}-service-account
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fullname" . }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/dispatch/charts/function-manager/templates/cluster-role.yaml
+++ b/charts/dispatch/charts/function-manager/templates/cluster-role.yaml
@@ -1,0 +1,9 @@
+# A cluster role for create/get/list/delete/update secrets
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "fullname" . }}-cluster-role
+rules:
+- apiGroups: ["projectriff.io"]
+  resources: ["functions", "topics"]
+  verbs: ["create", "delete"]

--- a/charts/dispatch/charts/function-manager/templates/config-map.yaml
+++ b/charts/dispatch/charts/function-manager/templates/config-map.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   organization: {{ .Values.global.organization }}
+  # TODO(imikushin): just use YAML
   config.json: |-
     {
       "openwhisk": {
@@ -12,6 +13,10 @@ data:
       },
       "openfaas": {
         "gateway": "{{ .Values.faas.openfaas.gateway }}"
+      },
+      "riff": {
+        "gateway": "{{ .Values.faas.riff.gateway }}",
+        "func_namespace": "{{ .Values.faas.riff.namespace }}"
       },
       "registry": {
         "uri": "{{ default .Values.global.registry.uri .Values.registry.uri }}",

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "fullname" . }}-service-account
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ default .Values.global.image.host .Values.image.host }}/{{ .Values.image.repository }}:{{ default .Values.global.image.tag .Values.image.tag }}"

--- a/charts/dispatch/charts/function-manager/templates/service-account.yaml
+++ b/charts/dispatch/charts/function-manager/templates/service-account.yaml
@@ -1,0 +1,5 @@
+# A service account for event-manager pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}-service-account

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -42,6 +42,9 @@ faas:
     host: "52.91.175.16"
   openfaas:
     gateway: "http://gateway.openfaas:8080/"
+  riff:
+    gateway: "http://riff-riff-http-gateway.riff/"
+    namespace: riff
 registry: {}
   # insecure: false
   # uri: docker-docker-registry.docker.svc.cluster.local:5000

--- a/cmd/function-manager/main.go
+++ b/cmd/function-manager/main.go
@@ -50,7 +50,7 @@ var drivers = map[string]func(string) functions.FaaSDriver{
 			RegistryAuth:  registryAuth,
 			Gateway:       config.Global.Riff.Gateway,
 			K8sConfig:     config.Global.Riff.K8sConfig,
-			RiffNamespace: config.Global.Riff.RiffNamespace,
+			FuncNamespace: config.Global.Riff.FuncNamespace,
 		})
 		if err != nil {
 			log.Fatalf("Error starting riff driver: %+v", err)
@@ -131,6 +131,8 @@ func main() {
 	}
 
 	config.Global = config.LoadConfiguration(functionmanager.FunctionManagerFlags.Config)
+	log.Debugln("config.Global:")
+	log.Debugf("%+v", config.Global)
 
 	registryAuth := config.Global.Registry.RegistryAuth
 	if config.Global.Registry.RegistryAuth == "" {

--- a/e2e/tests-riff/apis.bats
+++ b/e2e/tests-riff/apis.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTPS_PORT}"}
+: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTP_PORT}"}
+
+@test "Create Images for test" {
+
+    run dispatch create base-image base-nodejs6 $DOCKER_REGISTRY/$BASE_IMAGE_NODEJS6 --language nodejs6
+    assert_success
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "READY" 4 5
+
+    run dispatch create image nodejs6 base-nodejs6
+    assert_success
+    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create Functions for test" {
+    run dispatch create function nodejs6 func-nodejs6 ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function func-nodejs6 --json | jq -r .status" "READY" 6 5
+}
+
+@test "Test APIs with HTTP(S)" {
+    run dispatch create api api-test-http func-nodejs6 -m POST -p /http --auth public
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get api api-test-http --json | jq -r .status" "READY" 6 5
+
+    echo "${API_GATEWAY_HTTPS_HOST}"
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/http -d '{
+            \"name\": \"VMware\",
+            \"place\": \"HTTP\"
+        }' | jq -r .myField" "Hello, VMware from HTTP" 6 5
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/http -k -d '{
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS" 6 5
+}
+
+@test "Test APIs with HTTPS ONLY" {
+    run dispatch create api api-test-https-only func-nodejs6 -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/https-only -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .message" "Please use HTTPS protocol" 6 5
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/https-only -k -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+}
+
+@test "Test APIs with Kong Plugins" {
+
+    run dispatch create api api-test func-nodejs6 -m GET -m DELETE -m POST -m PUT -p /hello --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test --json | jq -r .status" "READY" 6 5
+
+    # "blocking: true" is default header
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
+
+    # with "x-serverless-blocking: false", it will not return an result
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k -H 'x-dispatch-blocking: false' -d '{
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' | jq -r .status" "CREATING" 6 5
+
+    # PUT with no payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+
+    # PUT with non-json payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k \
+        -d \"not a json payload\" | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+
+    # GET with parameters
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto" 6 5
+
+    # GET without parameters
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+
+}
+
+@test "Test APIs with CORS" {
+    run dispatch create api api-test-cors func-nodejs6 -m POST -m PUT -p /cors --auth public --cors
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-cors --json | jq -r .status" "READY" 6 5
+
+    # contains "Access-Control-Allow-Origin: *"
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/cors -k -v -d '{
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' 2>&1 | grep -c \"Access-Control-Allow-Origin: *\"" 1 6 5
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests-riff/application.bats
+++ b/e2e/tests-riff/application.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Application creation" {
+
+    run_with_retry "dispatch get application --json | jq -r length" 0 1 1
+    assert_success
+
+    # create applications "foo" and "bar"
+    run dispatch create application foo-app
+    assert_success
+    run dispatch create app bar-app
+    assert_success
+
+    run_with_retry "dispatch get app foo-app --json | jq -r .status" "READY" 4 5
+    run_with_retry "dispatch get app bar-app --json | jq -r .status" "READY" 4 5
+}
+
+@test "Base image creation" {
+
+    run dispatch get base-image
+    assert_success
+
+    # Create base image "base-nodejs6"
+    run dispatch create base-image base-nodejs6 $DOCKER_REGISTRY/$BASE_IMAGE_NODEJS6 --language nodejs6
+    assert_success
+
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "READY" 4 5
+}
+
+@test "Image creation" {
+
+    run_with_retry "dispatch get image --json | jq -r length" 0 1 1
+    assert_success
+
+    run dispatch create image foo-app-image base-nodejs6 --application foo-app
+    assert_success
+    run dispatch create image bar-app-image base-nodejs6 --application bar-app
+    assert_success
+
+    # list image of foo app, only one returns
+    run_with_retry "dispatch get image --application foo-app --json | jq -r length" 1 1 1
+    run_with_retry "dispatch get image --json | jq -r length" 2 1 1
+
+    # list image of a non-exist application => no result
+    run_with_retry "dispatch get image --application boo --json | jq length" 0 1 1
+
+    # get image by name and application
+    run_with_retry "dispatch get image foo-app-image --application foo-app --json | jq -r .status" "READY" 4 5
+    run_with_retry "dispatch get image bar-app-image --application bar-app --json | jq -r .status" "READY" 4 5
+
+    # get image of a wrong applicatio name => no result
+    run_with_retry "dispatch get image foo-app-image --application bar-app --json | jq length" 0 1 1
+}
+
+
+@test "Secret creation" {
+
+    run dispatch create secret open-sesame -a foo-app ${DISPATCH_ROOT}/examples/nodejs6/secret.json
+    echo_to_log
+    assert_success
+
+    run dispatch create secret open-sesame-bar -a bar-app ${DISPATCH_ROOT}/examples/nodejs6/secret.json
+    echo_to_log
+    assert_success
+
+    # list secret of foo app, only one returns
+    run_with_retry "dispatch get secret --application foo-app --json | jq length" 1 1 1
+}
+
+@test "Function creation" {
+
+    run dispatch create function foo-app-image foo-app-func -a foo-app ${DISPATCH_ROOT}/examples/nodejs6/i-have-a-secret.js --secret open-sesame
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function -a foo-app --json | jq -r .[].status" "READY" 8 5
+}
+
+@test "Function execution" {
+    run_with_retry "dispatch exec foo-app-func -a foo-app --wait --json | jq -r .output.message" "The password is OpenSesame" 5 5
+}
+
+@test "API creation" {
+
+    run dispatch create api foo-app-api foo-app-func --application foo-app -m POST -p /foo --auth public
+    echo_to_log
+    assert_success
+
+    # list apis of app foo
+    run_with_retry "dispatch get api -a foo-app --json | jq length" 1 1 1
+
+    # list with an wrong application name, => no result
+    run_with_retry "dispatch get api -a bar-app --json | jq length" 0 1 1
+
+    # get with application flag
+    run_with_retry "dispatch get api foo-app-api -a foo-app --json | jq -r .status" "READY" 6 5
+
+    # get with wrong application name => no result
+    run_with_retry "dispatch get api foo-app-api -a bar-app --json |  jq length" 0 1 1
+}
+
+@test "Event" {
+
+    run dispatch create subscription foo-app-one.event foo-app-func -a foo-app
+    echo_to_log
+    assert_success
+
+    run dispatch create subscription foo-app-two.event foo-app-func -a foo-app
+    echo_to_log
+    assert_success
+
+    # list subscriptions
+    run_with_retry "dispatch get subscription -a foo-app --json | jq length" 2 1 1
+
+    # get subscription by name with an application flag
+    run_with_retry "dispatch get subscription foo-app-one_event_foo-app-func -a foo-app --json | jq -r .status" "READY" 4 5
+
+    # get with wrong application name, no result
+    run_with_retry "dispatch get subscription foo-app-one_event_foo-app-func -a bar-app --json | jq length" 0 1 1
+}

--- a/e2e/tests-riff/clean.bats
+++ b/e2e/tests-riff/clean.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Clean all" {
+    cleanup
+}

--- a/e2e/tests-riff/events.bats
+++ b/e2e/tests-riff/events.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create node function with schema" {
+    run dispatch create function nodejs6 node-hello-subscribe-${RUN_ID} ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-subscribe-${RUN_ID} --json | jq -r .status" "READY" 6 5
+    sleep 15 # https://github.com/vmware/dispatch/issues/67
+}
+
+@test "Create subscription" {
+    run dispatch create subscription test.event node-hello-subscribe-${RUN_ID}
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get subscription test_event_node-hello-subscribe-${RUN_ID} --json | jq -r .status" "READY" 4 5
+}
+
+@test "Emit event" {
+    run dispatch emit test.event --payload='{"name": "Jon", "place": "Winterfell"}'
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get runs node-hello-subscribe-${RUN_ID} --json | jq -r .[0].output.myField" "Hello, Jon from Winterfell" 4 5
+}
+
+@test "Delete subscription" {
+    run dispatch delete subscription test_event_node-hello-subscribe-${RUN_ID}
+    echo_to_log
+    assert_success
+}
+
+@test "Cleanup" {
+    cleanup
+}
+
+

--- a/e2e/tests-riff/functions.bats
+++ b/e2e/tests-riff/functions.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create node function no schema" {
+
+    run dispatch create function nodejs6 node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Execute node function no schema" {
+    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Create python function no schema" {
+    skip
+
+    run dispatch create function python3 python-hello-no-schema ${DISPATCH_ROOT}/examples/python3/hello.py
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function python-hello-no-schema --json | jq -r .status" "READY" 6 5
+    sleep 5 # https://github.com/vmware/dispatch/issues/67
+}
+
+@test "Execute python function no schema" {
+    skip
+
+    run_with_retry "dispatch exec python-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Create node function with schema" {
+    run dispatch create function nodejs6 node-hello-with-schema ${DISPATCH_ROOT}/examples/nodejs6/hello.js --schema-in ${DISPATCH_ROOT}/examples/nodejs6/hello.schema.in.json --schema-out ${DISPATCH_ROOT}/examples/nodejs6/hello.schema.out.json
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-with-schema --json | jq -r .status" "READY" 6 5
+    sleep 5 # https://github.com/vmware/dispatch/issues/67
+}
+
+@test "Execute node function with schema" {
+    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Validate schema errors" {
+    skip "schema validation only returns null"
+}
+
+@test "Create python function with runtime deps" {
+    skip
+
+    run dispatch create function python3 http ${DISPATCH_ROOT}/examples/python3/http.py
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function http --json | jq -r .status" "READY" 6 5
+    sleep 5 # https://github.com/vmware/dispatch/issues/67
+}
+
+@test "Execute python function with runtime deps" {
+    skip
+
+    run_with_retry "dispatch exec http --wait --json | jq -r .output.status" "200" 5 5
+}
+
+@test "Delete functions" {
+    delete_entities function
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests-riff/helpers.bash
+++ b/e2e/tests-riff/helpers.bash
@@ -1,0 +1,258 @@
+#!/bin/bash
+
+### COMMON FUNCTIONS ###
+
+# retry_timeout takes 2 args: command [timeout (secs)]
+retry_timeout () {
+  count=0
+  while [[ ! `eval $1` ]]; do
+    sleep 1
+    count=$((count+1))
+    if [[ "$count" -gt $2 ]]; then
+      return 1
+    fi
+  done
+}
+
+# values_equal takes 2 values, both must be non-null and equal
+values_equal () {
+  if [[ "X$1" != "X" ]] || [[ "X$2" != "X" ]] && [[ $1 == $2 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# min_value_met takes 2 values, both must be non-null and 2 must be equal or greater than 1
+min_value_met () {
+  if [[ "X$1" != "X" ]] || [[ "X$2" != "X" ]] && [[ $2 -ge $1 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function echo_to_log {
+  echo "$output" >> ${BATS_LOG}
+}
+
+function setup {
+  echo "$BATS_TEST_NAME
+----------
+" >> ${BATS_LOG}
+}
+
+function teardown {
+  echo "
+----------
+
+" >> ${BATS_LOG}
+}
+
+function errecho {
+  >&2 echo "$@"
+}
+
+function only_if_env {
+  if [[ ${!1} != "$2" ]]; then
+      errecho "This test requires the $1 environment variable to be set to $2. Skipping..."
+      skip
+  fi
+}
+
+function require_env {
+  if [[ -z ${!1} ]]; then
+      errecho "This test requires the $1 environment variable to be set in order to run."
+      exit 1
+  fi
+}
+
+flunk() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } >&2
+  return 1
+}
+
+fatal() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } >&2
+  exit 1
+}
+
+assert_success() {
+  if [ "$status" -ne 0 ]; then
+    flunk "command failed with exit status $status: $output"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_success_or_fatal() {
+  if [ "$status" -ne 0 ]; then
+    fatal "command failed with exit status $status: $output"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_failure() {
+  if [ "$status" -ne 1 ]; then
+    flunk $(printf "expected failed exit status=1, got status=%d" $status)
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    { echo "expected: $1"
+      echo "actual:   $2"
+    } | flunk
+  fi
+}
+
+assert_output() {
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal "$expected" "$output"
+}
+
+assert_matches() {
+  local pattern="${1}"
+  local actual="${2}"
+
+  if [ $# -eq 1 ]; then
+    actual="$(cat -)"
+  fi
+
+  if ! grep -q "${pattern}" <<<"${actual}"; then
+    { echo "pattern: ${pattern}"
+      echo "actual:  ${actual}"
+    } | flunk
+  fi
+}
+
+assert_not_matches() {
+  local pattern="${1}"
+  local actual="${2}"
+
+  if [ $# -eq 1 ]; then
+    actual="$(cat -)"
+  fi
+
+  if grep -q "${pattern}" <<<"${actual}"; then
+    { echo "pattern: ${pattern}"
+      echo "actual:  ${actual}"
+    } | flunk
+  fi
+}
+
+assert_empty() {
+  local actual="${1}"
+
+  if [ $# -eq 0 ]; then
+    actual="$(cat -)"
+  fi
+
+  if [ -n "${actual}" ]; then
+    { echo "actual: ${actual}"
+    } | flunk
+  fi
+}
+
+assert_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    assert_equal "$2" "$(collapse_ws ${lines[$1]})"
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$(collapse_ws $line)" = "$1" ]; then return 0; fi
+    done
+    flunk "expected line \`$1'"
+  fi
+}
+
+refute_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    local num_lines="${#lines[@]}"
+    if [ "$1" -lt "$num_lines" ]; then
+      flunk "output has $num_lines lines"
+    fi
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$line" = "$1" ]; then
+        flunk "expected to not find line \`$line'"
+      fi
+    done
+  fi
+}
+
+assert() {
+  if ! "$@"; then
+    flunk "failed: $@"
+  fi
+}
+
+# Run an arbitrary bash command and validate the output.
+#
+# usage: run_with_retry <bash command> <success output> <retries> <sleep interval>
+#
+# example: validate the number of subnets for a given cell ID (success output is 1, retry is 2, sleep is 30s)
+#   run_with_retry "aws ec2 describe-subnets --region=$DEFAULT_AWS_REGION --filters 'Name=tag:CellID,Values=${TEST_ID}' | jq '.Subnets[].CidrBlock' | wc -l" 1 2 30
+run_with_retry() {
+  for i in $(seq 1 ${3}); do
+      run bash -c "${1}"
+      assert_success
+      echo_to_log
+      if [[ ${output} =~ "${2}" ]]; then
+          break
+      fi
+      sleep ${4}
+  done
+  echo ${1}
+  echo $output
+  [[ ${output} =~ "${2}" ]]
+}
+
+batch_create_images() {
+  run dispatch create --work-dir ${BATS_TEST_DIRNAME} --file ${1}
+  assert_success
+  run bash -c "dispatch get images --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run_with_retry "dispatch get image $i --json | jq -r .status" "READY" 6 30
+  done
+}
+
+batch_delete_images() {
+  run dispatch delete --work-dir ${BATS_TEST_DIRNAME} --file ${1}
+  assert_success
+  run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+delete_entities(){
+  echo "deleting entity type: ${1}"
+  run bash -c "dispatch get ${1} --json | jq -r .[].name"
+  assert_success
+  for i in $output; do
+      run bash -c "dispatch delete ${1} $i"
+  done
+  run_with_retry "dispatch get ${1} --json | jq '. | length'" 0 6 5
+}
+
+cleanup() {
+  delete_entities api
+  delete_entities application
+  delete_entities image
+  delete_entities base-image
+  delete_entities function
+  delete_entities subscription
+  delete_entities secret
+}

--- a/e2e/tests-riff/images.bats
+++ b/e2e/tests-riff/images.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Base image creation" {
+
+    run dispatch get base-image
+    assert_success
+
+    # Create base image "base-nodejs6"
+    run dispatch create base-image base-nodejs6 $DOCKER_REGISTRY/$BASE_IMAGE_NODEJS6 --language nodejs6
+    assert_success
+
+    # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "INITIALIZED" 1 0
+    run_with_retry "dispatch get base-image base-nodejs6 --json | jq -r .status" "READY" 4 5
+
+    # Create base image "base-python3"
+    #run dispatch create base-image base-python3 $DOCKER_REGISTRY/$BASE_IMAGE_PYTHON3 --language python3
+    #assert_success
+
+    # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
+    #run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "INITIALIZED" 1 0
+    #run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "READY" 4 5
+
+    # Create third image with non-existing image. Check that get operation returns three images. Wait for "ERROR" status for missing image.
+    run dispatch create base-image missing-image missing/image:latest --language nodejs6
+    assert_success
+    run bash -c "dispatch get base-image --json | jq '. | length'"
+    assert_equal 2 $output
+    run_with_retry "dispatch get base-image missing-image --json | jq -r .status" "ERROR" 4 5
+}
+
+@test "Image creation" {
+    run dispatch create image nodejs6 base-nodejs6
+    assert_success
+    #run dispatch create image python3 base-python3
+    #assert_success
+    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 8 5
+    #run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 8 5
+}
+
+@test "Delete images" {
+    run bash -c "dispatch get images --json | jq -r .[].name"
+    assert_success
+    for i in $output; do
+        run dispatch delete image $i
+    done
+    run_with_retry "dispatch get images --json | jq '. | length'" 0 4 5
+}
+
+@test "Delete base images" {
+    run bash -c "dispatch get base-images --json | jq -r .[].name"
+    assert_success
+    for i in $output; do
+        run dispatch delete base-image $i
+    done
+    run_with_retry "dispatch get base-images --json | jq '. | length'" 0 4 5
+}
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Batch delete images" {
+    batch_delete_images images.yaml
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests-riff/images.yaml
+++ b/e2e/tests-riff/images.yaml
@@ -1,0 +1,32 @@
+kind: base-image
+name: nodejs6-base
+dockerUrl: vmware/dispatch-riff-nodejs6-base:0.0.3-dev1
+language: nodejs6
+public: true
+tags:
+  - key: role
+    value: test
+#---
+#kind: base-image
+#name: python3-base
+#dockerUrl: vmware/dispatch-riff-python-base:0.0.5-dev1
+#language: python3
+#public: true
+#tags:
+#  - key: role
+#    value: test
+---
+kind: image
+name: nodejs6
+baseImageName: nodejs6-base
+tags:
+  - key: role
+    value: test
+#---
+#kind: image
+#name: python3
+#baseImageName: python3-base
+#runtimeDependenciesPath: requirements.txt
+#tags:
+#  - key: role
+#    value: test

--- a/e2e/tests-riff/requirements.txt
+++ b/e2e/tests-riff/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/e2e/tests-riff/secrets.bats
+++ b/e2e/tests-riff/secrets.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+@test "Batch load images" {
+    batch_create_images images.yaml
+}
+
+@test "Create secret" {
+    run dispatch create secret open-sesame ${DISPATCH_ROOT}/examples/nodejs6/secret.json
+    echo_to_log
+    assert_success
+}
+
+@test "Create function with a default secret" {
+    run dispatch create function nodejs6 i-have-a-default-secret ${DISPATCH_ROOT}/examples/nodejs6/i-have-a-secret.js --secret open-sesame
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-default-secret --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create function without a default secret" {
+    run dispatch create function nodejs6 i-have-a-secret ${DISPATCH_ROOT}/examples/nodejs6/i-have-a-secret.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-secret --json | jq -r .status" "READY" 8 5
+}
+
+@test "Execute function with a default secret" {
+    run_with_retry "dispatch exec i-have-a-default-secret --wait --json | jq -r .output.message" "The password is OpenSesame" 5 5
+}
+
+@test "Execute function without a default secret" {
+    run_with_retry "dispatch exec i-have-a-secret --wait --json | jq -r .output.message" "I know nothing" 5 5
+    run_with_retry "dispatch exec i-have-a-secret --secret open-sesame --wait --json | jq -r .output.message" "The password is OpenSesame" 5 5
+}
+
+@test "Validate invalid secret errors" {
+    skip "secret validation only returns null"
+}
+
+@test "Update secret" {
+    run dispatch get secret open-sesame --json | sed 's/OpenSesame/OpenSesameStreet/' > /tmp/secret.json
+    run dispatch update secret /tmp/secret.json
+}
+
+@test "Delete secrets" {
+    delete_entities secret
+}
+
+@test "Cleanup" {
+    cleanup
+}

--- a/e2e/tests-riff/variables.bash
+++ b/e2e/tests-riff/variables.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+### COMMON VARIABLES ###
+: ${DOCKER_REGISTRY:="vmware"}
+#: ${BASE_IMAGE_PYTHON3:="dispatch-riff-python-base:0.0.5-dev1"}
+: ${BASE_IMAGE_NODEJS6:="dispatch-riff-nodejs6-base:0.0.3-dev1"}

--- a/images/riff/deps-image-node/Dockerfile
+++ b/images/riff/deps-image-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM projectriff/node-function-invoker:0.0.2
+FROM projectriff/node-function-invoker:0.0.3
 
 FROM vmware/photon:2.0
 

--- a/images/riff/deps-image-node/build.sh
+++ b/images/riff/deps-image-node/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t vmware/dispatch-riff-nodejs6-base:0.0.1-dev1 .
+docker build -t vmware/dispatch-riff-nodejs6-base:0.0.3-dev1 .

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,8 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
+	"log"
 	"os"
 )
 
@@ -38,7 +39,7 @@ type Config struct {
 	Riff struct {
 		Gateway       string `json:"gateway"`
 		K8sConfig     string `json:"k8s_config"`
-		RiffNamespace string `json:"riff_namespace"`
+		FuncNamespace string `json:"func_namespace"`
 	} `json:"riff"`
 	Registry struct {
 		RegistryURI  string `json:"uri"`
@@ -48,16 +49,21 @@ type Config struct {
 
 // LoadConfiguration loads configurations from a local json file
 func LoadConfiguration(file string) Config {
-	var config Config
 	configFile, err := os.Open(file)
-	defer configFile.Close()
 	if err != nil {
-		fmt.Println(err.Error())
+		log.Fatal(err)
 	}
-	jsonParser := json.NewDecoder(configFile)
-	err = jsonParser.Decode(&config)
+	defer configFile.Close()
+	config, err := loadConfig(configFile)
 	if err != nil {
-		fmt.Printf("Error parsing config file: %v\n", err.Error())
+		log.Fatal(err)
 	}
 	return config
+}
+
+func loadConfig(reader io.Reader) (Config, error) {
+	var config Config
+	jsonParser := json.NewDecoder(reader)
+	err := jsonParser.Decode(&config)
+	return config, err
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_loadConfig(t *testing.T) {
+	conf := `{
+  "openwhisk": {
+    "auth_token": "<redacted>",
+    "host": "10.0.10.3"
+  },
+  "openfaas": {
+    "gateway": "http://gateway.openfaas:8080/"
+  },
+  "riff": {
+    "gateway": "http://riff-riff-http-gateway.riff/",
+    "func_namespace": "default"
+  },
+  "registry": {
+    "uri": "some-docker-user",
+    "auth": "<redacted>"
+  }
+}`
+	config, err := loadConfig(strings.NewReader(conf))
+	require.NoError(t, err)
+	assert.Equal(t, "some-docker-user", config.Registry.RegistryURI)
+	assert.Equal(t, "http://riff-riff-http-gateway.riff/", config.Riff.Gateway)
+	assert.Equal(t, "default", config.Riff.FuncNamespace)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -163,7 +163,7 @@ func defaultSyncFilter(resyncPeriod time.Duration) entitystore.Filter {
 			Subject: "Status",
 			Verb:    entitystore.FilterVerbIn,
 			Object: []entitystore.Status{
-				entitystore.StatusERROR, entitystore.StatusCREATING, entitystore.StatusUPDATING, entitystore.StatusDELETING,
+				entitystore.StatusCREATING, entitystore.StatusUPDATING, entitystore.StatusDELETING,
 			},
 		})
 }

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -49,6 +49,13 @@ openfaas:
     namespace: openfaas
     release: openfaas
   exposeService: false
+riff:
+  chart:
+    chart: riff
+    namespace: riff
+    release: riff
+    repo: https://riff-charts.storage.googleapis.com
+    version: 0.0.3-rbac
 dispatch:
   chart:
     chart: dispatch
@@ -68,6 +75,7 @@ dispatch:
   persistData: false
   skipAuth: false
   insecure: false
+  faas: openfaas
   #imageRegistry:
   #  name:
   #  username:

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -111,7 +111,9 @@ func helmUninstall(out, errOut io.Writer, namespace, release string, deleteNames
 	helm := exec.Command("helm", args...)
 	helmOut, err := helm.CombinedOutput()
 	if err != nil {
-		return errors.Wrapf(err, string(helmOut))
+		if !strings.Contains(string(helmOut), "not found") {
+			return errors.Wrapf(err, string(helmOut))
+		}
 	}
 	if uninstallDebug {
 		fmt.Fprintln(out, string(helmOut))
@@ -169,6 +171,12 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 		err = helmUninstall(out, errOut, config.OpenFaas.Chart.Namespace, config.OpenFaas.Chart.Release, true)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling openfaas chart")
+		}
+	}
+	if uninstallService("riff") {
+		err = helmUninstall(out, errOut, config.Riff.Chart.Namespace, config.Riff.Chart.Release, true)
+		if err != nil {
+			return errors.Wrapf(err, "Error uninstalling riff chart")
 		}
 	}
 	if uninstallService("api-gateway") {

--- a/pkg/entity-store/store.go
+++ b/pkg/entity-store/store.go
@@ -29,6 +29,11 @@ const (
 	// should wait until the READY state to use the object
 	StatusCREATING Status = "CREATING"
 
+	// StatusINTRANSIT object is currently being processed
+	// and should NOT be picked up by periodic sync
+	// TODO(imikushin) GC stale inflight objects - in case responsible process terminates (e.g. using process UUIDs)
+	StatusINTRANSIT Status = "INTRANSIT"
+
 	// StatusREADY object is READY to be used
 	StatusREADY Status = "READY"
 

--- a/pkg/functions/builder.go
+++ b/pkg/functions/builder.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
@@ -66,9 +65,9 @@ func BuildAndPushFromDir(client docker.ImageAPIClient, dir, name, registryAuth s
 	return nil
 }
 
-func (ib *DockerImageBuilder) BuildImage(fnName string, exec *Exec) (string, error) {
-	defer trace.Tracef("function: '%s', base: '%s'", fnName, exec.Image)()
-	name := imageName(ib.imageRegistry, fnName, utcTimeStampStr(time.Now()))
+func (ib *DockerImageBuilder) BuildImage(faas, fnID string, exec *Exec) (string, error) {
+	defer trace.Tracef("function: '%s', base: '%s'", fnID, exec.Image)()
+	name := imageName(ib.imageRegistry, faas, fnID)
 	log.Debugf("Building image '%s'", name)
 
 	tmpDir, err := ioutil.TempDir("", "func-build")
@@ -201,10 +200,6 @@ func tarDir(source string, tarball *tar.Writer) error {
 		})
 }
 
-func imageName(registry, funcName, ts string) string {
-	return registry + "/func-" + funcName + ":" + ts
-}
-
-func utcTimeStampStr(t time.Time) string {
-	return t.UTC().Format("20060102-150405")
+func imageName(registry, faas, fnID string) string {
+	return registry + "/func-" + faas + "-" + fnID
 }

--- a/pkg/functions/builder_test.go
+++ b/pkg/functions/builder_test.go
@@ -7,11 +7,9 @@ package functions
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
@@ -19,17 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-func TestTimeStampStr(t *testing.T) {
-	ts := time.Now().UTC()
-	expected := fmt.Sprintf("%04d%02d%02d-%02d%02d%02d", ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second())
-	assert.Equal(t, expected, utcTimeStampStr(ts))
-}
-
 func TestImageName(t *testing.T) {
 	prefix := rand.String(9)
-	name := rand.String(6)
-	ts := rand.String(11)
-	assert.Equal(t, prefix+"/func-"+name+":"+ts, imageName(prefix, name, ts))
+	faas := rand.String(5)
+	fnID := rand.String(6)
+	assert.Equal(t, prefix+"/func-"+faas+"-"+fnID, imageName(prefix, faas, fnID))
 }
 
 func mockDockerClient(t *testing.T, doer func(*http.Request) (*http.Response, error)) *docker.Client {

--- a/pkg/functions/mocks/image_builder.go
+++ b/pkg/functions/mocks/image_builder.go
@@ -9,20 +9,20 @@ type ImageBuilder struct {
 	mock.Mock
 }
 
-// BuildImage provides a mock function with given fields: fnName, e
-func (_m *ImageBuilder) BuildImage(fnName string, e *functions.Exec) (string, error) {
-	ret := _m.Called(fnName, e)
+// BuildImage provides a mock function with given fields: faas, fnID, e
+func (_m *ImageBuilder) BuildImage(faas string, fnID string, e *functions.Exec) (string, error) {
+	ret := _m.Called(faas, fnID, e)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, *functions.Exec) string); ok {
-		r0 = rf(fnName, e)
+	if rf, ok := ret.Get(0).(func(string, string, *functions.Exec) string); ok {
+		r0 = rf(faas, fnID, e)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, *functions.Exec) error); ok {
-		r1 = rf(fnName, e)
+	if rf, ok := ret.Get(1).(func(string, string, *functions.Exec) error); ok {
+		r1 = rf(faas, fnID, e)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/functions/openfaas/driver_test.go
+++ b/pkg/functions/openfaas/driver_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/vmware/dispatch/pkg/functions/mocks"
 
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/functions"
@@ -28,10 +26,6 @@ func registryAuth() string {
 
 func driver() *ofDriver {
 	log.SetLevel(log.DebugLevel)
-
-	ib := &mocks.ImageBuilder{}
-
-	ib.On("BuildImage", mock.Anything)
 
 	d, err := New(&Config{
 		Gateway:       "http://localhost:8080/",

--- a/pkg/functions/riff/driver_test.go
+++ b/pkg/functions/riff/driver_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/vmware/dispatch/pkg/testing/dev"
 )
 
+const (
+	funID   = "cafebabe-face-abba"
+	funName = "hello"
+)
+
 func registryAuth() string {
 	return os.Getenv("REGISTRY_AUTH")
 }
@@ -33,7 +38,7 @@ func driver() *riffDriver {
 		ImageRegistry: "imikushin",
 		RegistryAuth:  registryAuth(),
 		K8sConfig:     os.Getenv("K8S_CONFIG"),
-		RiffNamespace: "default",
+		FuncNamespace: "riff",
 	})
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "driver instance not created"))
@@ -69,12 +74,12 @@ func TestImagePush(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestOfDriver_GetRunnable(t *testing.T) {
+func TestDriver_GetRunnable(t *testing.T) {
 	dev.EnsureLocal(t)
 
 	d := driver()
 
-	f := d.GetRunnable(&functions.FunctionExecution{Name: "hello", ID: "cafebabe"})
+	f := d.GetRunnable(&functions.FunctionExecution{Name: funName, ID: funID})
 	ctx := functions.Context{}
 	r, err := f(ctx, map[string]interface{}{"name": "Noone", "place": "Braavos"})
 
@@ -91,13 +96,13 @@ func TestDriver_Create(t *testing.T) {
 
 	f := functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name: "hello",
-			ID:   "cafebabe",
+			Name: funName,
+			ID:   funID,
 		},
 	}
 
 	err := d.Create(&f, &functions.Exec{
-		Image:    "imikushin/dispatch-riff-nodejs6-base:0.0.1-dev1",
+		Image:    "imikushin/dispatch-riff-nodejs6-base:0.0.3-dev1",
 		Language: "nodejs6",
 		Code: `
 module.exports = (context, {name, place}) => {
@@ -116,15 +121,15 @@ module.exports = (context, {name, place}) => {
 	assert.NoError(t, err)
 }
 
-func TestOfDriver_Delete(t *testing.T) {
+func TestDriver_Delete(t *testing.T) {
 	dev.EnsureLocal(t)
 
 	d := driver()
 
 	f := functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name: "hello",
-			ID:   "cafebabe",
+			Name: funName,
+			ID:   funID,
 		},
 	}
 	err := d.Delete(&f)

--- a/pkg/functions/types.go
+++ b/pkg/functions/types.go
@@ -57,11 +57,13 @@ type FaaSDriver interface {
 	GetRunnable(e *FunctionExecution) Runnable
 }
 
+//go:generate mockery -name ImageBuilder -case underscore -dir .
+
 // ImageBuilder builds a docker image for a serverless function.
 type ImageBuilder interface {
 	// BuildImage builds a function image and pushes it to the docker registry.
 	// Returns image full name.
-	BuildImage(fnName string, e *Exec) (string, error)
+	BuildImage(faas, fnID string, e *Exec) (string, error)
 }
 
 type Runner interface {


### PR DESCRIPTION
Official riff-0.0.3-rbac chart is used.

Either `openfaas` or `riff` can be specified in install config.yaml:
`  faas: riff`
Only the configured driver gets installed. OpenFaaS gets installed by
default.

`dispatch uninstall` tolerates not found services.

Function images are named as follows:
`<registry>/func-<faas>-<fnID>`

Function ID are used in lieu of Name in FaaS drivers.

Don’t delete the function in the FaaS driver while creating it.
Simply create. If we’re using UUID there’s no such function in yet.

e2e tests can run with riff driver:
`INSTALL_DISPATCH=0 e2e/scripts/run-e2e.sh ./e2e/tests-riff`