### PR TITLE
Remove docker.io canonical reference in sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ dispatch:
     tag: v0.1.2
   debug: true
   imageRegistry:
-    # The registry name format varies by the container registry provider.
-    # For dockerhub, use docker.io/<username>
+    # The <registry name> format varies by the container registry provider.
+    # For dockerhub, use your <username>
     # For Google Container Registry, use gcr.io/[GCR-PROJECT-ID]
     name: <registry name>
     # Username for registry authentication


### PR DESCRIPTION
docker.io/<username> doesn't work when used in imageRegistry.name. It was added by mistake in the previous PR.