### PR TITLE
Identify resources from request URL

### DIFF
--- a/pkg/identity-manager/testdata/test_policy.csv
+++ b/pkg/identity-manager/testdata/test_policy.csv
@@ -1,1 +1,2 @@
 p, readonly-user@example.com, *, get
+p, super-admin@example.com, *, *

--- a/pkg/identity-manager/types.go
+++ b/pkg/identity-manager/types.go
@@ -8,7 +8,9 @@ package identitymanager
 // NO TESTS
 
 type attributesRecord struct {
-	userEmail string
-	resource  string
-	action    Action
+	userEmail         string
+	resource          string
+	path              string
+	action            Action
+	isResourceRequest bool
 }


### PR DESCRIPTION
Currently, we don't consider the requested resource when enforcing Authz. This patch adds support to parse URL and identify the resource that can be then used to enforce the policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/235)
<!-- Reviewable:end -->
