### PR TITLE
parallelize control loop and make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,20 +93,23 @@ cli-darwin:
 cli-linux:
 	GOOS=linux go build -o bin/dispatch-linux ./cmd/dispatch
 
+IMAGES = image-manager identity-manager \
+         function-manager secret-store \
+         api-manager event-manager \
+         event-driver application-manager
+
 .PHONY: images
 images: linux ci-images
 
-.PHONY: ci-images
-ci-images:
-	scripts/images.sh image-manager $(BUILD)
-	scripts/images.sh identity-manager $(BUILD)
-	scripts/images.sh function-manager $(BUILD)
-	scripts/images.sh secret-store $(BUILD)
-	scripts/images.sh api-manager $(BUILD)
-	scripts/images.sh event-manager $(BUILD)
-	scripts/images.sh event-driver $(BUILD)
-	scripts/images.sh application-manager $(BUILD)
+.PHONY: ci-values
+ci-values:
 	scripts/values.sh $(BUILD)
+
+.PHONY: ci-images $(IMAGES)
+ci-images: ci-values $(IMAGES)
+
+$(IMAGES):
+	scripts/images.sh $@ $(BUILD)
 
 .PHONY: generate
 generate: ## run go generate

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -133,6 +133,7 @@ var (
 	installDryRun     = false
 	installDebug      = false
 	configDest        = i18n.T(``)
+	helmTimeout       = 300
 )
 
 // NewCmdInstall creates a command object for the generic "get" action, which
@@ -160,6 +161,7 @@ func NewCmdInstall(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&installChartsRepo, "charts-repo", "dispatch", "Helm Chart Repo used")
 	cmd.Flags().StringVar(&installChartsDir, "charts-dir", "dispatch", "File path to local charts (for chart development)")
 	cmd.Flags().StringVarP(&configDest, "destination", "d", "~/.dispatch", "Destination of the CLI configuration")
+	cmd.Flags().IntVarP(&helmTimeout, "timeout", "t", 300, "Timeout passed to Helm when installing charts")
 	return cmd
 }
 
@@ -284,6 +286,7 @@ func helmInstall(out, errOut io.Writer, meta *chartConfig, options map[string]st
 		args = append(args, "--debug")
 	}
 	args = append(args, "--wait")
+	args = append(args, "--timeout", strconv.Itoa(helmTimeout))
 	if installDryRun {
 		args = append(args, "--dry-run")
 	}


### PR DESCRIPTION
* control loop "work" now in goroutine
* images can now be made in parallel with the -j option to make
  - make -j8 ci-images
* --timeout now an option to install to avoid/mitigate helm install timeouts