### PR TITLE
Fix helm command in minikube guide

### DIFF
--- a/docs/_guides/minikube.md
+++ b/docs/_guides/minikube.md
@@ -77,8 +77,7 @@ kube-system   storage-provisioner           1/1       Running   0          42s
 
 ```
 $ brew install kubernetes-helm
-# If not using the tiller service account, simply run `helm init`
-$ helm init --service-account tiller
+$ helm init
 $HELM_HOME has been configured at /Users/bjung/.helm.
 
 Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.


### PR DESCRIPTION
The helm init command currently refers to a service account
which doesn't exist and causes tiller to fail.  This is a silent
failure which prevents dispatch from installing