### PR TITLE
Increase backoff timeout in test

### DIFF
--- a/pkg/utils/backoff_test.go
+++ b/pkg/utils/backoff_test.go
@@ -21,7 +21,7 @@ func init() {
 func TestBackoff(t *testing.T) {
 	n := 95
 
-	assert.NoError(t, Backoff(5*time.Second, func() error {
+	assert.NoError(t, Backoff(8*time.Second, func() error {
 		n = n / 2
 		r := n % 2
 		if r == 0 {


### PR DESCRIPTION
In some cases, the total backoff time could exceed 5s. The max could be 7500ms. Hence, keeping it at 8s. This test was failing intermittently. 

e.g. of some failures
https://ci.dispatchframework.io/teams/main/pipelines/dispatch-pr/jobs/dispatch-units/builds/415
https://ci.dispatchframework.io/teams/main/pipelines/dispatch-pr/jobs/dispatch-units/builds/409

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/283)
<!-- Reviewable:end -->
