### PR TITLE
fix an api-gateway bug 

### DIFF
--- a/charts/kong/dispatch-transformer/handler.lua
+++ b/charts/kong/dispatch-transformer/handler.lua
@@ -60,7 +60,9 @@ local function transform_method(conf)
 
     -- for GET to POST transform:
     -- tranform query strings into the req body
-    if org_http_method == "GET" and rpl_http_method == "POST" then
+    -- hack: cors sends OPTIONS as a preflight query
+    -- hence, we also need to support OPTIONS
+    if (org_http_method == "GET" or org_http_method == "OPTIONS") and rpl_http_method == "POST" then
       local body = {}
       local args = ngx.req.get_uri_args()
       for key, val in pairs(args) do

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -16,8 +16,8 @@ HTTP_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-http-port"]')
 : ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${HTTPS_PORT}"}
 : ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${HTTP_PORT}"}
 
-# echo ${API_GATEWAY_HTTPS_HOST}
-# echo ${API_GATEWAY_HTTP_HOST}
+echo ${API_GATEWAY_HTTPS_HOST}
+echo ${API_GATEWAY_HTTP_HOST}
 
 @test "Create Images for test" {
 

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -5,19 +5,8 @@ set -o pipefail
 load helpers
 load variables
 
-DISPATCH_CONFIG_ROOT=~/.dispatch
-if [ "${CI}" = true ] ; then
-    DISPATCH_CONFIG_ROOT=${DISPATCH_ROOT}
-fi
-
-HTTPS_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-https-port"]')
-HTTP_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-http-port"]')
-
-: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${HTTPS_PORT}"}
-: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${HTTP_PORT}"}
-
-echo ${API_GATEWAY_HTTPS_HOST}
-echo ${API_GATEWAY_HTTP_HOST}
+: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTPS_PORT}"}
+: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTP_PORT}"}
 
 @test "Create Images for test" {
 

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -5,8 +5,19 @@ set -o pipefail
 load helpers
 load variables
 
-: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTPS_PORT}"}
-: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTP_PORT}"}
+DISPATCH_CONFIG_ROOT=~/.dispatch
+if [ "${CI}" = true ] ; then
+    DISPATCH_CONFIG_ROOT=${DISPATCH_ROOT}
+fi
+
+HTTPS_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-https-port"]')
+HTTP_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-http-port"]')
+
+: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${HTTPS_PORT}"}
+: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${HTTP_PORT}"}
+
+# echo ${API_GATEWAY_HTTPS_HOST}
+# echo ${API_GATEWAY_HTTP_HOST}
 
 @test "Create Images for test" {
 

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -1,7 +1,16 @@
 #!/bin/bash
 
 ### COMMON VARIABLES ###
-
 : ${DOCKER_REGISTRY:="vmware"}
 : ${BASE_IMAGE_PYTHON3:="dispatch-openfaas-python-base:0.0.5-dev1"}
 : ${BASE_IMAGE_NODEJS6:="dispatch-openfaas-nodejs6-base:0.0.3-dev1"}
+
+DISPATCH_CONFIG_ROOT=~/.dispatch
+if [ "${CI}" = true ] ; then
+    DISPATCH_CONFIG_ROOT=${DISPATCH_ROOT}
+fi
+API_GATEWAY_HTTPS_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-https-port"]')
+API_GATEWAY_HTTP_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-http-port"]')
+
+: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTPS_PORT}"}
+: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTP_PORT}"}

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -4,13 +4,3 @@
 : ${DOCKER_REGISTRY:="vmware"}
 : ${BASE_IMAGE_PYTHON3:="dispatch-openfaas-python-base:0.0.5-dev1"}
 : ${BASE_IMAGE_NODEJS6:="dispatch-openfaas-nodejs6-base:0.0.3-dev1"}
-
-DISPATCH_CONFIG_ROOT=~/.dispatch
-if [ "${CI}" = true ] ; then
-    DISPATCH_CONFIG_ROOT=${DISPATCH_ROOT}
-fi
-API_GATEWAY_HTTPS_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-https-port"]')
-API_GATEWAY_HTTP_PORT=$(cat ${DISPATCH_CONFIG_ROOT}/config.json | jq  '.["api-http-port"]')
-
-: ${API_GATEWAY_HTTPS_HOST:="https://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTPS_PORT}"}
-: ${API_GATEWAY_HTTP_HOST:="http://api.dev.dispatch.vmware.com:${API_GATEWAY_HTTP_PORT}"}

--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -26,6 +26,8 @@ var dispatchConfig struct {
 	SkipAuth     bool   `json:"skipauth"`
 	Insecure     bool   `json:"insecure"`
 	Json         bool   `json:"-"`
+	APIHTTPSPort int    `json:"api-https-port"`
+	APIHTTPPort  int    `json:"api-http-port"`
 }
 
 var validResources = i18n.T(`Valid resource types include:

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -160,7 +160,7 @@ func installCert(out, errOut io.Writer, configDir, namespace, domain string, tls
 	var key, cert string
 	if tls.CertFile != "" {
 		if tls.PrivateKey == "" {
-			return errors.New("Error installing certificate: missing private key for the tls cert.")
+			return errors.New("error installing certificate: missing private key for the tls cert")
 		}
 		key = tls.PrivateKey
 		cert = tls.CertFile
@@ -306,6 +306,10 @@ func writeConfig(out, errOut io.Writer, configDir string, config *installConfig)
 	if err != nil {
 		return err
 	}
+	if config.APIGateway.ServiceType == "NodePort" {
+		fmt.Fprintf(out, "dispatch api-gateway is running at http port: %d and https port: %d\n",
+			dispatchConfig.APIHTTPPort, dispatchConfig.APIHTTPSPort)
+	}
 	if installDryRun {
 		fmt.Fprintf(out, "Copy the following to your %s/config.json\n", configDir)
 		fmt.Fprintln(out, string(b))
@@ -380,9 +384,6 @@ func getK8sServiceNodePort(service, namespace string, https bool) (int, error) {
 }
 
 func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
-
-	apiGatewayHTTPSPort := 443
-	apiGatewayHTTPPort := 80
 
 	config, err := readConfig(out, errOut, installConfigFile)
 	if err != nil {
@@ -489,11 +490,11 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 		if config.APIGateway.ServiceType == "NodePort" {
 
 			service := fmt.Sprintf("%s-kongproxy", config.APIGateway.Chart.Release)
-			apiGatewayHTTPSPort, err = getK8sServiceNodePort(service, config.APIGateway.Chart.Namespace, true)
+			dispatchConfig.APIHTTPSPort, err = getK8sServiceNodePort(service, config.APIGateway.Chart.Namespace, true)
 			if err != nil {
 				return err
 			}
-			apiGatewayHTTPPort, err = getK8sServiceNodePort(service, config.APIGateway.Chart.Namespace, false)
+			dispatchConfig.APIHTTPPort, err = getK8sServiceNodePort(service, config.APIGateway.Chart.Namespace, false)
 			if err != nil {
 				return err
 			}
@@ -583,14 +584,6 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 		if err != nil {
 			return errors.Wrapf(err, "Error installing dispatch chart")
 		}
-	}
-
-	if config.APIGateway.ServiceType == "NodePort" {
-		fmt.Fprintf(out, "dispatch api-gateway is running at http port: %d and https port: %d\n", apiGatewayHTTPPort, apiGatewayHTTPSPort)
-
-		// note: used for e2e api test
-		os.Setenv("API_GATEWAY_HTTPS_PORT", strconv.Itoa(apiGatewayHTTPSPort))
-		os.Setenv("API_GATEWAY_HTTP_PORT", strconv.Itoa(apiGatewayHTTPPort))
 	}
 	err = writeConfig(out, errOut, configDir, config)
 	return err


### PR DESCRIPTION
fix an api-gateway bug related to cors #174 

- enable query params to http body tranform for OPTIONS method, previous only for GET
- automatically add OPTIONS method for cors-enabled api
- will not add OPTIONS method while register the corresponding kong cors plugin, this is a hard requirement from kong, as listed in the issue too.

Also: for convenience of local dev: print Kong https and http port in dispatch install output
which looks like this:
```
$ dispatch install --file config.yaml --charts-dir charts
...
Installing charts/kong helm chart
Installing charts/openfaas helm chart
Installing charts/dispatch helm chart
dispatch api-gateway is running at http port 32519 and https port 31841
Config file written to: /Users/xueyangh/.dispatch/config.json
...
```
note: the line for api-gateway port is only printed only when kong is deployed at nodePort mode