### PR TITLE
Add progress information for normal (non --debug) install/uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ EOF
 ```
 
 ```
-$ ./dispatch-darwin install --file config.yaml --debug
+$ ./dispatch-darwin install --file config.yaml
 ...
 Config file written to: $HOME/.dispatch/config.json
 ```

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -166,6 +166,7 @@ func installCert(out, errOut io.Writer, configDir, namespace, domain string, tls
 		cert = tls.CertFile
 	} else {
 		// make a new key and cert.
+		fmt.Fprintf(out, "Creating new certificate for domain %s\n", domain)
 		subject := fmt.Sprintf("/CN=%s/O=%s", domain, domain)
 		key = path.Join(configDir, fmt.Sprintf("%s.key", domain))
 		cert = path.Join(configDir, fmt.Sprintf("%s.crt", domain))
@@ -185,6 +186,7 @@ func installCert(out, errOut io.Writer, configDir, namespace, domain string, tls
 			}
 		}
 	}
+	fmt.Fprintf(out, "Updating certificate in namespace %s\n", namespace)
 	kubectl := exec.Command(
 		"kubectl", "delete", "secret", "tls", tls.SecretName, "-n", namespace)
 	kubectlOut, err := kubectl.CombinedOutput()
@@ -281,6 +283,8 @@ func helmInstall(out, errOut io.Writer, meta *chartConfig, options map[string]st
 			fmt.Fprintf(out, " %s", a)
 		}
 		fmt.Fprintf(out, "\n")
+	} else {
+		fmt.Fprintf(out, "Installing %s helm chart\n", chart)
 	}
 
 	helm := exec.Command("helm", args...)
@@ -360,7 +364,6 @@ func getK8sServiceNodePort(service, namespace string, https bool) (int, error) {
 		standardPort = 443
 	}
 
-	fmt.Printf("get nodePort for service %s from namespace %s", service, namespace)
 	kubectl := exec.Command(
 		"kubectl", "get", "svc", service, "-n", namespace,
 		"-o", fmt.Sprintf("jsonpath={.spec.ports[?(@.port==%d)].nodePort}", standardPort))

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -106,6 +106,7 @@ func helmUninstall(out, errOut io.Writer, namespace, release string, deleteNames
 		args = append(args, "--dry-run")
 	}
 
+	fmt.Fprintf(out, "Uninstalling %s from namespace %s\n", release, namespace)
 	helm := exec.Command("helm", args...)
 	helmOut, err := helm.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Add progress information for non --debug install/uninstall. Fixes #145. Sample output:

$ ./bin/dispatch-darwin install --file config.yaml
Creating new certificate for domain 192.168.111.132
Updating certificate in namespace dispatch
Creating new certificate for domain 192.168.111.132
Updating certificate in namespace kong
Installing nginx-ingress helm chart
Installing postgresql helm chart
Installing kong helm chart
Installing openfaas helm chart
Installing dispatch helm chart
Config file written to: /Users/username/.dispatch/config.json

$ ./bin/dispatch-darwin uninstall --file config.yaml
Uninstalling ingress from namespace kube-system
Uninstalling postgres from namespace dispatch
Uninstalling openfaas from namespace openfaas
Uninstalling api-gateway from namespace kong
Uninstalling dispatch from namespace dispatch