### PR TITLE
WIP: images are now built not just pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Make a note of the `<port>` as this will be used in the next step.
 Dispatch runs on a non-standard https port on minikube since it uses
 NodePort for the ingress controller service. Hence, update the
 Authorization callback URL of your OAuth2 Client App (created by following
-[How to Create OAuth Client App](docs/create-oauth-client-app.md)) from
+[How to Create OAuth Client App](docs/_guides/create-oauth-client-app.md)) from
 `https://<DISPATCH_HOST>/oauth2` to `https://<DISPATCH_HOST>:<port>/oauth2`
 where `<port>` can be found in your dispatch config file available at
 $HOME/.dispatch/config.json.

--- a/charts/dispatch/charts/application-manager/templates/ingress.yaml
+++ b/charts/dispatch/charts/application-manager/templates/ingress.yaml
@@ -31,7 +31,9 @@ spec:
   {{- if $tls.secretName }}
   tls:
     - secretName: {{ $tls.secretName }}
+      {{- if $ingress_host }}
       hosts:
         - {{ default .Values.global.host .Values.ingress.host }}
+      {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/dispatch/charts/function-manager/templates/config-map.yaml
+++ b/charts/dispatch/charts/function-manager/templates/config-map.yaml
@@ -8,12 +8,13 @@ data:
   config.json: |-
     {
       "openwhisk": {
-        "auth_token": "{{ .Values.faas.openwhisk.authToken }}",
         "host": "{{ .Values.faas.openwhisk.host }}"
       },
       "openfaas": {
-        "gateway": "{{ .Values.faas.openfaas.gateway }}",
-        "image_registry": "{{ .Values.faas.openfaas.imageRegistry }}",
-        "registry_auth": "{{ .Values.faas.openfaas.registryAuth }}"
+        "gateway": "{{ .Values.faas.openfaas.gateway }}"
+      },
+      "registry": {
+        "uri": "{{ default .Values.global.registry.uri .Values.registry.uri }}",
+        "auth": "{{ default .Values.global.registry.auth .Values.registry.auth }}"
       }
     }

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -74,14 +74,14 @@ spec:
             - mountPath: /data/config
               name: {{ template "fullname" . }}-config
               readOnly: true
-            - mountPath: "/var/run/docker.sock"
-              name: {{ template "fullname" . }}-docker
             - mountPath: "/data/tls"
               name: tls
               readOnly: true
           env:
             - name: DOCKER_API_VERSION
               value: "1.24"
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
             - name: ORGANIZATION
               valueFrom:
                 configMapKeyRef:
@@ -89,6 +89,18 @@ spec:
                   key: organization
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        - name: {{ .Chart.Name }}-docker
+          image: docker:dind
+          imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
+          {{- if default .Values.global.registry.insecure .Values.registry.insecure }}
+          args:
+          - --insecure-registry={{ default .Values.global.registry.uri .Values.registry.uri }}
+          {{- end }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-graph-storage
+            mountPath: /var/lib/docker
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}
@@ -103,12 +115,11 @@ spec:
             items:
             - key: config.json
               path: {{ template "name" . }}.json
-        - name: {{ template "fullname" . }}-docker
-          hostPath:
-            path: /var/run/docker.sock
         - name: tls
           secret:
             secretName: dispatch-tls
+        - name: docker-graph-storage
+          emptyDir: {}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -42,8 +42,9 @@ faas:
     host: "52.91.175.16"
   openfaas:
     gateway: "http://gateway.openfaas:8080/"
-    imageRegistry: "vmware"
-    registryAuth: SECRET
+registry: {}
+  # insecure: true
+  # uri: docker-docker-registry.docker.svc.cluster.local:5000
 data:
   # persist: false
   hostPath: /var/function-manager

--- a/charts/dispatch/charts/image-manager/templates/config-map.yaml
+++ b/charts/dispatch/charts/image-manager/templates/config-map.yaml
@@ -5,5 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   organization: {{ .Values.global.organization }}
-  serverless.json: |-
-    {}
+  config.json: |-
+    {
+      "registry": {
+        "uri": "{{ default .Values.global.registry.uri .Values.registry.uri }}",
+        "auth": "{{ default .Values.global.registry.auth .Values.registry.auth }}"
+      }
+    }

--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           image: "{{ default .Values.global.image.host .Values.image.host }}/{{ .Values.image.repository }}:{{ default .Values.global.image.tag .Values.image.tag }}"
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
           args:
+            - "--config=/data/config/{{ template "name" . }}.json"
             - "--organization=$(ORGANIZATION)"
             - "--host=0.0.0.0"
             - "--port={{ .Values.service.internalPort }}"
@@ -66,14 +67,17 @@ spec:
           volumeMounts:
             - mountPath: "/data/{{ template "name" . }}"
               name: {{ template "fullname" . }}
-            - mountPath: "/var/run/docker.sock"
-              name: {{ template "fullname" . }}-docker
+            - mountPath: /data/config
+              name: {{ template "fullname" . }}-config
+              readOnly: true
             - mountPath: "/data/tls"
               name: tls
               readOnly: true
           env:
             - name: DOCKER_API_VERSION
               value: "1.24"
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
             - name: ORGANIZATION
               valueFrom:
                 configMapKeyRef:
@@ -81,6 +85,18 @@ spec:
                   key: organization
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        - name: {{ .Chart.Name }}-docker
+          image: docker:dind
+          imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
+          {{- if default .Values.global.registry.insecure .Values.registry.insecure }}
+          args:
+          - --insecure-registry={{ default .Values.global.registry.uri .Values.registry.uri }}
+          {{- end }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-graph-storage
+            mountPath: /var/lib/docker
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}
@@ -89,12 +105,17 @@ spec:
 {{- else }}
           emptyDir: {}
 {{- end }}
-        - name: {{ template "fullname" . }}-docker
-          hostPath:
-            path: /var/run/docker.sock
+        - name: {{ template "fullname" . }}-config
+          configMap:
+            name: {{ template "fullname" . }}
+            items:
+            - key: config.json
+              path: {{ template "name" . }}.json
         - name: tls
           secret:
             secretName: dispatch-tls
+        - name: docker-graph-storage
+          emptyDir: {}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dispatch/charts/image-manager/values.yaml
+++ b/charts/dispatch/charts/image-manager/values.yaml
@@ -35,6 +35,9 @@ resources: {}
   #requests:
   #  cpu: 100m
   #  memory: 128Mi
+registry: {}
+  # insecure: true
+  # uri: docker-docker-registry.docker.svc.cluster.local:5000
 data:
   # persist: false
   hostPath: /var/image-manager

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -5,7 +5,7 @@ global:
   pullPolicy: IfNotPresent
   organization: dispatch
   image:
-    tag: v0.1.2
+    tag: v0.1.3
     host: vmware
   debug: true
   trace: false
@@ -25,5 +25,8 @@ global:
     database: dispatch
     namespace: dispatch
     release: postgres
+  registry:
+    insecure: true
+    uri: docker-docker-registry.docker.svc.cluster.local:5000
 rabbitmq:
   rabbitmqPassword: serverless

--- a/cmd/image-manager/main.go
+++ b/cmd/image-manager/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/justinas/alice"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/vmware/dispatch/pkg/config"
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/image-manager"
 	"github.com/vmware/dispatch/pkg/image-manager/gen/restapi"
@@ -89,6 +90,8 @@ func main() {
 		trace.Enable()
 	}
 
+	config.Global = config.LoadConfiguration(imagemanager.ImageManagerFlags.Config)
+
 	es, err := entitystore.NewFromBackend(
 		entitystore.BackendConfig{
 			Backend:  imagemanager.ImageManagerFlags.DbBackend,
@@ -106,7 +109,12 @@ func main() {
 		OrganizationID: imagemanager.ImageManagerFlags.OrgID,
 	}
 
-	ib, err := imagemanager.NewImageBuilder(es)
+	registryAuth := config.Global.Registry.RegistryAuth
+	if config.Global.Registry.RegistryAuth == "" {
+		registryAuth = config.EmptyRegistryAuth
+	}
+
+	ib, err := imagemanager.NewImageBuilder(es, config.Global.Registry.RegistryURI, registryAuth)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -16,7 +16,7 @@ load variables
 
     run dispatch create image nodejs6 base-nodejs6
     assert_success
-    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 4 5
+    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 8 5
 }
 
 @test "Create Functions for test" {

--- a/e2e/tests/images.bats
+++ b/e2e/tests/images.bats
@@ -37,11 +37,10 @@ load variables
 @test "Image creation" {
     run dispatch create image nodejs6 base-nodejs6
     assert_success
-    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 4 5
-
     run dispatch create image python3 base-python3
     assert_success
-    run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 4 5
+    run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 8 5
+    run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 8 5
 }
 
 @test "Delete images" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,9 @@ import (
 // Global contains global configuration variables
 var Global Config
 
+// EmptyRegistryAuth == echo -n '{"username":"","password":"","email":""}' | base64
+var EmptyRegistryAuth = "eyJ1c2VybmFtZSI6IiIsInBhc3N3b3JkIjoiIiwiZW1haWwiOiIifQ=="
+
 // Config defines global configurations used in Dispatch
 type Config struct {
 	Identity struct {
@@ -29,17 +32,17 @@ type Config struct {
 		Host      string `json:"host"`
 	} `json:"openwhisk"`
 	OpenFaas struct {
-		Gateway       string `json:"gateway"`
-		ImageRegistry string `json:"image_registry"`
-		RegistryAuth  string `json:"registry_auth"`
+		Gateway string `json:"gateway"`
 	} `json:"openfaas"`
 	Riff struct {
 		Gateway       string `json:"gateway"`
-		ImageRegistry string `json:"image_registry"`
-		RegistryAuth  string `json:"registry_auth"`
 		K8sConfig     string `json:"k8s_config"`
 		RiffNamespace string `json:"riff_namespace"`
 	} `json:"riff"`
+	Registry struct {
+		RegistryURI  string `json:"uri"`
+		RegistryAuth string `json:"auth"`
+	} `json:"registry"`
 }
 
 // LoadConfiguration loads configurations from a local json file

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -295,6 +295,7 @@ func helmInstall(out, errOut io.Writer, meta *chartConfig, options map[string]st
 	if installDebug {
 		fmt.Fprintln(out, string(helmOut))
 	}
+	fmt.Fprintf(out, "Successfully installed %s chart - %s\n", chart, meta.Release)
 	return nil
 }
 
@@ -544,24 +545,24 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 
 		dockerAuthEncoded := base64.StdEncoding.EncodeToString(dockerAuthJSON)
 		dispatchOpts := map[string]string{
-			"global.host":                                  dispatchHost,
-			"global.host_ip":                               dispatchHostIP,
-			"global.port":                                  strconv.Itoa(config.DispatchConfig.Port),
-			"global.debug":                                 strconv.FormatBool(config.DispatchConfig.Debug),
-			"global.trace":                                 strconv.FormatBool(config.DispatchConfig.Trace),
-			"global.data.persist":                          strconv.FormatBool(config.DispatchConfig.PersistData),
-			"function-manager.faas.openfaas.registryAuth":  dockerAuthEncoded,
-			"function-manager.faas.openfaas.imageRegistry": config.DispatchConfig.ImageRegistry.Name,
-			"oauth2-proxy.app.clientID":                    config.DispatchConfig.OAuth2Proxy.ClientID,
-			"oauth2-proxy.app.clientSecret":                config.DispatchConfig.OAuth2Proxy.ClientSecret,
-			"oauth2-proxy.app.cookieSecret":                config.DispatchConfig.OAuth2Proxy.CookieSecret,
-			"global.db.backend":                            config.DispatchConfig.Database,
-			"global.db.host":                               config.PostgresConfig.Host,
-			"global.db.port":                               fmt.Sprintf("%d", config.PostgresConfig.Port),
-			"global.db.user":                               config.PostgresConfig.Username,
-			"global.db.password":                           config.PostgresConfig.Password,
-			"global.db.release":                            config.PostgresConfig.Chart.Release,
-			"global.db.namespace":                          config.PostgresConfig.Chart.Namespace,
+			"global.host":                   dispatchHost,
+			"global.host_ip":                dispatchHostIP,
+			"global.port":                   strconv.Itoa(config.DispatchConfig.Port),
+			"global.debug":                  strconv.FormatBool(config.DispatchConfig.Debug),
+			"global.trace":                  strconv.FormatBool(config.DispatchConfig.Trace),
+			"global.data.persist":           strconv.FormatBool(config.DispatchConfig.PersistData),
+			"global.registry.auth":          dockerAuthEncoded,
+			"global.registry.uri":           config.DispatchConfig.ImageRegistry.Name,
+			"oauth2-proxy.app.clientID":     config.DispatchConfig.OAuth2Proxy.ClientID,
+			"oauth2-proxy.app.clientSecret": config.DispatchConfig.OAuth2Proxy.ClientSecret,
+			"oauth2-proxy.app.cookieSecret": config.DispatchConfig.OAuth2Proxy.CookieSecret,
+			"global.db.backend":             config.DispatchConfig.Database,
+			"global.db.host":                config.PostgresConfig.Host,
+			"global.db.port":                fmt.Sprintf("%d", config.PostgresConfig.Port),
+			"global.db.user":                config.PostgresConfig.Username,
+			"global.db.password":            config.PostgresConfig.Password,
+			"global.db.release":             config.PostgresConfig.Chart.Release,
+			"global.db.namespace":           config.PostgresConfig.Chart.Namespace,
 		}
 
 		// If unset values default to chart values

--- a/pkg/entity-store/libkv.go
+++ b/pkg/entity-store/libkv.go
@@ -29,8 +29,8 @@ func newLibkv(kv store.Store) EntityStore {
 
 func (es *libkvEntityStore) UpdateWithError(e Entity, err error) {
 	if err != nil {
-		e.setStatus(StatusERROR)
-		e.setReason([]string{err.Error()})
+		e.SetStatus(StatusERROR)
+		e.SetReason([]string{err.Error()})
 	}
 	if _, err2 := es.Update(e.GetRevision(), e); err2 != nil {
 		log.Error(err2)

--- a/pkg/entity-store/postgres.go
+++ b/pkg/entity-store/postgres.go
@@ -174,11 +174,11 @@ func dbToEntity(row dbEntity, entity Entity) error {
 	entity.setModifiedTime(row.ModifiedTime)
 	entity.setRevision(row.Revision)
 	entity.setVersion(row.Version)
-	entity.setStatus(Status(row.Status))
-	entity.setDelete(row.Delete)
-	entity.setSpec(row.Spec)
-	entity.setReason(row.Reason)
-	entity.setTags(row.Tags)
+	entity.SetStatus(Status(row.Status))
+	entity.SetDelete(row.Delete)
+	entity.SetSpec(row.Spec)
+	entity.SetReason(row.Reason)
+	entity.SetTags(row.Tags)
 	return nil
 }
 
@@ -429,8 +429,8 @@ func (p *postgresEntityStore) Delete(organizationID string, name string, entity 
 func (p *postgresEntityStore) UpdateWithError(e Entity, err error) {
 
 	if err != nil {
-		e.setStatus(StatusERROR)
-		e.setReason([]string{err.Error()})
+		e.SetStatus(StatusERROR)
+		e.SetReason([]string{err.Error()})
 	}
 	if _, err2 := p.Update(e.GetRevision(), e); err2 != nil {
 		log.Error(err2)

--- a/pkg/entity-store/store.go
+++ b/pkg/entity-store/store.go
@@ -81,11 +81,11 @@ type Entity interface {
 	setModifiedTime(time.Time)
 	setRevision(uint64)
 	setVersion(uint64)
-	setSpec(Spec)
-	setStatus(Status)
-	setReason(Reason)
-	setTags(Tags)
-	setDelete(bool)
+	SetSpec(Spec)
+	SetStatus(Status)
+	SetReason(Reason)
+	SetTags(Tags)
+	SetDelete(bool)
 
 	GetID() string
 	GetName() string
@@ -159,22 +159,22 @@ func (e *BaseEntity) setRevision(revision uint64) {
 func (e *BaseEntity) setVersion(version uint64) {
 	e.Version = version
 }
-func (e *BaseEntity) setSpec(spec Spec) {
+func (e *BaseEntity) SetSpec(spec Spec) {
 	e.Spec = spec
 }
 
-func (e *BaseEntity) setStatus(status Status) {
+func (e *BaseEntity) SetStatus(status Status) {
 	e.Status = status
 }
 
-func (e *BaseEntity) setReason(reason Reason) {
+func (e *BaseEntity) SetReason(reason Reason) {
 	e.Reason = reason
 }
 
-func (e *BaseEntity) setTags(tags Tags) {
+func (e *BaseEntity) SetTags(tags Tags) {
 	e.Tags = tags
 }
-func (e *BaseEntity) setDelete(delete bool) {
+func (e *BaseEntity) SetDelete(delete bool) {
 	e.Delete = delete
 }
 

--- a/pkg/function-manager/controller.go
+++ b/pkg/function-manager/controller.go
@@ -54,6 +54,13 @@ func (h *funcEntityHandler) Add(obj entitystore.Entity) (err error) {
 	if err != nil {
 		return errors.Wrapf(err, "Error when fetching image for function %s", e.Name)
 	}
+
+	// If the image isn't ready yet, we cannot proceed.  The loop should pick up the work
+	// next iteration.
+	if img.Status != imagemodels.StatusREADY {
+		return
+	}
+
 	if err := h.FaaS.Create(e, &functions.Exec{
 		Code:     e.Code,
 		Main:     e.Main,

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -44,7 +44,7 @@ var FunctionManagerFlags = struct {
 	ImageManager string `long:"image-manager" description:"Image manager endpoint" default:"localhost:8002"`
 	SecretStore  string `long:"secret-store" description:"Secret store endpoint" default:"localhost:8003"`
 	Faas         string `long:"faas" description:"FaaS implementation" default:"openfaas"`
-	ResyncPeriod int    `long:"resync-period" description:"The time period (in seconds) to sync with FaaS" default:"60"`
+	ResyncPeriod int    `long:"resync-period" description:"The time period (in seconds) to sync with FaaS" default:"10"`
 	K8sConfig    string `long:"kubeconfig" description:"Path to kubernetes config file" default:""`
 }{}
 

--- a/pkg/image-manager/entities.go
+++ b/pkg/image-manager/entities.go
@@ -37,3 +37,12 @@ type Image struct {
 	Language      string `json:"language"`
 	BaseImageName string `json:"baseImageName"`
 }
+
+func (i *Image) GetDockerURL() string {
+	return i.DockerURL
+}
+
+type DockerImage interface {
+	entitystore.Entity
+	GetDockerURL() string
+}

--- a/pkg/images/builder.go
+++ b/pkg/images/builder.go
@@ -1,0 +1,104 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package images
+
+// NO TESTS
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/vmware/dispatch/pkg/trace"
+)
+
+func DockerError(r io.ReadCloser, err error) error {
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		log.Debug(s.Text())
+		result := struct {
+			Message *string `json:"message,omitempty"`
+			Error   *string `json:"error,omitempty"`
+		}{}
+		if err := json.Unmarshal(s.Bytes(), &result); err != nil {
+			return errors.Wrapf(err, "failed to parse ImagePull response: %s", s.Text())
+		}
+		if result.Error != nil {
+			return errors.New(*result.Error)
+		}
+	}
+	return nil
+}
+
+func BuildAndPushFromDir(client docker.ImageAPIClient, dir, name, registryAuth string) error {
+	tarBall := &bytes.Buffer{}
+	if err := tarDir(dir, tar.NewWriter(tarBall)); err != nil {
+		return errors.Wrap(err, "failed to create a tarball archive")
+	}
+
+	if r, err := client.ImageBuild(context.Background(), tarBall, types.ImageBuildOptions{
+		Tags:           []string{name},
+		SuppressOutput: true,
+	}); err != nil {
+		return errors.Wrap(err, "failed to build an image")
+	} else {
+		r.Body.Close()
+	}
+	opts := types.ImagePushOptions{
+		RegistryAuth: registryAuth,
+	}
+	if err := DockerError(client.ImagePush(context.Background(), name, opts)); err != nil {
+		return errors.Wrapf(err, "failed to push the image %s", name)
+	}
+	return nil
+}
+
+func tarDir(source string, tarball *tar.Writer) error {
+	defer trace.Tracef("tar dir: %s", source)()
+	return filepath.Walk(source,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			header, err := tar.FileInfoHeader(info, info.Name())
+			if err != nil {
+				return err
+			}
+
+			header.Name = "." + strings.TrimPrefix(path, source)
+			log.Debugf("tar: writing header: %s", header.Name)
+
+			if err := tarball.WriteHeader(header); err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(tarball, file)
+			return err
+		})
+}


### PR DESCRIPTION
This is the first step towards being able to build images with
dependencies.  We now build a docker image based on the base-image.
There are other cool things in this commit, such as being able
to use a local repository (yay!) `helm install stable/docker-registry`.

* Added docker in docker side-cars to image manager and function
  manager so that they can reach local repos within the k8s cluster
  - Set DOCKER_HOST to the localhost socket as opposed to the
    host's unix socket
* Build docker images based on the base-image
* Unify the repostory config (do we need separate repo configs for
  FaaSs and image manager?)
* Function manager is more async now as images are not necessarily
  "ready" when function created.
  - Should make "sync" smarter...
* Tried to generalize the image building, but I haven't changed the
  function manager code to use it... yet.
* Image manager now uses global config.

Testing Done:
- Installed and ran chart
- Needs more tests and e2e