### PR TITLE
Bump version mentions to v0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ helm init
 ### Download Dispatch CLI
 Get the dispatch command:
 ```
-$ curl -OL https://github.com/vmware/dispatch/releases/download/v0.1.3/dispatch-darwin
+$ curl -OL https://github.com/vmware/dispatch/releases/download/v0.1.6/dispatch-darwin
 $ chmod +x dispatch-darwin
 ```
 

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -5,7 +5,7 @@ global:
   pullPolicy: IfNotPresent
   organization: dispatch
   image:
-    tag: v0.1.3
+    tag: v0.1.6
     host: vmware
   debug: true
   trace: false


### PR DESCRIPTION
Since the current version is v0.1.6, the use of v0.1.3 in README.md and 
charts/dispatch/values.yaml looks incorrect.