### PR TITLE
Check failed Helm release and add insecure registry config

### DIFF
--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -43,7 +43,7 @@ faas:
   openfaas:
     gateway: "http://gateway.openfaas:8080/"
 registry: {}
-  # insecure: true
+  # insecure: false
   # uri: docker-docker-registry.docker.svc.cluster.local:5000
 data:
   # persist: false

--- a/charts/dispatch/charts/image-manager/values.yaml
+++ b/charts/dispatch/charts/image-manager/values.yaml
@@ -36,7 +36,7 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 registry: {}
-  # insecure: true
+  # insecure: false
   # uri: docker-docker-registry.docker.svc.cluster.local:5000
 data:
   # persist: false

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -26,7 +26,7 @@ global:
     namespace: dispatch
     release: postgres
   registry:
-    insecure: true
+    insecure: false
     uri: docker-docker-registry.docker.svc.cluster.local:5000
 rabbitmq:
   rabbitmqPassword: serverless


### PR DESCRIPTION
Add a validation to check if there are failed helm releases and if
so ask the user to purge them. Added a flag `--ignore-helm-check`
if the user knows what she/he is doing and wants to continue
with the install.

Added an insecure option to ImageRegistry since all registries
were treated as insecure. Specifying a registry like
`quay.io/<username>` will fail dind pod since it is not
a valid hostname/IP or CIDR range for the `--insecure-registry` option.