### PR TITLE
Remove hostname requirements and rename registry params

### DIFF
--- a/charts/dispatch/charts/api-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/api-manager/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/echo-server/templates/ingress.yaml
+++ b/charts/dispatch/charts/echo-server/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/event-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/event-manager/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/function-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/function-manager/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/identity-manager/templates/ingress.home.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/ingress.home.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -15,17 +16,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.home.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/identity-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.identity.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/image-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/image-manager/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/oauth2-proxy/templates/configmap.yaml
+++ b/charts/dispatch/charts/oauth2-proxy/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,9 +34,9 @@ data:
       ## the OAuth Redirect URL.
       # defaults to the "https://" + requested host header + "/oauth2/callback"
       {{- if eq (.Values.global.port | toString) "443" }}
-      redirect_url = "https://{{ default .Values.global.host .Values.ingress.host }}{{ .Values.app.redirectPath }}"
+      redirect_url = "https://{{ default $ingress_host .Values.global.host_ip}}{{ .Values.app.redirectPath }}"
       {{- else }}
-      redirect_url = "https://{{ default .Values.global.host .Values.ingress.host }}:{{ .Values.global.port }}{{ .Values.app.redirectPath }}"
+      redirect_url = "https://{{ default $ingress_host .Values.global.host_ip}}:{{ .Values.global.port }}{{ .Values.app.redirectPath }}"
       {{- end }}
     {{- end }}
 

--- a/charts/dispatch/charts/oauth2-proxy/templates/ingress.yaml
+++ b/charts/dispatch/charts/oauth2-proxy/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -17,16 +18,20 @@ metadata:
 {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.http.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}

--- a/charts/dispatch/charts/secret-store/templates/ingress.yaml
+++ b/charts/dispatch/charts/secret-store/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $tls := default .Values.global.tls .Values.ingress.tls -}}
+{{- $ingress_host := default .Values.global.host .Values.ingress.host -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,17 +19,21 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ default .Values.global.host .Values.ingress.host }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
+      {{- if $ingress_host }}
+      host: {{ $ingress_host }}
+      {{- end -}}
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -11,7 +11,8 @@ global:
   trace: false
   data:
     persist: false
-  host: dispatch.vmware.com
+  #host_ip:
+  #host: dispatch.vmware.com
   port: 443
   tls:
     secretName: dispatch-tls

--- a/ci/e2e/config-dispatch.sh
+++ b/ci/e2e/config-dispatch.sh
@@ -22,13 +22,13 @@ apiGateway:
 openfaas:
   exposeServices: false
 dispatch:
-  hostname: dev.dispatch.vmware.com
+  host: dev.dispatch.vmware.com
   port: 443
   image:
     host: ${DOCKER_REGISTRY_HOST}
     tag: ${IMAGE_TAG:-}
-  openfaasRepository:
-    host: ${DOCKER_REGISTRY_HOST}
+  imageRegistry:
+    name: ${DOCKER_REGISTRY_HOST}
     username: ${DOCKER_REGISTRY_USER}
     email: ${DOCKER_REGISTRY_EMAIL}
     password: ${DOCKER_REGISTRY_PASS}

--- a/ci/e2e/config-dispatch.sh
+++ b/ci/e2e/config-dispatch.sh
@@ -18,7 +18,7 @@ ingress:
   serviceType: NodePort
 apiGateway:
   serviceType: NodePort
-  hostname: api.dev.dispatch.vmware.com
+  host: api.dev.dispatch.vmware.com
 openfaas:
   exposeServices: false
 dispatch:

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -33,7 +33,7 @@ apiGateway:
     release: api-gateway
   serviceType: NodePort
   database: postgres
-  hostname: api.dev.dispatch.vmware.com
+  host:
   tls:
     secretName: api-dispatch-tls
 openfaas:
@@ -48,7 +48,7 @@ dispatch:
     namespace: dispatch
     release: dispatch
   organization: dispatch
-  hostname: dev.dispatch.vmware.com
+  host:
   port: 443
   tls:
     secretName: dispatch-tls
@@ -59,10 +59,10 @@ dispatch:
   debug: true
   trace: true
   persistData: false
-  openfaasRepository:
-    host: <host>
+  imageRegistry:
+    name:
     username: <username>
-    email: <email>@vmware.com
+    email:
     password: <password>
   oauth2Proxy:
     clientID: <client-id>

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -142,11 +142,11 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 	configDir, err := homedir.Expand(configDest)
 
 	if uninstallService("certs") || !uninstallDryRun {
-		err = uninstallSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Hostname, config.DispatchConfig.TLS.SecretName)
+		err = uninstallSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Host, config.DispatchConfig.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}
-		err = uninstallSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Hostname, config.APIGateway.TLS.SecretName)
+		err = uninstallSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Host, config.APIGateway.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}


### PR DESCRIPTION
The patch removes the need to specify a hostname during dispatch installation and hence adding the hostname to your local /etc/hosts. This is done by removing name based virtual routing in ingress. But the user has to specify at least the IP address of the dispatch host i.e the node address if using NodePort or the LB IP if using loadbalancer (or use hostname as before). 

The IP address is needed for generating the certs and also for setting the redirect_uri for oauth2 proxy.

The patch also renames image registry's host parameter to 'name'. This is because the term 'host' is misleading for a registry which may also contain the username or repo details as part of it. e.g gcr.io/<PROJECT_ID> or docker.io/\<username\>

Fixes #80 