### PR TITLE
Move base-image from v1/image/base to v1/baseimage

### DIFF
--- a/charts/dispatch/charts/api-manager/values.yaml
+++ b/charts/dispatch/charts/api-manager/values.yaml
@@ -23,7 +23,8 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/api
+  paths:
+  - /v1/api
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/application-manager/values.yaml
+++ b/charts/dispatch/charts/application-manager/values.yaml
@@ -19,7 +19,8 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/application
+  paths:
+  - /v1/application
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/echo-server/values.yaml
+++ b/charts/dispatch/charts/echo-server/values.yaml
@@ -17,7 +17,8 @@ ingress:
   enabled: true
   # Used to create an Ingress record.
   # host: dispatch.vmware.com
-  path: /echo
+  paths:
+  - /echo
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/event-manager/values.yaml
+++ b/charts/dispatch/charts/event-manager/values.yaml
@@ -18,7 +18,8 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/event
+  paths:
+  - /v1/event
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -18,7 +18,8 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/function
+  paths:
+  - /v1/function
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/identity-manager/values.yaml
+++ b/charts/dispatch/charts/identity-manager/values.yaml
@@ -34,7 +34,8 @@ oauth2proxy:
 ingress:
   enabled: true
   # host: dispatch.vmware.com
-  path: /v1/iam
+  paths:
+  - /v1/iam
   tls:
     # Secrets must be manually created in the namespace.
     # secretName: dispatch-tls

--- a/charts/dispatch/charts/image-manager/values.yaml
+++ b/charts/dispatch/charts/image-manager/values.yaml
@@ -18,7 +18,9 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/image
+  paths:
+  - /v1/image
+  - /v1/baseimage
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/charts/secret-store/values.yaml
+++ b/charts/dispatch/charts/secret-store/values.yaml
@@ -18,7 +18,8 @@ ingress:
   enabled: true
   # Used to create Ingress record (should used with service.type: ClusterIP).
   # host: dispatch.vmware.com
-  path: /v1/secret
+  paths:
+  - /v1/secret
   annotations:
     # kubernetes.io/tls-acme: "true"
   tls:

--- a/charts/dispatch/templates/_helpers.tpl
+++ b/charts/dispatch/templates/_helpers.tpl
@@ -26,10 +26,12 @@ spec:
   rules:
     - http:
         paths:
-          - path: {{ .Values.ingress.path }}
+        {{- range $path := .Values.ingress.paths }}
+          - path: {{ $path }}
             backend:
-              serviceName: {{ include "fullname" . }}
-              servicePort: {{ .Values.service.externalPort }}
+              serviceName: {{ include "fullname" $ }}
+              servicePort: {{ $.Values.service.externalPort }}
+        {{- end -}}
       {{- if $ingress_host }}
       host: {{ $ingress_host }}
       {{- end -}}

--- a/docs/_guides/troubleshooting.md
+++ b/docs/_guides/troubleshooting.md
@@ -92,7 +92,7 @@ minikube delete && minikube start --vm-driver=hyperkit --bootstrapper=kubeadm --
 ##### Issue:
 
 ```
-received unexpected error: Post https://<dispatch-host>:32015/v1/image/base: x509: cannot validate certificate for <dispatch-host> because it doesn't contain any IP SANs
+received unexpected error: Post https://<dispatch-host>:32015/v1/baseimage: x509: cannot validate certificate for <dispatch-host> because it doesn't contain any IP SANs
 
 ```
 

--- a/pkg/image-manager/gen/client/base_image/add_base_image_responses.go
+++ b/pkg/image-manager/gen/client/base_image/add_base_image_responses.go
@@ -77,7 +77,7 @@ type AddBaseImageCreated struct {
 }
 
 func (o *AddBaseImageCreated) Error() string {
-	return fmt.Sprintf("[POST /base][%d] addBaseImageCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /baseimage][%d] addBaseImageCreated  %+v", 201, o.Payload)
 }
 
 func (o *AddBaseImageCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type AddBaseImageBadRequest struct {
 }
 
 func (o *AddBaseImageBadRequest) Error() string {
-	return fmt.Sprintf("[POST /base][%d] addBaseImageBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /baseimage][%d] addBaseImageBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *AddBaseImageBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type AddBaseImageConflict struct {
 }
 
 func (o *AddBaseImageConflict) Error() string {
-	return fmt.Sprintf("[POST /base][%d] addBaseImageConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /baseimage][%d] addBaseImageConflict  %+v", 409, o.Payload)
 }
 
 func (o *AddBaseImageConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *AddBaseImageDefault) Code() int {
 }
 
 func (o *AddBaseImageDefault) Error() string {
-	return fmt.Sprintf("[POST /base][%d] addBaseImage default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[POST /baseimage][%d] addBaseImage default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *AddBaseImageDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/base_image/base_image_client.go
+++ b/pkg/image-manager/gen/client/base_image/base_image_client.go
@@ -41,7 +41,7 @@ func (a *Client) AddBaseImage(params *AddBaseImageParams, authInfo runtime.Clien
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "addBaseImage",
 		Method:             "POST",
-		PathPattern:        "/base",
+		PathPattern:        "/baseimage",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -70,7 +70,7 @@ func (a *Client) DeleteBaseImageByName(params *DeleteBaseImageByNameParams, auth
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "deleteBaseImageByName",
 		Method:             "DELETE",
-		PathPattern:        "/base/{baseImageName}",
+		PathPattern:        "/baseimage/{baseImageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -101,7 +101,7 @@ func (a *Client) GetBaseImageByName(params *GetBaseImageByNameParams, authInfo r
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "getBaseImageByName",
 		Method:             "GET",
-		PathPattern:        "/base/{baseImageName}",
+		PathPattern:        "/baseimage/{baseImageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -130,7 +130,7 @@ func (a *Client) GetBaseImages(params *GetBaseImagesParams, authInfo runtime.Cli
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "getBaseImages",
 		Method:             "GET",
-		PathPattern:        "/base",
+		PathPattern:        "/baseimage",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -159,7 +159,7 @@ func (a *Client) UpdateBaseImageByName(params *UpdateBaseImageByNameParams, auth
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "updateBaseImageByName",
 		Method:             "PUT",
-		PathPattern:        "/base/{baseImageName}",
+		PathPattern:        "/baseimage/{baseImageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/pkg/image-manager/gen/client/base_image/delete_base_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/base_image/delete_base_image_by_name_responses.go
@@ -77,7 +77,7 @@ type DeleteBaseImageByNameOK struct {
 }
 
 func (o *DeleteBaseImageByNameOK) Error() string {
-	return fmt.Sprintf("[DELETE /base/{baseImageName}][%d] deleteBaseImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[DELETE /baseimage/{baseImageName}][%d] deleteBaseImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *DeleteBaseImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type DeleteBaseImageByNameBadRequest struct {
 }
 
 func (o *DeleteBaseImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /base/{baseImageName}][%d] deleteBaseImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[DELETE /baseimage/{baseImageName}][%d] deleteBaseImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *DeleteBaseImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type DeleteBaseImageByNameNotFound struct {
 }
 
 func (o *DeleteBaseImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /base/{baseImageName}][%d] deleteBaseImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /baseimage/{baseImageName}][%d] deleteBaseImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeleteBaseImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *DeleteBaseImageByNameDefault) Code() int {
 }
 
 func (o *DeleteBaseImageByNameDefault) Error() string {
-	return fmt.Sprintf("[DELETE /base/{baseImageName}][%d] deleteBaseImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[DELETE /baseimage/{baseImageName}][%d] deleteBaseImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *DeleteBaseImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/base_image/get_base_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/base_image/get_base_image_by_name_responses.go
@@ -77,7 +77,7 @@ type GetBaseImageByNameOK struct {
 }
 
 func (o *GetBaseImageByNameOK) Error() string {
-	return fmt.Sprintf("[GET /base/{baseImageName}][%d] getBaseImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /baseimage/{baseImageName}][%d] getBaseImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *GetBaseImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type GetBaseImageByNameBadRequest struct {
 }
 
 func (o *GetBaseImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[GET /base/{baseImageName}][%d] getBaseImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[GET /baseimage/{baseImageName}][%d] getBaseImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *GetBaseImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type GetBaseImageByNameNotFound struct {
 }
 
 func (o *GetBaseImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[GET /base/{baseImageName}][%d] getBaseImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /baseimage/{baseImageName}][%d] getBaseImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetBaseImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *GetBaseImageByNameDefault) Code() int {
 }
 
 func (o *GetBaseImageByNameDefault) Error() string {
-	return fmt.Sprintf("[GET /base/{baseImageName}][%d] getBaseImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /baseimage/{baseImageName}][%d] getBaseImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetBaseImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/base_image/get_base_images_responses.go
+++ b/pkg/image-manager/gen/client/base_image/get_base_images_responses.go
@@ -63,7 +63,7 @@ type GetBaseImagesOK struct {
 }
 
 func (o *GetBaseImagesOK) Error() string {
-	return fmt.Sprintf("[GET /base][%d] getBaseImagesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /baseimage][%d] getBaseImagesOK  %+v", 200, o.Payload)
 }
 
 func (o *GetBaseImagesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -99,7 +99,7 @@ func (o *GetBaseImagesDefault) Code() int {
 }
 
 func (o *GetBaseImagesDefault) Error() string {
-	return fmt.Sprintf("[GET /base][%d] getBaseImages default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /baseimage][%d] getBaseImages default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetBaseImagesDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/base_image/update_base_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/base_image/update_base_image_by_name_responses.go
@@ -77,7 +77,7 @@ type UpdateBaseImageByNameOK struct {
 }
 
 func (o *UpdateBaseImageByNameOK) Error() string {
-	return fmt.Sprintf("[PUT /base/{baseImageName}][%d] updateBaseImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /baseimage/{baseImageName}][%d] updateBaseImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *UpdateBaseImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateBaseImageByNameBadRequest struct {
 }
 
 func (o *UpdateBaseImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /base/{baseImageName}][%d] updateBaseImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /baseimage/{baseImageName}][%d] updateBaseImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateBaseImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type UpdateBaseImageByNameNotFound struct {
 }
 
 func (o *UpdateBaseImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[PUT /base/{baseImageName}][%d] updateBaseImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /baseimage/{baseImageName}][%d] updateBaseImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateBaseImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *UpdateBaseImageByNameDefault) Code() int {
 }
 
 func (o *UpdateBaseImageByNameDefault) Error() string {
-	return fmt.Sprintf("[PUT /base/{baseImageName}][%d] updateBaseImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[PUT /baseimage/{baseImageName}][%d] updateBaseImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *UpdateBaseImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image/add_image_responses.go
+++ b/pkg/image-manager/gen/client/image/add_image_responses.go
@@ -77,7 +77,7 @@ type AddImageCreated struct {
 }
 
 func (o *AddImageCreated) Error() string {
-	return fmt.Sprintf("[POST /][%d] addImageCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /image][%d] addImageCreated  %+v", 201, o.Payload)
 }
 
 func (o *AddImageCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type AddImageBadRequest struct {
 }
 
 func (o *AddImageBadRequest) Error() string {
-	return fmt.Sprintf("[POST /][%d] addImageBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /image][%d] addImageBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *AddImageBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type AddImageConflict struct {
 }
 
 func (o *AddImageConflict) Error() string {
-	return fmt.Sprintf("[POST /][%d] addImageConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /image][%d] addImageConflict  %+v", 409, o.Payload)
 }
 
 func (o *AddImageConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *AddImageDefault) Code() int {
 }
 
 func (o *AddImageDefault) Error() string {
-	return fmt.Sprintf("[POST /][%d] addImage default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[POST /image][%d] addImage default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *AddImageDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image/delete_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/image/delete_image_by_name_responses.go
@@ -77,7 +77,7 @@ type DeleteImageByNameOK struct {
 }
 
 func (o *DeleteImageByNameOK) Error() string {
-	return fmt.Sprintf("[DELETE /{imageName}][%d] deleteImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[DELETE /image/{imageName}][%d] deleteImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *DeleteImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type DeleteImageByNameBadRequest struct {
 }
 
 func (o *DeleteImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /{imageName}][%d] deleteImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[DELETE /image/{imageName}][%d] deleteImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *DeleteImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type DeleteImageByNameNotFound struct {
 }
 
 func (o *DeleteImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /{imageName}][%d] deleteImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /image/{imageName}][%d] deleteImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeleteImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *DeleteImageByNameDefault) Code() int {
 }
 
 func (o *DeleteImageByNameDefault) Error() string {
-	return fmt.Sprintf("[DELETE /{imageName}][%d] deleteImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[DELETE /image/{imageName}][%d] deleteImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *DeleteImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image/get_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/image/get_image_by_name_responses.go
@@ -77,7 +77,7 @@ type GetImageByNameOK struct {
 }
 
 func (o *GetImageByNameOK) Error() string {
-	return fmt.Sprintf("[GET /{imageName}][%d] getImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /image/{imageName}][%d] getImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *GetImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type GetImageByNameBadRequest struct {
 }
 
 func (o *GetImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[GET /{imageName}][%d] getImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[GET /image/{imageName}][%d] getImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *GetImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type GetImageByNameNotFound struct {
 }
 
 func (o *GetImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[GET /{imageName}][%d] getImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /image/{imageName}][%d] getImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *GetImageByNameDefault) Code() int {
 }
 
 func (o *GetImageByNameDefault) Error() string {
-	return fmt.Sprintf("[GET /{imageName}][%d] getImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /image/{imageName}][%d] getImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image/get_images_responses.go
+++ b/pkg/image-manager/gen/client/image/get_images_responses.go
@@ -70,7 +70,7 @@ type GetImagesOK struct {
 }
 
 func (o *GetImagesOK) Error() string {
-	return fmt.Sprintf("[GET /][%d] getImagesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /image][%d] getImagesOK  %+v", 200, o.Payload)
 }
 
 func (o *GetImagesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -97,7 +97,7 @@ type GetImagesBadRequest struct {
 }
 
 func (o *GetImagesBadRequest) Error() string {
-	return fmt.Sprintf("[GET /][%d] getImagesBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[GET /image][%d] getImagesBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *GetImagesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ func (o *GetImagesDefault) Code() int {
 }
 
 func (o *GetImagesDefault) Error() string {
-	return fmt.Sprintf("[GET /][%d] getImages default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /image][%d] getImages default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetImagesDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image/image_client.go
+++ b/pkg/image-manager/gen/client/image/image_client.go
@@ -41,7 +41,7 @@ func (a *Client) AddImage(params *AddImageParams, authInfo runtime.ClientAuthInf
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "addImage",
 		Method:             "POST",
-		PathPattern:        "/",
+		PathPattern:        "/image",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -70,7 +70,7 @@ func (a *Client) DeleteImageByName(params *DeleteImageByNameParams, authInfo run
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "deleteImageByName",
 		Method:             "DELETE",
-		PathPattern:        "/{imageName}",
+		PathPattern:        "/image/{imageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -101,7 +101,7 @@ func (a *Client) GetImageByName(params *GetImageByNameParams, authInfo runtime.C
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "getImageByName",
 		Method:             "GET",
-		PathPattern:        "/{imageName}",
+		PathPattern:        "/image/{imageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -132,7 +132,7 @@ func (a *Client) GetImages(params *GetImagesParams, authInfo runtime.ClientAuthI
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "getImages",
 		Method:             "GET",
-		PathPattern:        "/",
+		PathPattern:        "/image",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{""},
 		Schemes:            []string{"http", "https"},
@@ -161,7 +161,7 @@ func (a *Client) UpdateImageByName(params *UpdateImageByNameParams, authInfo run
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "updateImageByName",
 		Method:             "PUT",
-		PathPattern:        "/{imageName}",
+		PathPattern:        "/image/{imageName}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/pkg/image-manager/gen/client/image/update_image_by_name_responses.go
+++ b/pkg/image-manager/gen/client/image/update_image_by_name_responses.go
@@ -77,7 +77,7 @@ type UpdateImageByNameOK struct {
 }
 
 func (o *UpdateImageByNameOK) Error() string {
-	return fmt.Sprintf("[PUT /{imageName}][%d] updateImageByNameOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PUT /image/{imageName}][%d] updateImageByNameOK  %+v", 200, o.Payload)
 }
 
 func (o *UpdateImageByNameOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateImageByNameBadRequest struct {
 }
 
 func (o *UpdateImageByNameBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /{imageName}][%d] updateImageByNameBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /image/{imageName}][%d] updateImageByNameBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateImageByNameBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -135,7 +135,7 @@ type UpdateImageByNameNotFound struct {
 }
 
 func (o *UpdateImageByNameNotFound) Error() string {
-	return fmt.Sprintf("[PUT /{imageName}][%d] updateImageByNameNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /image/{imageName}][%d] updateImageByNameNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateImageByNameNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -173,7 +173,7 @@ func (o *UpdateImageByNameDefault) Code() int {
 }
 
 func (o *UpdateImageByNameDefault) Error() string {
-	return fmt.Sprintf("[PUT /{imageName}][%d] updateImageByName default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[PUT /image/{imageName}][%d] updateImageByName default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *UpdateImageByNameDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/image-manager/gen/client/image_manager_client.go
+++ b/pkg/image-manager/gen/client/image_manager_client.go
@@ -29,7 +29,7 @@ const (
 	DefaultHost string = "localhost"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
-	DefaultBasePath string = "/v1/image"
+	DefaultBasePath string = "/v1"
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file

--- a/pkg/image-manager/gen/restapi/doc.go
+++ b/pkg/image-manager/gen/restapi/doc.go
@@ -15,7 +15,7 @@ VMware Dispatch Image Manager
       http
       https
     Host: localhost
-    BasePath: /v1/image
+    BasePath: /v1
     Version: 1.0.0
     Contact: <dispatch@vmware.com>
 

--- a/pkg/image-manager/gen/restapi/embedded_spec.go
+++ b/pkg/image-manager/gen/restapi/embedded_spec.go
@@ -32,110 +32,9 @@ func init() {
     },
     "version": "1.0.0"
   },
-  "basePath": "/v1/image",
+  "basePath": "/v1",
   "paths": {
-    "/": {
-      "get": {
-        "description": "List all images",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "image"
-        ],
-        "summary": "Get all images",
-        "operationId": "getImages",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "image runtime language",
-            "name": "language",
-            "in": "query"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "collectionFormat": "multi",
-            "description": "Filter on image tags",
-            "name": "tags",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/getImagesOKBody"
-            }
-          },
-          "400": {
-            "description": "Invalid input",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "default": {
-            "description": "Generic error response",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "image"
-        ],
-        "summary": "Add a new image",
-        "operationId": "addImage",
-        "parameters": [
-          {
-            "description": "Image object",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Image"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "created",
-            "schema": {
-              "$ref": "#/definitions/Image"
-            }
-          },
-          "400": {
-            "description": "Invalid input",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "409": {
-            "description": "Already Exists",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "default": {
-            "description": "Generic error response",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/base": {
+    "/baseimage": {
       "get": {
         "produces": [
           "application/json"
@@ -229,7 +128,7 @@ func init() {
         }
       }
     },
-    "/base/{baseImageName}": {
+    "/baseimage/{baseImageName}": {
       "get": {
         "description": "Returns a single base image",
         "produces": [
@@ -372,7 +271,108 @@ func init() {
         }
       ]
     },
-    "/{imageName}": {
+    "/image": {
+      "get": {
+        "description": "List all images",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "image"
+        ],
+        "summary": "Get all images",
+        "operationId": "getImages",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "image runtime language",
+            "name": "language",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filter on image tags",
+            "name": "tags",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/getImagesOKBody"
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Generic error response",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "image"
+        ],
+        "summary": "Add a new image",
+        "operationId": "addImage",
+        "parameters": [
+          {
+            "description": "Image object",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Image"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "created",
+            "schema": {
+              "$ref": "#/definitions/Image"
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Generic error response",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/image/{imageName}": {
       "get": {
         "description": "Returns a single image",
         "produces": [

--- a/pkg/image-manager/gen/restapi/operations/base_image/add_base_image.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/add_base_image.go
@@ -34,7 +34,7 @@ func NewAddBaseImage(ctx *middleware.Context, handler AddBaseImageHandler) *AddB
 	return &AddBaseImage{Context: ctx, Handler: handler}
 }
 
-/*AddBaseImage swagger:route POST /base baseImage addBaseImage
+/*AddBaseImage swagger:route POST /baseimage baseImage addBaseImage
 
 Add a new base image
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/add_base_image_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/add_base_image_urlbuilder.go
@@ -40,11 +40,11 @@ func (o *AddBaseImageURL) SetBasePath(bp string) {
 func (o *AddBaseImageURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/base"
+	var _path = "/baseimage"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/delete_base_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/delete_base_image_by_name.go
@@ -34,7 +34,7 @@ func NewDeleteBaseImageByName(ctx *middleware.Context, handler DeleteBaseImageBy
 	return &DeleteBaseImageByName{Context: ctx, Handler: handler}
 }
 
-/*DeleteBaseImageByName swagger:route DELETE /base/{baseImageName} baseImage deleteBaseImageByName
+/*DeleteBaseImageByName swagger:route DELETE /baseimage/{baseImageName} baseImage deleteBaseImageByName
 
 Deletes a base image
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/delete_base_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/delete_base_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *DeleteBaseImageByNameURL) SetBasePath(bp string) {
 func (o *DeleteBaseImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/base/{baseImageName}"
+	var _path = "/baseimage/{baseImageName}"
 
 	baseImageName := o.BaseImageName
 	if baseImageName != "" {
@@ -59,7 +59,7 @@ func (o *DeleteBaseImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/get_base_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/get_base_image_by_name.go
@@ -34,7 +34,7 @@ func NewGetBaseImageByName(ctx *middleware.Context, handler GetBaseImageByNameHa
 	return &GetBaseImageByName{Context: ctx, Handler: handler}
 }
 
-/*GetBaseImageByName swagger:route GET /base/{baseImageName} baseImage getBaseImageByName
+/*GetBaseImageByName swagger:route GET /baseimage/{baseImageName} baseImage getBaseImageByName
 
 Find base image by Name
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/get_base_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/get_base_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *GetBaseImageByNameURL) SetBasePath(bp string) {
 func (o *GetBaseImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/base/{baseImageName}"
+	var _path = "/baseimage/{baseImageName}"
 
 	baseImageName := o.BaseImageName
 	if baseImageName != "" {
@@ -59,7 +59,7 @@ func (o *GetBaseImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/get_base_images.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/get_base_images.go
@@ -34,7 +34,7 @@ func NewGetBaseImages(ctx *middleware.Context, handler GetBaseImagesHandler) *Ge
 	return &GetBaseImages{Context: ctx, Handler: handler}
 }
 
-/*GetBaseImages swagger:route GET /base baseImage getBaseImages
+/*GetBaseImages swagger:route GET /baseimage baseImage getBaseImages
 
 List all existing base images
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/get_base_images_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/get_base_images_urlbuilder.go
@@ -47,11 +47,11 @@ func (o *GetBaseImagesURL) SetBasePath(bp string) {
 func (o *GetBaseImagesURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/base"
+	var _path = "/baseimage"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/update_base_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/update_base_image_by_name.go
@@ -34,7 +34,7 @@ func NewUpdateBaseImageByName(ctx *middleware.Context, handler UpdateBaseImageBy
 	return &UpdateBaseImageByName{Context: ctx, Handler: handler}
 }
 
-/*UpdateBaseImageByName swagger:route PUT /base/{baseImageName} baseImage updateBaseImageByName
+/*UpdateBaseImageByName swagger:route PUT /baseimage/{baseImageName} baseImage updateBaseImageByName
 
 Updates a base image
 

--- a/pkg/image-manager/gen/restapi/operations/base_image/update_base_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/update_base_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *UpdateBaseImageByNameURL) SetBasePath(bp string) {
 func (o *UpdateBaseImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/base/{baseImageName}"
+	var _path = "/baseimage/{baseImageName}"
 
 	baseImageName := o.BaseImageName
 	if baseImageName != "" {
@@ -59,7 +59,7 @@ func (o *UpdateBaseImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image/add_image.go
+++ b/pkg/image-manager/gen/restapi/operations/image/add_image.go
@@ -34,7 +34,7 @@ func NewAddImage(ctx *middleware.Context, handler AddImageHandler) *AddImage {
 	return &AddImage{Context: ctx, Handler: handler}
 }
 
-/*AddImage swagger:route POST / image addImage
+/*AddImage swagger:route POST /image image addImage
 
 Add a new image
 

--- a/pkg/image-manager/gen/restapi/operations/image/add_image_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/image/add_image_urlbuilder.go
@@ -40,11 +40,11 @@ func (o *AddImageURL) SetBasePath(bp string) {
 func (o *AddImageURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/"
+	var _path = "/image"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image/delete_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/image/delete_image_by_name.go
@@ -34,7 +34,7 @@ func NewDeleteImageByName(ctx *middleware.Context, handler DeleteImageByNameHand
 	return &DeleteImageByName{Context: ctx, Handler: handler}
 }
 
-/*DeleteImageByName swagger:route DELETE /{imageName} image deleteImageByName
+/*DeleteImageByName swagger:route DELETE /image/{imageName} image deleteImageByName
 
 Deletes an image
 

--- a/pkg/image-manager/gen/restapi/operations/image/delete_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/image/delete_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *DeleteImageByNameURL) SetBasePath(bp string) {
 func (o *DeleteImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/{imageName}"
+	var _path = "/image/{imageName}"
 
 	imageName := o.ImageName
 	if imageName != "" {
@@ -59,7 +59,7 @@ func (o *DeleteImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image/get_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/image/get_image_by_name.go
@@ -34,7 +34,7 @@ func NewGetImageByName(ctx *middleware.Context, handler GetImageByNameHandler) *
 	return &GetImageByName{Context: ctx, Handler: handler}
 }
 
-/*GetImageByName swagger:route GET /{imageName} image getImageByName
+/*GetImageByName swagger:route GET /image/{imageName} image getImageByName
 
 Find image by ID
 

--- a/pkg/image-manager/gen/restapi/operations/image/get_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/image/get_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *GetImageByNameURL) SetBasePath(bp string) {
 func (o *GetImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/{imageName}"
+	var _path = "/image/{imageName}"
 
 	imageName := o.ImageName
 	if imageName != "" {
@@ -59,7 +59,7 @@ func (o *GetImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image/get_images.go
+++ b/pkg/image-manager/gen/restapi/operations/image/get_images.go
@@ -34,7 +34,7 @@ func NewGetImages(ctx *middleware.Context, handler GetImagesHandler) *GetImages 
 	return &GetImages{Context: ctx, Handler: handler}
 }
 
-/*GetImages swagger:route GET / image getImages
+/*GetImages swagger:route GET /image image getImages
 
 Get all images
 

--- a/pkg/image-manager/gen/restapi/operations/image/get_images_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/image/get_images_urlbuilder.go
@@ -47,11 +47,11 @@ func (o *GetImagesURL) SetBasePath(bp string) {
 func (o *GetImagesURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/"
+	var _path = "/image"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image/update_image_by_name.go
+++ b/pkg/image-manager/gen/restapi/operations/image/update_image_by_name.go
@@ -34,7 +34,7 @@ func NewUpdateImageByName(ctx *middleware.Context, handler UpdateImageByNameHand
 	return &UpdateImageByName{Context: ctx, Handler: handler}
 }
 
-/*UpdateImageByName swagger:route PUT /{imageName} image updateImageByName
+/*UpdateImageByName swagger:route PUT /image/{imageName} image updateImageByName
 
 Updates an image
 

--- a/pkg/image-manager/gen/restapi/operations/image/update_image_by_name_urlbuilder.go
+++ b/pkg/image-manager/gen/restapi/operations/image/update_image_by_name_urlbuilder.go
@@ -49,7 +49,7 @@ func (o *UpdateImageByNameURL) SetBasePath(bp string) {
 func (o *UpdateImageByNameURL) Build() (*url.URL, error) {
 	var result url.URL
 
-	var _path = "/{imageName}"
+	var _path = "/image/{imageName}"
 
 	imageName := o.ImageName
 	if imageName != "" {
@@ -59,7 +59,7 @@ func (o *UpdateImageByNameURL) Build() (*url.URL, error) {
 	}
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/v1/image"
+		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/pkg/image-manager/gen/restapi/operations/image_manager_api.go
+++ b/pkg/image-manager/gen/restapi/operations/image_manager_api.go
@@ -348,52 +348,52 @@ func (o *ImageManagerAPI) initHandlerCache() {
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/base"] = base_image.NewAddBaseImage(o.context, o.BaseImageAddBaseImageHandler)
+	o.handlers["POST"]["/baseimage"] = base_image.NewAddBaseImage(o.context, o.BaseImageAddBaseImageHandler)
 
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"][""] = image.NewAddImage(o.context, o.ImageAddImageHandler)
+	o.handlers["POST"]["/image"] = image.NewAddImage(o.context, o.ImageAddImageHandler)
 
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/base/{baseImageName}"] = base_image.NewDeleteBaseImageByName(o.context, o.BaseImageDeleteBaseImageByNameHandler)
+	o.handlers["DELETE"]["/baseimage/{baseImageName}"] = base_image.NewDeleteBaseImageByName(o.context, o.BaseImageDeleteBaseImageByNameHandler)
 
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/{imageName}"] = image.NewDeleteImageByName(o.context, o.ImageDeleteImageByNameHandler)
+	o.handlers["DELETE"]["/image/{imageName}"] = image.NewDeleteImageByName(o.context, o.ImageDeleteImageByNameHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/base/{baseImageName}"] = base_image.NewGetBaseImageByName(o.context, o.BaseImageGetBaseImageByNameHandler)
+	o.handlers["GET"]["/baseimage/{baseImageName}"] = base_image.NewGetBaseImageByName(o.context, o.BaseImageGetBaseImageByNameHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/base"] = base_image.NewGetBaseImages(o.context, o.BaseImageGetBaseImagesHandler)
+	o.handlers["GET"]["/baseimage"] = base_image.NewGetBaseImages(o.context, o.BaseImageGetBaseImagesHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/{imageName}"] = image.NewGetImageByName(o.context, o.ImageGetImageByNameHandler)
+	o.handlers["GET"]["/image/{imageName}"] = image.NewGetImageByName(o.context, o.ImageGetImageByNameHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"][""] = image.NewGetImages(o.context, o.ImageGetImagesHandler)
+	o.handlers["GET"]["/image"] = image.NewGetImages(o.context, o.ImageGetImagesHandler)
 
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/base/{baseImageName}"] = base_image.NewUpdateBaseImageByName(o.context, o.BaseImageUpdateBaseImageByNameHandler)
+	o.handlers["PUT"]["/baseimage/{baseImageName}"] = base_image.NewUpdateBaseImageByName(o.context, o.BaseImageUpdateBaseImageByNameHandler)
 
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/{imageName}"] = image.NewUpdateImageByName(o.context, o.ImageUpdateImageByNameHandler)
+	o.handlers["PUT"]["/image/{imageName}"] = image.NewUpdateImageByName(o.context, o.ImageUpdateImageByNameHandler)
 
 }
 

--- a/pkg/image-manager/handlers_test.go
+++ b/pkg/image-manager/handlers_test.go
@@ -38,7 +38,7 @@ func addBaseImageEntity(t *testing.T, api *operations.ImageManagerAPI, h *Handle
 		Language:  models.Language(language),
 		Tags:      entityTags,
 	}
-	r := httptest.NewRequest("POST", "/v1/image/base", nil)
+	r := httptest.NewRequest("POST", "/v1/baseimage", nil)
 	params := baseimage.AddBaseImageParams{
 		HTTPRequest: r,
 		Body:        reqBody,
@@ -100,7 +100,7 @@ func TestBaseImageGetBaseImageByNameHandler(t *testing.T) {
 	assert.NotEmpty(t, addBody.ID)
 
 	createdTime := addBody.CreatedTime
-	r := httptest.NewRequest("GET", "/v1/image/base/testEntity", nil)
+	r := httptest.NewRequest("GET", "/v1/baseimage/testEntity", nil)
 	get := baseimage.GetBaseImageByNameParams{
 		HTTPRequest:   r,
 		BaseImageName: "testEntity",
@@ -118,7 +118,7 @@ func TestBaseImageGetBaseImageByNameHandler(t *testing.T) {
 	assert.Equal(t, "role", getBody.Tags[0].Key)
 	assert.Equal(t, "test", getBody.Tags[0].Value)
 
-	r = httptest.NewRequest("GET", "/v1/image/base/doesNotExist", nil)
+	r = httptest.NewRequest("GET", "/v1/baseimage/doesNotExist", nil)
 	get = baseimage.GetBaseImageByNameParams{
 		HTTPRequest:   r,
 		BaseImageName: "doesNotExist",
@@ -140,7 +140,7 @@ func TestBaseImageGetBaseImagesHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testEntity2", "test/base", "python3", true, map[string]string{"role": "test", "item": "2"})
 	addBaseImageEntity(t, api, h, "testEntity3", "test/base", "python3", true, map[string]string{"role": "test", "item": "3"})
 
-	r := httptest.NewRequest("GET", "/v1/image/base", nil)
+	r := httptest.NewRequest("GET", "/v1/baseimage", nil)
 	get := baseimage.GetBaseImagesParams{
 		HTTPRequest: r,
 	}
@@ -159,7 +159,7 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 
 	addBaseImageEntity(t, api, h, "testEntity", "test/base", "python3", true, map[string]string{"role": "test"})
 
-	r := httptest.NewRequest("GET", "/v1/image/base", nil)
+	r := httptest.NewRequest("GET", "/v1/baseimage", nil)
 	get := baseimage.GetBaseImagesParams{
 		HTTPRequest: r,
 	}
@@ -168,7 +168,7 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 	helpers.HandlerRequest(t, getResponder, &getBody, 200)
 	assert.Len(t, getBody, 1)
 
-	r = httptest.NewRequest("DELETE", "/v1/image/base/testEntity", nil)
+	r = httptest.NewRequest("DELETE", "/v1/baseimage/testEntity", nil)
 	del := baseimage.DeleteBaseImageByNameParams{
 		HTTPRequest:   r,
 		BaseImageName: "testEntity",

--- a/swagger/image-manager.yaml
+++ b/swagger/image-manager.yaml
@@ -18,9 +18,9 @@ tags:
 schemes:
 - http
 - https
-basePath: /v1/image
+basePath: /v1
 paths:
-  /base:
+  /baseimage:
     post:
       tags:
       - baseImage
@@ -84,7 +84,7 @@ paths:
           description: Generic error response
           schema:
             $ref: '#/definitions/Error'
-  /base/{baseImageName}:
+  /baseimage/{baseImageName}:
     parameters:
     - in: path
       name: baseImageName
@@ -179,7 +179,7 @@ paths:
           description: Generic error response
           schema:
             $ref: '#/definitions/Error'
-  /:
+  /image:
     get:
       tags:
       - image
@@ -248,7 +248,7 @@ paths:
           description: Generic error response
           schema:
             $ref: '#/definitions/Error'
-  /{imageName}:
+  /image/{imageName}:
     parameters:
     - in: path
       name: imageName


### PR DESCRIPTION
To be consistent with other resources' URI's, let's move the base-image URI from /v1/image/base to v1/baseimage. 

* Swagger changes
* Chart changes to specify multiple API paths in a single ingress

Fixes #271

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/275)
<!-- Reviewable:end -->
