### PR TITLE
add support for returning a promise object in openfaas nodejs runtime

### DIFF
--- a/images/openfaas/deps-image-node/build.sh
+++ b/images/openfaas/deps-image-node/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t vmware/dispatch-openfaas-nodejs6-base:0.0.3-dev1 .
+docker build -t vmware/dispatch-openfaas-nodejs6-base:0.0.4-dev1 .

--- a/images/openfaas/deps-image-node/index.js
+++ b/images/openfaas/deps-image-node/index.js
@@ -10,7 +10,11 @@ let func = require('./function/func');
 
 getStdin().then(input => {
     let ctxAndIn = JSON.parse(input);
-    print(JSON.stringify(func(ctxAndIn.context, ctxAndIn.input)));
+    Promise.resolve(func(ctxAndIn.context, ctxAndIn.input)).then(obj => {
+        print(JSON.stringify(obj))
+    }).catch(e => {
+        console.error(e)
+    })
 }).catch(e => {
     console.error(e.stack);
 });


### PR DESCRIPTION
fixes https://github.com/vmware/dispatch/issues/169

built: ``seanhu93/dispatch-openfaas-nodejs6-base:0.0.4-dev1``
manually tested with an nodejs webapp, (connecting to a minio backend), works well.