### PR TITLE
Support OIDC provider config in dispatch

### DIFF
--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -78,11 +78,14 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         - name: oauth2-proxy
-          image: docker.io/colemickens/oauth2_proxy
+          image: {{ .Values.oauth2proxy.image }}
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
           args:
             - "-upstream=http://localhost:8080/"
-            - "-provider=github"
+            - "-provider={{ .Values.oauth2proxy.provider }}"
+            {{- if eq .Values.oauth2proxy.provider "oidc" }}
+            - "-oidc-issuer-url={{ .Values.oauth2proxy.oidcIssuerURL }}"
+            {{- end }}
             - "-http-address=0.0.0.0:{{ .Values.service.internalPort }}"
             {{- if .Values.oauth2proxy.redirectPath }}
               ## the OAuth Redirect URL.

--- a/charts/dispatch/charts/identity-manager/values.yaml
+++ b/charts/dispatch/charts/identity-manager/values.yaml
@@ -15,10 +15,13 @@ service:
   externalPort: 80
   internalPort: 80
 oauth2proxy:
+  image: docker.io/neosab/oauth2-proxy
+  provider: github
   clientID: <client-id>
   clientSecret: <client-secret>
-  redirectPath: /v1/iam
-# OAuth2 proxy session cookie config
+  redirectPath: /v1/iam/oauth2/callback
+  oidcIssuerURL:
+  # OAuth2 proxy session cookie config
   cookieName: _oauth2_proxy
   # NOTE: replace with your client id & secret with helm install
   cookieSecret: <invalid-secret>

--- a/docs/_guides/create-oauth-client-app.md
+++ b/docs/_guides/create-oauth-client-app.md
@@ -6,33 +6,94 @@ layout: default
 Dispatch is a serverless framework that requires developers and end-users to authenticate themselves before they are
 using the platform.
 
-Dispatch integrates with 3rd party identification providiers (IDP) in order to provide authorization.  The goal for
-Dispatch is to provide integrations with a number of IDPs, including enterprise IDPs such is vIDM.  Currently GitHub is
-the only supported IDP.
+Dispatch integrates with 3rd party identification providers (IDP) in order to provide authentication.  The goal for
+Dispatch is to provide integrations with a number of IDPs, including enterprise IDPs such is vIDM.
 
 This document provides instructions for how to integrate specific IDPs into Dispatch.  This is generally a prerequisite
 to setting up a Dispatch deployment.
 
-## Github
+## 1. Create An OAuth Client App with your Identity Provider
 
-### 1. Create An OAuth Client App with your Github Account
+> **NOTE:** You will need to setup a different `OAuth App` for every dispatch deployment with a different Hostname/IP.
+
+### Using Github
 
 Login to your Github Account and go to [Github developer portal](https://github.com/settings/developers)
 
 Click ``New OAuth App`` Button to create a new client app.
 
 - Application name: for your reference only, e.g. ``dev-dispatch-app``
-- Homepage URL: the hostname for your Dispatch deployment, e.g. ``https://dev.dispatch.vmware.com``
-- Authorization callback URL: <homepage-url>/v1/iam/oauth2, e.g. ``https://dev.dispatch.vmware.com/v1/iam/oauth2``
+- Homepage URL: the hostname or IP address of your Dispatch deployment, e.g. ``https://dev.dispatch.vmware.com``
+- Authorization callback URL: <homepage-url>/v1/iam/oauth2/callback, e.g. ``https://dev.dispatch.vmware.com/v1/iam/oauth2/callback``
 
 Click ``Register application`` and now the client app is created
 
-You should see ``Client ID`` and ``Client Secret`` in the next page, they are the credientials you will use in the next
+You should see ``Client ID`` and ``Client Secret`` in the next page, they are the credentials you will use in the next
 step.
 
-> **NOTE:** You will need to setup a different `OAuth App` for every deployment with a different hostname.
+Edit dispatch's install config.yaml to add the information of the Identity Provider.
 
-### 2. Create Cookie Secret (Optional)
+
+```
+...
+dispatch:
+  oauth2Proxy:
+    provider: github
+    clientID: <client-id>
+    clientSecret: <client-secret>
+```
+
+### Using Google Identity Platform
+
+Login to your [Google API Console](https://console.developers.google.com/) and [Create a Project](https://console.developers.google.com/projectcreate) if you don't have one already. You must setup a project in order to proceed to the next steps. 
+
+* Navigate to the _API and Services_ -> _[Credentials](https://console.developers.google.com/apis/credentials)_ page from the left menu of your project's home page.
+* Enter a Product name e.g ``dispatch-dev-app`` in the OAuth2 Consent Screen tab
+* Click on ``Create credentials > OAuth client ID``
+* Choose ``Application type`` as ``Web Application``
+* Provide a name to the client app
+* Specify the Authorization Redirect URI as ``https://<dispatch_host>/v1/iam/oauth2/callback`` where ``dispatch_host`` is the hostname of IP address of your dispatch deployment. e.g ``https://dev.dispatch.vmware.com/v1/iam/oauth2/callback``
+* Click ``Create``
+
+You should see ``Client ID`` and ``Client Secret`` in the next page, they are the credentials you will use in the next
+step. 
+
+For more detailed information visit Google's [Setting up an OAuth2 App page](https://developers.google.com/identity/protocols/OpenIDConnect#appsetup)
+
+Edit dispatch's install config.yaml to add the information of the Identity Provider.
+
+```
+...
+dispatch:
+  oauth2Proxy:
+    provider: oidc
+    oidcIssuerURL: https://accounts.google.com
+    clientID: XYZ.apps.googleusercontent.com
+    clientSecret: <client-secret>
+```
+
+###  Other OpenID Connect Providers
+
+Dispatch supports OpenID Connect compliant Identity Providers for providing authentication.
+
+The steps to create an ``OAuth2 Client App`` varies by the provider and hence please refer to the provider documentation.
+Most likely you just need the _Authorization Redirect URI_ which is ``https://<dispatch_host>/v1/iam/oauth2/callback`` where ``dispatch_host`` is the hostname of IP address of your dispatch deployment.
+
+Once you have secured the ``Client ID`` and ``Client Secret`` from your provider,
+edit dispatch's install `config.yaml` to add the information of the Identity Provider. You also need the `Issuer URL` of your ODIC compliant Identity provider.
+
+```
+...
+dispatch:
+  oauth2Proxy:
+    provider: oidc
+    oidcIssuerURL: <OIDC Issuer URL>
+    clientID: <client-id>
+    clientSecret: <client-secret>
+```
+ 
+
+## 2. Create Cookie Secret (Optional)
 
 Dispatch uses HTTP session cookies to keep track users. It is optional to encrypt the cookie sent to the end users, but it is highly recommended for security reasons.
 
@@ -42,30 +103,20 @@ $ python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
 YVBLBQXd4CZo1vnUTSM/3w==
 ```
 
-### 3. Import Client App Credientials into Dispatch Chart
-
-Install/Update your Dispatch chart as normal, with
+Specify the cookie secret in the install config.yaml's `oauth2proxy` section
 ```
-export DISPATCH_OAUTH_CLIENT_ID = <client-id>
-export DISPATCH_OAUTH_CLIENT_SECRET = <client-secret>
-export DISPATCH_OAUTH_COOKIE_SECRET = <cookie-secret>
+...
+dispatch:
+  oauth2Proxy:
+    ....
+    cookieSecret: YVBLBQXd4CZo1vnUTSM/3w==
+```
 
-# install
-helm install charts/dispatch --name=dev-dispatch --namespace dispatch \
-    <other configurations> ... \
-    --set oauth2-proxy.app.clientID=$DISPATCH_OAUTH_CLIENT_ID  \
-    --set oauth2-proxy.app.clientSecret=$DISPATCH_OAUTH_CLIENT_SECRET \
-    --set oauth2-proxy.app.cookieSecret=$DISPATCH_OAUTH_COOKIE_SECRET \
-    --set --debug
+## 3. Re-run Dispatch Install
 
-# upgrade
-# install
-helm upgrade dev-dispatch charts/dispatch --namespace dispatch \
-    <other configurations> ... \
-    --set oauth2-proxy.app.clientID=$DISPATCH_OAUTH_CLIENT_ID  \
-    --set oauth2-proxy.app.clientSecret=$DISPATCH_OAUTH_CLIENT_SECRET \
-    --set oauth2-proxy.app.cookieSecret=$DISPATCH_OAUTH_COOKIE_SECRET \
-    --set --debug
+Install/Update your Dispatch installation as normal, with
+```
+dispatch install -f config.yaml
 ```
 
 

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -82,6 +82,8 @@ dispatch:
   #  email:
   #  password:
   oauth2Proxy:
+    provider: github
+    oidcIssuerURL:
     clientID: <client-id>
     clientSecret: <client-secret>
     cookieSecret:


### PR DESCRIPTION
Add support for specifying an OIDC provider in dispatch install command. Now, we can add an OIDC compliant provider like Google Identity Platform to dispatch.

Other changes:

* Changed the oauth2 proxy image to
  ``docker.io/neosab/oauth2-proxy`` which tracks the master branch of bitly's oauth2 proxy code. We need the latest because of the support for OIDC providers in oauth2 proxy.

  There is no official docker image from bitly. We were using ``docker.io/colemickens/oauth2_proxy`` but that image is old and only tracks released versions.

* Doc changes