### PR TITLE
Add an insecure config option

### DIFF
--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -66,6 +66,7 @@ dispatch:
   trace: true
   persistData: false
   skipAuth: false
+  insecure: false
   #imageRegistry:
   #  name:
   #  username:


### PR DESCRIPTION
* This allows the setting to be set from config
* If self-signed certs are generated, set insecure to true

I think this is good for the dev use-case, but we want to start integrating
with lets encrypt or similar to make real certs the default on non-dev
environments.