### PR TITLE
Support single ns mode and better service selection during install

### DIFF
--- a/ci/e2e/collect-logs.yml
+++ b/ci/e2e/collect-logs.yml
@@ -73,6 +73,21 @@ run:
 
     tar -czf dispatch-logs/${BUNDLE_ID}.tar.gz *.log
 
-    echo -e "\n\n"
+    echo
+    echo
     echo "Job failed. Download logs from dispatch-logs/${BUNDLE_ID}.tar.gz on S3"
-    echo -e "\n\n"
+    echo
+    echo
+
+    cp dispatch-cli/dispatch /usr/local/bin/dispatch
+    mkdir -p ~/.dispatch
+
+    set +x
+    if [[ -n ${GKE_PROJECT_ID} ]]; then
+        cp dispatch/ci/e2e/configs/dispatch-install-gke.yml install.yaml
+    else
+        cp dispatch/ci/e2e/configs/dispatch-install-local.yml install.yaml
+    fi
+    set -x
+    dispatch uninstall --file install.yaml
+    exit $?

--- a/ci/e2e/run-tests.yml
+++ b/ci/e2e/run-tests.yml
@@ -57,5 +57,25 @@ run:
       sed -i "s/INGRESS_PORT/$INGRESS_PORT/g" ~/.dispatch/config.json
     fi
     export BATS_LOG="$(pwd)/tests-logs/bats.log"
-    cd dispatch
+    pushd dispatch
+    set +e
     ./e2e/scripts/run-e2e.sh e2e/tests
+    test_result=$?
+    popd
+    set -e
+    if [ "$test_result" -eq 0 ]
+    then
+        set +x
+        if [[ -n ${GKE_PROJECT_ID} ]]; then
+            cp dispatch/ci/e2e/configs/dispatch-install-gke.yml install.yaml
+        else
+            cp dispatch/ci/e2e/configs/dispatch-install-local.yml install.yaml
+        fi
+        set -x
+        dispatch uninstall --file install.yaml
+        exit $?
+    else
+        # collect logs must uninstall
+        exit 1
+    fi
+


### PR DESCRIPTION
**Changes:**
* Add `--single-namespace` flag to `dispatch install` to support single namespace installation
* `--service` install flag reworked. Maintains backward compatibility. You can specify `no-` prefix for any service to disable its installation, e.g. `dispatch install --service no-ingress` will install everything except ingress.
* explicit namespace existence check to avoid corner cases where `create namespace` returns "Forbidden" instead of "AlreadyExists" even if a namespace already exists (due to RBAC settings).
* Added docker registry to uninstall, also added `--keep-namespaces` flag to avoid errors in environments with precreated namespaces
* Added support for domain names longer than 64 characters (previously there was an issue with certificate)
* Fixed some linting errors