### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# To be bumped by every release
+VERSION_MAJOR ?= 0
+VERSION_MINOR ?= 1
+VERSION_BUILD ?= 7
+
+VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+
 GO ?= go
 GOVERSION ?= go1.9
 OS := $(shell uname)
@@ -10,6 +17,13 @@ GOPATH := $(firstword $(subst :, ,$(GOPATH)))
 SWAGGER := $(GOPATH)/bin/swagger
 GOBINDATA := $(GOPATH)/bin/go-bindata
 BUILD := $(shell date +%s)
+VERSION_PACKAGE := github.com/vmware/dispatch/pkg/version
+
+GO_LDFLAGS :="
+GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
+GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
+GO_LDFLAGS += -X $(VERSION_PACKAGE).commit=$(shell git rev-parse HEAD)
+GO_LDFLAGS +="
 
 PKGS := pkg
 
@@ -85,16 +99,16 @@ linux: $(LINUX_BINS)
 darwin: $(DARWIN_BINS)
 
 $(LINUX_BINS):
-	GOOS=linux go build -o bin/$@ ./cmd/$(subst -linux,,$@)
+	GOOS=linux go build -ldflags $(GO_LDFLAGS) -o bin/$@ ./cmd/$(subst -linux,,$@)
 
 $(DARWIN_BINS):
-	GOOS=darwin go build -o bin/$@ ./cmd/$(subst -darwin,,$@)
+	GOOS=darwin go build -ldflags $(GO_LDFLAGS) -o bin/$@ ./cmd/$(subst -darwin,,$@)
 
 cli-darwin:
-	GOOS=darwin go build -o bin/$(CLI)-darwin ./cmd/$(CLI)
+	GOOS=darwin go build -ldflags $(GO_LDFLAGS) -o bin/$(CLI)-darwin ./cmd/$(CLI)
 
 cli-linux:
-	GOOS=linux go build -o bin/$(CLI)-linux ./cmd/$(CLI)
+	GOOS=linux go build -ldflags $(GO_LDFLAGS) -o bin/$(CLI)-linux ./cmd/$(CLI)
 
 .PHONY: images
 images: linux ci-images

--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -103,6 +103,7 @@ func NewCLI(in io.Reader, out, errOut io.Writer) *cobra.Command {
 	cmds.AddCommand(NewCmdEmit(out, errOut))
 	cmds.AddCommand(NewCmdInstall(out, errOut))
 	cmds.AddCommand(NewCmdUninstall(out, errOut))
+	cmds.AddCommand(NewCmdVersion(out))
 	return cmds
 }
 

--- a/pkg/dispatchcli/cmd/version.go
+++ b/pkg/dispatchcli/cmd/version.go
@@ -1,0 +1,29 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
+	"github.com/vmware/dispatch/pkg/version"
+)
+
+// NewCmdVersion creates a version command for CLI
+func NewCmdVersion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: i18n.T("Print Dispatch CLI version."),
+		Run: func(cmd *cobra.Command, args []string) {
+			v := version.Get()
+			fmt.Fprintf(out, "%s-%s\n", v.Version, v.Commit[0:7])
+		},
+	}
+	return cmd
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,42 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	version   string
+	commit    string
+	buildDate string
+)
+
+// NO TESTS
+
+// BuildInfo describes build metadata
+type BuildInfo struct {
+	Version   string
+	Commit    string
+	BuildDate string
+	GoVersion string
+	Compiler  string
+	Platform  string
+}
+
+// Get returns information about the build
+func Get() *BuildInfo {
+	// Filled by -ldflags passed to `go build`
+	return &BuildInfo{
+		Version:   version,
+		Commit:    commit,
+		BuildDate: buildDate,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
```
$ make cli-darwin
GOOS=darwin go build -ldflags " -X github.com/vmware/dispatch/pkg/version.version=v0.1.7 -X github.com/vmware/dispatch/pkg/version.buildDate=2018-03-08T02:23:12Z -X github.com/vmware/dispatch/pkg/version.commit=7a5a611a74190d7b84ef1da3767ce58d2ad693bd " -o bin/dispatch-darwin ./cmd/dispatch

$ bin/dispatch-darwin version
v0.1.7-7a5a611a74
```
Release pipeline would need some tunning to automatically bump versions