### PR TITLE
Bump to riff-0.0.4

### DIFF
--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -85,6 +85,10 @@ type riffConfig struct {
 	Chart *chartConfig `json:"chart,omitempty" validate:"required"`
 }
 
+type kafkaConfig struct {
+	Chart *chartConfig `json:"chart,omitempty" validate:"required"`
+}
+
 type imageConfig struct {
 	Host string `json:"host,omitempty" validate:"omitempty"`
 	Tag  string `json:"tag,omitempty"  validate:"omitempty"`
@@ -128,6 +132,7 @@ type installConfig struct {
 	APIGateway        *apiGatewayConfig      `json:"apiGateway,omitempty" validate:"required"`
 	OpenFaas          *openfaasConfig        `json:"openfaas,omitempty" validate:"required"`
 	Riff              *riffConfig            `json:"riff,omitempty" validate:"required"`
+	Kafka             *kafkaConfig           `json:"kafka,omitempty" validate:"required"`
 	DispatchConfig    *dispatchInstallConfig `json:"dispatch,omitempty" validate:"required"`
 	DockerRegistry    *dockerRegistry        `json:"dockerRegistry,omitempty" validate:"omitempty"`
 }
@@ -577,6 +582,12 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 		err = helmInstall(out, errOut, config.OpenFaas.Chart, openFaasOpts)
 		if err != nil {
 			return errors.Wrapf(err, "Error installing openfaas chart")
+		}
+	}
+	if installService("kafka") && installFaaS(config, "riff") {
+		err = helmInstall(out, errOut, config.Kafka.Chart, nil)
+		if err != nil {
+			return errors.Wrapf(err, "Error installing kafka chart")
 		}
 	}
 	if installService("riff") && installFaaS(config, "riff") {

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -49,13 +49,20 @@ openfaas:
     namespace: openfaas
     release: openfaas
   exposeService: false
+kafka:
+  chart:
+    chart: kafka
+    namespace: riff-system
+    release: transport
+    repo: https://riff-charts.storage.googleapis.com
+    version: 0.0.1
 riff:
   chart:
     chart: riff
     namespace: riff
     release: riff
     repo: https://riff-charts.storage.googleapis.com
-    version: 0.0.3-rbac
+    version: 0.0.4
 dispatch:
   chart:
     chart: dispatch

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -179,6 +179,12 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 			return errors.Wrapf(err, "Error uninstalling riff chart")
 		}
 	}
+	if uninstallService("kafka") {
+		err = helmUninstall(out, errOut, config.Kafka.Chart.Namespace, config.Kafka.Chart.Release, true)
+		if err != nil {
+			return errors.Wrapf(err, "Error uninstalling kafka chart")
+		}
+	}
 	if uninstallService("api-gateway") {
 		err = helmUninstall(out, errOut, config.APIGateway.Chart.Namespace, config.APIGateway.Chart.Release, true)
 		if err != nil {


### PR DESCRIPTION
Kafka is now installed from a separate chart.

We're still using the base image from riff v0.0.3 though: holding off 
gRPC comm between the function sidecar an the func for now. 

Tested locally with `e2e/tests-riff`.