### PR TITLE
Change to X-Auth-Request-Redirect Header

### DIFF
--- a/pkg/identity-manager/handlers.go
+++ b/pkg/identity-manager/handlers.go
@@ -43,7 +43,7 @@ m = keyMatch(r.sub, p.sub) && keyMatch(r.obj, p.obj) && keyMatch(r.act, p.act)
 )
 
 const (
-	HTTP_HEADER_ORIG_URL    = "X-Original-URL"
+	HTTP_HEADER_REQ_URI     = "X-Auth-Request-Redirect"
 	HTTP_HEADER_ORIG_METHOD = "X-Original-Method"
 	HTTP_HEADER_FWD_EMAIL   = "X-Forwarded-Email"
 )
@@ -184,10 +184,10 @@ func getRequestAttributes(request *http.Request) (*attributesRecord, error) {
 	// /
 	// /{version}
 	// /{specialPrefix} e.g /echo
-	requestPath := request.Header.Get(HTTP_HEADER_ORIG_URL)
-	log.Debugf("Request path: %s\n", requestPath)
+	requestPath := request.Header.Get(HTTP_HEADER_REQ_URI)
+	log.Debugf("Request path: %s", requestPath)
 	if requestPath == "" {
-		return nil, fmt.Errorf("%s header not found", HTTP_HEADER_ORIG_URL)
+		return nil, fmt.Errorf("%s header not found", HTTP_HEADER_REQ_URI)
 	}
 	currentParts := strings.Split(strings.Trim(requestPath, "/"), "/")
 	// Check if a nonResource path is requested

--- a/pkg/identity-manager/handlers_test.go
+++ b/pkg/identity-manager/handlers_test.go
@@ -61,7 +61,7 @@ func TestAuthHandlerPolicyPass(t *testing.T) {
 	helpers.MakeAPI(t, handlers.ConfigureHandlers, api)
 	IdentityManagerFlags.PolicyFile = filepath.Join("testdata", "test_policy.csv")
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "GET")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "readonly-user@example.com")
 	params := operations.AuthParams{
@@ -78,7 +78,7 @@ func TestAuthHandlerNonResourcePass(t *testing.T) {
 	helpers.MakeAPI(t, handlers.ConfigureHandlers, api)
 	IdentityManagerFlags.PolicyFile = filepath.Join("testdata", "test_policy.csv")
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/echo")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/echo")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "GET")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "noname@example.com")
 	params := operations.AuthParams{
@@ -95,7 +95,7 @@ func TestAuthHandlerPolicyFail(t *testing.T) {
 	helpers.MakeAPI(t, handlers.ConfigureHandlers, api)
 	IdentityManagerFlags.PolicyFile = filepath.Join("testdata", "test_policy.csv")
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "POST")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "readonly-user@example.com")
 	params := operations.AuthParams{
@@ -111,7 +111,7 @@ func TestAuthHandlerWithoutPolicyFile(t *testing.T) {
 	handlers := &Handlers{}
 	helpers.MakeAPI(t, handlers.ConfigureHandlers, api)
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	params := operations.AuthParams{
 		HTTPRequest: request,
 	}
@@ -127,7 +127,7 @@ func TestAuthHandlerPolicyNoValidHeader(t *testing.T) {
 	IdentityManagerFlags.PolicyFile = filepath.Join("testdata", "test_policy.csv")
 	request := httptest.NewRequest("GET", "/auth", nil)
 	// Missing Email Header
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "POST")
 	params := operations.AuthParams{
 		HTTPRequest: request,
@@ -139,7 +139,7 @@ func TestAuthHandlerPolicyNoValidHeader(t *testing.T) {
 func TestGetRequestAttributesNoEmailHeader(t *testing.T) {
 
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "POST")
 	_, err := getRequestAttributes(request)
 	assert.EqualError(t, err, "X-Forwarded-Email header not found")
@@ -149,7 +149,7 @@ func TestGetRequestAttributesNoMethodHeader(t *testing.T) {
 
 	request := httptest.NewRequest("GET", "/auth", nil)
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "super-admin@example.com")
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	_, err := getRequestAttributes(request)
 	assert.EqualError(t, err, "X-Original-Method header not found")
 }
@@ -160,13 +160,13 @@ func TestGetRequestAttributesNoURLHeader(t *testing.T) {
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "super-admin@example.com")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "POST")
 	_, err := getRequestAttributes(request)
-	assert.EqualError(t, err, "X-Original-URL header not found")
+	assert.EqualError(t, err, "X-Auth-Request-Redirect header not found")
 }
 
 func TestGetRequestAttributesValidResource(t *testing.T) {
 
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/v1/function")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/v1/function")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "POST")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "super-admin@example.com")
 	attrRecord, _ := getRequestAttributes(request)
@@ -180,7 +180,7 @@ func TestGetRequestAttributesValidResource(t *testing.T) {
 func TestGetRequestAttributesNonResourcePath(t *testing.T) {
 
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "/echo")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "/echo")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "GET")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "super-admin@example.com")
 	attrRecord, _ := getRequestAttributes(request)
@@ -194,7 +194,7 @@ func TestGetRequestAttributesNonResourcePath(t *testing.T) {
 func TestGetRequestAttributesValidSubResource(t *testing.T) {
 
 	request := httptest.NewRequest("GET", "/auth", nil)
-	request.Header.Add(HTTP_HEADER_ORIG_URL, "v1/function/func_name/foo/bar")
+	request.Header.Add(HTTP_HEADER_REQ_URI, "v1/function/func_name/foo/bar")
 	request.Header.Add(HTTP_HEADER_ORIG_METHOD, "GET")
 	request.Header.Add(HTTP_HEADER_FWD_EMAIL, "super-admin@example.com")
 	attrRecord, _ := getRequestAttributes(request)


### PR DESCRIPTION
`X-Auth-Request-Redirect` HTTP header from nginx ingress controller returns the redirect URI instead of the complete original URL (skipping host/port). This fixes an issue where the resource parsing wasn't functioning correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/243)
<!-- Reviewable:end -->
