### PR TITLE
Return 409 Conflict on non-unique names

### DIFF
--- a/pkg/api-manager/gen/client/endpoint/add_api_responses.go
+++ b/pkg/api-manager/gen/client/endpoint/add_api_responses.go
@@ -51,6 +51,13 @@ func (o *AddAPIReader) ReadResponse(response runtime.ClientResponse, consumer ru
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddAPIConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddAPIInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -139,6 +146,35 @@ func (o *AddAPIUnauthorized) Error() string {
 }
 
 func (o *AddAPIUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddAPIConflict creates a AddAPIConflict with default headers values
+func NewAddAPIConflict() *AddAPIConflict {
+	return &AddAPIConflict{}
+}
+
+/*AddAPIConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddAPIConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddAPIConflict) Error() string {
+	return fmt.Sprintf("[POST /][%d] addApiConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddAPIConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/api-manager/gen/restapi/embedded_spec.go
+++ b/pkg/api-manager/gen/restapi/embedded_spec.go
@@ -125,6 +125,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "500": {
             "description": "Internal Error",
             "schema": {

--- a/pkg/api-manager/gen/restapi/operations/endpoint/add_api_responses.go
+++ b/pkg/api-manager/gen/restapi/operations/endpoint/add_api_responses.go
@@ -147,6 +147,49 @@ func (o *AddAPIUnauthorized) WriteResponse(rw http.ResponseWriter, producer runt
 	}
 }
 
+// AddAPIConflictCode is the HTTP code returned for type AddAPIConflict
+const AddAPIConflictCode int = 409
+
+/*AddAPIConflict Already Exists
+
+swagger:response addApiConflict
+*/
+type AddAPIConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddAPIConflict creates AddAPIConflict with default headers values
+func NewAddAPIConflict() *AddAPIConflict {
+	return &AddAPIConflict{}
+}
+
+// WithPayload adds the payload to the add Api conflict response
+func (o *AddAPIConflict) WithPayload(payload *models.Error) *AddAPIConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add Api conflict response
+func (o *AddAPIConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddAPIConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddAPIInternalServerErrorCode is the HTTP code returned for type AddAPIInternalServerError
 const AddAPIInternalServerErrorCode int = 500
 

--- a/pkg/api-manager/handlers.go
+++ b/pkg/api-manager/handlers.go
@@ -133,6 +133,12 @@ func (h *Handlers) addAPI(params endpoint.AddAPIParams, principal interface{}) m
 
 	e.Status = entitystore.StatusCREATING
 	if _, err := h.Store.Add(e); err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return endpoint.NewAddAPIConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating API: non-unique name"),
+			})
+		}
 		log.Errorf("store error when adding a new api %s: %+v", e.Name, err)
 		return endpoint.NewAddAPIInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,

--- a/pkg/application-manager/gen/client/application/add_app_responses.go
+++ b/pkg/application-manager/gen/client/application/add_app_responses.go
@@ -51,6 +51,13 @@ func (o *AddAppReader) ReadResponse(response runtime.ClientResponse, consumer ru
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddAppConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddAppInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -139,6 +146,35 @@ func (o *AddAppUnauthorized) Error() string {
 }
 
 func (o *AddAppUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddAppConflict creates a AddAppConflict with default headers values
+func NewAddAppConflict() *AddAppConflict {
+	return &AddAppConflict{}
+}
+
+/*AddAppConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddAppConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddAppConflict) Error() string {
+	return fmt.Sprintf("[POST /][%d] addAppConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddAppConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/application-manager/gen/restapi/embedded_spec.go
+++ b/pkg/application-manager/gen/restapi/embedded_spec.go
@@ -119,6 +119,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "500": {
             "description": "Internal Error",
             "schema": {

--- a/pkg/application-manager/gen/restapi/operations/application/add_app_responses.go
+++ b/pkg/application-manager/gen/restapi/operations/application/add_app_responses.go
@@ -147,6 +147,49 @@ func (o *AddAppUnauthorized) WriteResponse(rw http.ResponseWriter, producer runt
 	}
 }
 
+// AddAppConflictCode is the HTTP code returned for type AddAppConflict
+const AddAppConflictCode int = 409
+
+/*AddAppConflict Already Exists
+
+swagger:response addAppConflict
+*/
+type AddAppConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddAppConflict creates AddAppConflict with default headers values
+func NewAddAppConflict() *AddAppConflict {
+	return &AddAppConflict{}
+}
+
+// WithPayload adds the payload to the add app conflict response
+func (o *AddAppConflict) WithPayload(payload *models.Error) *AddAppConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add app conflict response
+func (o *AddAppConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddAppConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddAppInternalServerErrorCode is the HTTP code returned for type AddAppInternalServerError
 const AddAppInternalServerErrorCode int = 500
 

--- a/pkg/application-manager/handlers.go
+++ b/pkg/application-manager/handlers.go
@@ -112,6 +112,12 @@ func (h *Handlers) addApp(params application.AddAppParams, principal interface{}
 
 	e.Status = entitystore.StatusREADY
 	if _, err := h.store.Add(e); err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return application.NewAddAppConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating application: non-unique name"),
+			})
+		}
 		log.Errorf("store error when adding a new application %s: %+v", e.Name, err)
 		return application.NewAddAppInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,

--- a/pkg/dispatchcli/cmd/errors.go
+++ b/pkg/dispatchcli/cmd/errors.go
@@ -35,6 +35,8 @@ func formatAPIError(err error, params interface{}) error {
 	// Add
 	case *baseimage.AddBaseImageBadRequest:
 		return i18n.Errorf("[Code: %d] Bad request: %s", v.Payload.Code, msg(v.Payload.Message))
+	case *baseimage.AddBaseImageConflict:
+		return i18n.Errorf("[Code: %d] Conflict: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *baseimage.AddBaseImageDefault:
 		return i18n.Errorf("[Code: %d] Error: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *baseimage.UpdateBaseImageByNameNotFound:
@@ -65,6 +67,8 @@ func formatAPIError(err error, params interface{}) error {
 	// Add
 	case *image.AddImageBadRequest:
 		return i18n.Errorf("[Code: %d] Bad request: %s", v.Payload.Code, msg(v.Payload.Message))
+	case *image.AddImageConflict:
+		return i18n.Errorf("[Code: %d] Conflict: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *image.AddImageDefault:
 		return i18n.Errorf("[Code: %d] Error: %s", v.Payload.Code, msg(v.Payload.Message))
 	// Delete
@@ -144,6 +148,8 @@ func formatAPIError(err error, params interface{}) error {
 	case *secret.UpdateSecretNotFound:
 		return i18n.Errorf("[Code: %d] update Secret error: %s", 404, "Secret not found")
 	// Create
+	case *secret.AddSecretConflict:
+		return i18n.Errorf("[Code: %d] Conflict: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *secret.AddSecretDefault:
 		return i18n.Errorf("[Code: %d] create Secret error: %s", v.Payload.Code, msg(v.Payload.Message))
 
@@ -154,6 +160,8 @@ func formatAPIError(err error, params interface{}) error {
 	// Get
 	case *endpoint.GetAPIBadRequest:
 		return i18n.Errorf("[Code: %d] get api error: %s", v.Payload.Code, msg(v.Payload.Message))
+	case *endpoint.AddAPIConflict:
+		return i18n.Errorf("[Code: %d] Conflict: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *endpoint.GetAPINotFound:
 		return i18n.Errorf("[Code: %d] get api error: %s", v.Payload.Code, msg(v.Payload.Message))
 	case *endpoint.GetAPIInternalServerError:

--- a/pkg/event-manager/drivers/http_handlers.go
+++ b/pkg/event-manager/drivers/http_handlers.go
@@ -123,6 +123,12 @@ func (h *Handlers) addDriver(params driverapi.AddDriverParams, principal interfa
 
 	d.Status = entitystore.StatusCREATING
 	if _, err := h.store.Add(d); err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return driverapi.NewAddDriverConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating driver: non-unique name"),
+			})
+		}
 		log.Errorf("store error when adding a new driver %s: %+v", d.Name, err)
 		return driverapi.NewAddDriverInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,
@@ -290,6 +296,12 @@ func (h *Handlers) addDriverType(params driverapi.AddDriverTypeParams, principal
 	dt.FromModel(params.Body, h.config.OrgID)
 	dt.Status = entitystore.StatusREADY
 	if _, err := h.store.Add(dt); err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return driverapi.NewAddDriverTypeConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating driver type: non-unique name"),
+			})
+		}
 		log.Errorf("store error when adding a new driver type %s: %+v", dt.Name, err)
 		return driverapi.NewAddDriverTypeInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,

--- a/pkg/event-manager/gen/client/drivers/add_driver_responses.go
+++ b/pkg/event-manager/gen/client/drivers/add_driver_responses.go
@@ -51,6 +51,13 @@ func (o *AddDriverReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddDriverConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddDriverInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -146,6 +153,35 @@ func (o *AddDriverUnauthorized) Error() string {
 }
 
 func (o *AddDriverUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddDriverConflict creates a AddDriverConflict with default headers values
+func NewAddDriverConflict() *AddDriverConflict {
+	return &AddDriverConflict{}
+}
+
+/*AddDriverConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddDriverConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddDriverConflict) Error() string {
+	return fmt.Sprintf("[POST /drivers][%d] addDriverConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddDriverConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/event-manager/gen/client/drivers/add_driver_type_responses.go
+++ b/pkg/event-manager/gen/client/drivers/add_driver_type_responses.go
@@ -51,6 +51,13 @@ func (o *AddDriverTypeReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddDriverTypeConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddDriverTypeInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -146,6 +153,35 @@ func (o *AddDriverTypeUnauthorized) Error() string {
 }
 
 func (o *AddDriverTypeUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddDriverTypeConflict creates a AddDriverTypeConflict with default headers values
+func NewAddDriverTypeConflict() *AddDriverTypeConflict {
+	return &AddDriverTypeConflict{}
+}
+
+/*AddDriverTypeConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddDriverTypeConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddDriverTypeConflict) Error() string {
+	return fmt.Sprintf("[POST /drivertypes][%d] addDriverTypeConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddDriverTypeConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/event-manager/gen/client/subscriptions/add_subscription_responses.go
+++ b/pkg/event-manager/gen/client/subscriptions/add_subscription_responses.go
@@ -51,6 +51,13 @@ func (o *AddSubscriptionReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddSubscriptionConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	case 500:
 		result := NewAddSubscriptionInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -146,6 +153,35 @@ func (o *AddSubscriptionUnauthorized) Error() string {
 }
 
 func (o *AddSubscriptionUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddSubscriptionConflict creates a AddSubscriptionConflict with default headers values
+func NewAddSubscriptionConflict() *AddSubscriptionConflict {
+	return &AddSubscriptionConflict{}
+}
+
+/*AddSubscriptionConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddSubscriptionConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddSubscriptionConflict) Error() string {
+	return fmt.Sprintf("[POST /subscriptions][%d] addSubscriptionConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddSubscriptionConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/event-manager/gen/restapi/embedded_spec.go
+++ b/pkg/event-manager/gen/restapi/embedded_spec.go
@@ -177,6 +177,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "500": {
             "description": "Internal server error",
             "schema": {
@@ -380,6 +386,12 @@ func init() {
           },
           "401": {
             "description": "Unauthorized Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Already Exists",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -593,6 +605,12 @@ func init() {
           },
           "401": {
             "description": "Unauthorized Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Already Exists",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/pkg/event-manager/gen/restapi/operations/drivers/add_driver_responses.go
+++ b/pkg/event-manager/gen/restapi/operations/drivers/add_driver_responses.go
@@ -147,6 +147,49 @@ func (o *AddDriverUnauthorized) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
+// AddDriverConflictCode is the HTTP code returned for type AddDriverConflict
+const AddDriverConflictCode int = 409
+
+/*AddDriverConflict Already Exists
+
+swagger:response addDriverConflict
+*/
+type AddDriverConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddDriverConflict creates AddDriverConflict with default headers values
+func NewAddDriverConflict() *AddDriverConflict {
+	return &AddDriverConflict{}
+}
+
+// WithPayload adds the payload to the add driver conflict response
+func (o *AddDriverConflict) WithPayload(payload *models.Error) *AddDriverConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add driver conflict response
+func (o *AddDriverConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddDriverConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddDriverInternalServerErrorCode is the HTTP code returned for type AddDriverInternalServerError
 const AddDriverInternalServerErrorCode int = 500
 

--- a/pkg/event-manager/gen/restapi/operations/drivers/add_driver_type_responses.go
+++ b/pkg/event-manager/gen/restapi/operations/drivers/add_driver_type_responses.go
@@ -147,6 +147,49 @@ func (o *AddDriverTypeUnauthorized) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
+// AddDriverTypeConflictCode is the HTTP code returned for type AddDriverTypeConflict
+const AddDriverTypeConflictCode int = 409
+
+/*AddDriverTypeConflict Already Exists
+
+swagger:response addDriverTypeConflict
+*/
+type AddDriverTypeConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddDriverTypeConflict creates AddDriverTypeConflict with default headers values
+func NewAddDriverTypeConflict() *AddDriverTypeConflict {
+	return &AddDriverTypeConflict{}
+}
+
+// WithPayload adds the payload to the add driver type conflict response
+func (o *AddDriverTypeConflict) WithPayload(payload *models.Error) *AddDriverTypeConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add driver type conflict response
+func (o *AddDriverTypeConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddDriverTypeConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddDriverTypeInternalServerErrorCode is the HTTP code returned for type AddDriverTypeInternalServerError
 const AddDriverTypeInternalServerErrorCode int = 500
 

--- a/pkg/event-manager/gen/restapi/operations/subscriptions/add_subscription_responses.go
+++ b/pkg/event-manager/gen/restapi/operations/subscriptions/add_subscription_responses.go
@@ -147,6 +147,49 @@ func (o *AddSubscriptionUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 	}
 }
 
+// AddSubscriptionConflictCode is the HTTP code returned for type AddSubscriptionConflict
+const AddSubscriptionConflictCode int = 409
+
+/*AddSubscriptionConflict Already Exists
+
+swagger:response addSubscriptionConflict
+*/
+type AddSubscriptionConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddSubscriptionConflict creates AddSubscriptionConflict with default headers values
+func NewAddSubscriptionConflict() *AddSubscriptionConflict {
+	return &AddSubscriptionConflict{}
+}
+
+// WithPayload adds the payload to the add subscription conflict response
+func (o *AddSubscriptionConflict) WithPayload(payload *models.Error) *AddSubscriptionConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add subscription conflict response
+func (o *AddSubscriptionConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddSubscriptionConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AddSubscriptionInternalServerErrorCode is the HTTP code returned for type AddSubscriptionInternalServerError
 const AddSubscriptionInternalServerErrorCode int = 500
 

--- a/pkg/image-manager/gen/client/base_image/add_base_image_responses.go
+++ b/pkg/image-manager/gen/client/base_image/add_base_image_responses.go
@@ -44,6 +44,13 @@ func (o *AddBaseImageReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddBaseImageConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	default:
 		result := NewAddBaseImageDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -103,6 +110,35 @@ func (o *AddBaseImageBadRequest) Error() string {
 }
 
 func (o *AddBaseImageBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddBaseImageConflict creates a AddBaseImageConflict with default headers values
+func NewAddBaseImageConflict() *AddBaseImageConflict {
+	return &AddBaseImageConflict{}
+}
+
+/*AddBaseImageConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddBaseImageConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddBaseImageConflict) Error() string {
+	return fmt.Sprintf("[POST /base][%d] addBaseImageConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddBaseImageConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/image-manager/gen/client/image/add_image_responses.go
+++ b/pkg/image-manager/gen/client/image/add_image_responses.go
@@ -44,6 +44,13 @@ func (o *AddImageReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddImageConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	default:
 		result := NewAddImageDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -103,6 +110,35 @@ func (o *AddImageBadRequest) Error() string {
 }
 
 func (o *AddImageBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddImageConflict creates a AddImageConflict with default headers values
+func NewAddImageConflict() *AddImageConflict {
+	return &AddImageConflict{}
+}
+
+/*AddImageConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddImageConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddImageConflict) Error() string {
+	return fmt.Sprintf("[POST /][%d] addImageConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddImageConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/image-manager/gen/restapi/embedded_spec.go
+++ b/pkg/image-manager/gen/restapi/embedded_spec.go
@@ -120,6 +120,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "default": {
             "description": "Generic error response",
             "schema": {
@@ -204,6 +210,12 @@ func init() {
           },
           "400": {
             "description": "Invalid input",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Already Exists",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/pkg/image-manager/gen/restapi/operations/base_image/add_base_image_responses.go
+++ b/pkg/image-manager/gen/restapi/operations/base_image/add_base_image_responses.go
@@ -104,6 +104,49 @@ func (o *AddBaseImageBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 	}
 }
 
+// AddBaseImageConflictCode is the HTTP code returned for type AddBaseImageConflict
+const AddBaseImageConflictCode int = 409
+
+/*AddBaseImageConflict Already Exists
+
+swagger:response addBaseImageConflict
+*/
+type AddBaseImageConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddBaseImageConflict creates AddBaseImageConflict with default headers values
+func NewAddBaseImageConflict() *AddBaseImageConflict {
+	return &AddBaseImageConflict{}
+}
+
+// WithPayload adds the payload to the add base image conflict response
+func (o *AddBaseImageConflict) WithPayload(payload *models.Error) *AddBaseImageConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add base image conflict response
+func (o *AddBaseImageConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddBaseImageConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 /*AddBaseImageDefault Generic error response
 
 swagger:response addBaseImageDefault

--- a/pkg/image-manager/gen/restapi/operations/image/add_image_responses.go
+++ b/pkg/image-manager/gen/restapi/operations/image/add_image_responses.go
@@ -104,6 +104,49 @@ func (o *AddImageBadRequest) WriteResponse(rw http.ResponseWriter, producer runt
 	}
 }
 
+// AddImageConflictCode is the HTTP code returned for type AddImageConflict
+const AddImageConflictCode int = 409
+
+/*AddImageConflict Already Exists
+
+swagger:response addImageConflict
+*/
+type AddImageConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddImageConflict creates AddImageConflict with default headers values
+func NewAddImageConflict() *AddImageConflict {
+	return &AddImageConflict{}
+}
+
+// WithPayload adds the payload to the add image conflict response
+func (o *AddImageConflict) WithPayload(payload *models.Error) *AddImageConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add image conflict response
+func (o *AddImageConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddImageConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 /*AddImageDefault Generic error response
 
 swagger:response addImageDefault

--- a/pkg/image-manager/handlers.go
+++ b/pkg/image-manager/handlers.go
@@ -217,6 +217,12 @@ func (h *Handlers) addBaseImage(params baseimage.AddBaseImageParams, principal i
 	e.Status = StatusINITIALIZED
 	_, err := h.Store.Add(e)
 	if err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return baseimage.NewAddBaseImageConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating base image: non-unique name"),
+			})
+		}
 		log.Debugf("store error when adding base image: %+v", err)
 		return baseimage.NewAddBaseImageBadRequest().WithPayload(
 			&models.Error{
@@ -347,6 +353,12 @@ func (h *Handlers) addImage(params image.AddImageParams, principal interface{}) 
 
 	_, err = h.Store.Add(e)
 	if err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return image.NewAddImageConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating image: non-unique name"),
+			})
+		}
 		log.Debugf("store error when adding image: %+v", err)
 		return image.NewAddImageBadRequest().WithPayload(
 			&models.Error{

--- a/pkg/secret-store/gen/client/secret/add_secret_responses.go
+++ b/pkg/secret-store/gen/client/secret/add_secret_responses.go
@@ -44,6 +44,13 @@ func (o *AddSecretReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 
+	case 409:
+		result := NewAddSecretConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	default:
 		result := NewAddSecretDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -103,6 +110,35 @@ func (o *AddSecretBadRequest) Error() string {
 }
 
 func (o *AddSecretBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAddSecretConflict creates a AddSecretConflict with default headers values
+func NewAddSecretConflict() *AddSecretConflict {
+	return &AddSecretConflict{}
+}
+
+/*AddSecretConflict handles this case with default header values.
+
+Already Exists
+*/
+type AddSecretConflict struct {
+	Payload *models.Error
+}
+
+func (o *AddSecretConflict) Error() string {
+	return fmt.Sprintf("[POST /][%d] addSecretConflict  %+v", 409, o.Payload)
+}
+
+func (o *AddSecretConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/pkg/secret-store/gen/restapi/embedded_spec.go
+++ b/pkg/secret-store/gen/restapi/embedded_spec.go
@@ -105,6 +105,12 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           },
+          "409": {
+            "description": "Already Exists",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "default": {
             "description": "Standard error",
             "schema": {

--- a/pkg/secret-store/gen/restapi/operations/secret/add_secret_responses.go
+++ b/pkg/secret-store/gen/restapi/operations/secret/add_secret_responses.go
@@ -104,6 +104,49 @@ func (o *AddSecretBadRequest) WriteResponse(rw http.ResponseWriter, producer run
 	}
 }
 
+// AddSecretConflictCode is the HTTP code returned for type AddSecretConflict
+const AddSecretConflictCode int = 409
+
+/*AddSecretConflict Already Exists
+
+swagger:response addSecretConflict
+*/
+type AddSecretConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewAddSecretConflict creates AddSecretConflict with default headers values
+func NewAddSecretConflict() *AddSecretConflict {
+	return &AddSecretConflict{}
+}
+
+// WithPayload adds the payload to the add secret conflict response
+func (o *AddSecretConflict) WithPayload(payload *models.Error) *AddSecretConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the add secret conflict response
+func (o *AddSecretConflict) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AddSecretConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 /*AddSecretDefault Standard error
 
 swagger:response addSecretDefault

--- a/pkg/secret-store/web/handlers.go
+++ b/pkg/secret-store/web/handlers.go
@@ -104,6 +104,12 @@ func (h *Handlers) addSecret(params secret.AddSecretParams, principal interface{
 
 	vmwSecret, err := h.secretsService.AddSecret(*params.Secret)
 	if err != nil {
+		if entitystore.IsUniqueViolation(err) {
+			return secret.NewAddSecretConflict().WithPayload(&models.Error{
+				Code:    http.StatusConflict,
+				Message: swag.String("error creating secret: non-unique name"),
+			})
+		}
 		log.Errorf("error when creating the secret with k8s APIs: %+v", err)
 		return secret.NewAddSecretDefault(http.StatusInternalServerError).WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,

--- a/swagger/api-manager.yaml
+++ b/swagger/api-manager.yaml
@@ -44,6 +44,10 @@ paths:
           description: Unauthorized Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal Error
           schema:

--- a/swagger/application-manager.yaml
+++ b/swagger/application-manager.yaml
@@ -44,6 +44,10 @@ paths:
           description: Unauthorized Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal Error
           schema:

--- a/swagger/event-manager.yaml
+++ b/swagger/event-manager.yaml
@@ -94,6 +94,10 @@ paths:
           description: Unauthorized Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal server error
           schema:
@@ -238,6 +242,10 @@ paths:
           description: Unauthorized Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal server error
           schema:
@@ -376,6 +384,10 @@ paths:
             $ref: '#/definitions/Error'
         401:
           description: Unauthorized Request
+          schema:
+            $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
           schema:
             $ref: '#/definitions/Error'
         500:

--- a/swagger/image-manager.yaml
+++ b/swagger/image-manager.yaml
@@ -46,6 +46,10 @@ paths:
           description: Invalid input
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         default:
           description: Generic error response
           schema:
@@ -234,6 +238,10 @@ paths:
             $ref: '#/definitions/Image'
         400:
           description: Invalid input
+          schema:
+            $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
           schema:
             $ref: '#/definitions/Error'
         default:

--- a/swagger/secret-store.yaml
+++ b/swagger/secret-store.yaml
@@ -63,6 +63,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Already Exists
+          schema:
+            $ref: '#/definitions/Error'
         default:
           description: Standard error
           schema:


### PR DESCRIPTION
Modify APIs to return 409 Conflict on non-unique names where
appropriate.