### PR TITLE
Appropriate error when creating an entity with non-unique name

### DIFF
--- a/e2e/tests-riff/functions.bats
+++ b/e2e/tests-riff/functions.bats
@@ -18,6 +18,15 @@ load variables
     run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 6 5
 }
 
+@test "Create a function with duplicate name" {
+    run dispatch create function nodejs6 node-hello-dup ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run dispatch create function nodejs6 node-hello-dup ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    assert_failure
+}
+
 @test "Execute node function no schema" {
     run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
 }

--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -18,6 +18,15 @@ load variables
     run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 6 5
 }
 
+@test "Create a function with duplicate name" {
+    run dispatch create function nodejs6 node-hello-dup ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    echo_to_log
+    assert_success
+
+    run dispatch create function nodejs6 node-hello-dup ${DISPATCH_ROOT}/examples/nodejs6/hello.js
+    assert_failure
+}
+
 @test "Execute node function no schema" {
     run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
 }

--- a/pkg/dispatchcli/cmd/errors.go
+++ b/pkg/dispatchcli/cmd/errors.go
@@ -90,6 +90,8 @@ func formatAPIError(err error, params interface{}) error {
 	// Add
 	case *function.AddFunctionBadRequest:
 		return i18n.Errorf("[Code: %d] Bad request: %s", v.Payload.Code, msg(v.Payload.Message))
+	case *function.AddFunctionConflict:
+		return i18n.Errorf("[Code: %d] Conflict: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *function.AddFunctionUnauthorized:
 		return i18n.Errorf("[Code: %d] Unauthorized: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *function.AddFunctionInternalServerError:

--- a/pkg/entity-store/store.go
+++ b/pkg/entity-store/store.go
@@ -275,6 +275,15 @@ type EntityStore interface {
 	UpdateWithError(e Entity, err error)
 }
 
+type uniqueViolation interface {
+	UniqueViolation() bool
+}
+
+func IsUniqueViolation(err error) bool {
+	e, ok := errors.Cause(err).(uniqueViolation)
+	return ok && e.UniqueViolation()
+}
+
 // BackendConfig list a set of configuration values for backend DB
 type BackendConfig struct {
 	Backend  string

--- a/pkg/function-manager/gen/client/store/add_function_responses.go
+++ b/pkg/function-manager/gen/client/store/add_function_responses.go
@@ -51,6 +51,13 @@ func (o *AddFunctionReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddFunctionConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddFunctionInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -139,6 +146,35 @@ func (o *AddFunctionUnauthorized) Error() string {
 }
 
 func (o *AddFunctionUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddFunctionConflict creates a AddFunctionConflict with default headers values
+func NewAddFunctionConflict() *AddFunctionConflict {
+	return &AddFunctionConflict{}
+}
+
+/*AddFunctionConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddFunctionConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddFunctionConflict) Error() string {
+	return fmt.Sprintf("[POST /][%d] addFunctionConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddFunctionConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -131,6 +131,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "500": {
             "description": "Internal error",
             "schema": {

--- a/pkg/function-manager/gen/restapi/operations/store/add_function_responses.go
+++ b/pkg/function-manager/gen/restapi/operations/store/add_function_responses.go
@@ -147,6 +147,49 @@ func (o *AddFunctionUnauthorized) WriteResponse(rw http.ResponseWriter, producer
 	}
 }
 
+// AddFunctionConflictCode is the HTTP code returned for type AddFunctionConflict
+const AddFunctionConflictCode int = 409
+
+/*AddFunctionConflict Already Exists
+
+swagger:response addFunctionConflict
+*/
+type AddFunctionConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddFunctionConflict creates AddFunctionConflict with default headers values
+func NewAddFunctionConflict() *AddFunctionConflict {
+	return &AddFunctionConflict{}
+}
+
+// WithPayload adds the payload to the add function conflict response
+func (o *AddFunctionConflict) WithPayload(payload *models.Error) *AddFunctionConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add function conflict response
+func (o *AddFunctionConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddFunctionConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddFunctionInternalServerErrorCode is the HTTP code returned for type AddFunctionInternalServerError
 const AddFunctionInternalServerErrorCode int = 500
 

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -303,6 +303,12 @@ func (h *Handlers) addFunction(params fnstore.AddFunctionParams, principal inter
 	log.Debugf("trying to add entity to store")
 	log.Debugf("entity org=%s, name=%s, id=%s, status=%s", e.OrganizationID, e.Name, e.ID, e.Status)
 	if _, err := h.Store.Add(e); err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return fnstore.NewAddFunctionConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating function: non-unique name"),
+			})
+		}
 		log.Errorf("Store error when adding a new function %s: %+v", e.Name, err)
 		return fnstore.NewAddFunctionInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,

--- a/swagger/function-manager.yaml
+++ b/swagger/function-manager.yaml
@@ -46,6 +46,10 @@ paths:
           description: Unauthorized Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal error
           schema:


### PR DESCRIPTION
When trying to create a function, return 409 Conflict if a function
with the same name already exists.