### PR TITLE
Update PowerShell base image & add powershell runtime dependency manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --tags)
 GOPATH := $(firstword $(subst :, ,$(GOPATH)))
 SWAGGER := $(GOPATH)/bin/swagger
 GOBINDATA := $(GOPATH)/bin/go-bindata
-BUILD := $(shell date +%s)
+BUILD ?= $(shell date +%s)
 VERSION_PACKAGE := github.com/vmware/dispatch/pkg/version
 
 GO_LDFLAGS :="

--- a/e2e/tests/images.bats
+++ b/e2e/tests/images.bats
@@ -26,11 +26,18 @@ load variables
     run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "INITIALIZED" 1 0
     run_with_retry "dispatch get base-image base-python3 --json | jq -r .status" "READY" 4 5
 
+    # Create base image "base-powershell"
+    run dispatch create base-image base-powershell $DOCKER_REGISTRY/$BASE_IMAGE_POWERSHELL --language powershell
+    assert_success
+
+    run_with_retry "dispatch get base-image base-powershell --json | jq -r .status" "INITIALIZED" 1 0
+    run_with_retry "dispatch get base-image base-powershell --json | jq -r .status" "READY" 10 5
+
     # Create third image with non-existing image. Check that get operation returns three images. Wait for "ERROR" status for missing image.
     run dispatch create base-image missing-image missing/image:latest --language nodejs6
     assert_success
     run bash -c "dispatch get base-image --json | jq '. | length'"
-    assert_equal 3 $output
+    assert_equal 4 $output
     run_with_retry "dispatch get base-image missing-image --json | jq -r .status" "ERROR" 4 5
 }
 
@@ -39,8 +46,10 @@ load variables
     assert_success
     run dispatch create image python3 base-python3
     assert_success
+    run dispatch create image powershell base-powershell
     run_with_retry "dispatch get image nodejs6 --json | jq -r .status" "READY" 8 5
     run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 8 5
+    run_with_retry "dispatch get image powershell --json | jq -r .status" "READY" 8 5
 }
 
 @test "Delete images" {

--- a/e2e/tests/images.yaml
+++ b/e2e/tests/images.yaml
@@ -16,7 +16,7 @@ tags:
 ---
 kind: BaseImage
 name: powershell-base
-dockerUrl: vmware/dispatch-powershell-base:0.0.1-dev1
+dockerUrl: vmware/dispatch-powershell-base:0.0.2
 language: powershell
 tags:
   - key: role

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -4,3 +4,4 @@
 : ${DOCKER_REGISTRY:="vmware"}
 : ${BASE_IMAGE_PYTHON3:="dispatch-python3-base:0.0.1-dev1"}
 : ${BASE_IMAGE_NODEJS6:="dispatch-nodejs6-base:0.0.1-dev1"}
+: ${BASE_IMAGE_POWERSHELL:="dispatch-powershell-base:0.0.2"}

--- a/examples/powershell/powercli-run-vm-script.ps1
+++ b/examples/powershell/powercli-run-vm-script.ps1
@@ -1,0 +1,42 @@
+Import-Module PowerCLI.ViCore
+
+function handle($context, $payload) {
+    [void](Set-PowerCLIConfiguration -InvalidCertificateAction ignore -Confirm:$false)
+
+    $username = $context.secrets.username
+    $password = $context.secrets.password
+    $hostname = $context.secrets.host
+    $vmName = $payload.metadata.vm_name
+    $guestUser = $context.secrets.guestUsername
+    $guestPassword = $context.secrets.guestPassword
+
+    # Connect to vSphere
+    $server = connect-viserver -server $hostname -User $username -Password $password
+
+    # Get Virtual Machine By name
+    $vm = Get-VM -Name $vmName
+
+    # Invoke Guest Script
+    $output = Invoke-VMScript -VM $vm -GuestUser $guestUser -GuestPassword $guestPassword -ScriptType "Bash" -ScriptText "echo Script executed successfully!"
+
+    # Refresh VM
+    $vm = Get-VM -Name $vmName
+
+    # Rename VM by Appending "-ready"
+    $newName = $vm.Name + "-ready"
+    Set-VM -VM $vm -Name $newName -confirm:$false
+
+    # Retrieve IP Address
+    $ipaddress = $vm.guest.IPAddress[0]
+
+    [void](emitEvent $newName $ipaddress)
+
+    return ($output | Select ScriptOutput)
+}
+
+function emitEvent($newName, $ipaddress) {
+    $payload = @{vm_name=$newName;vm_ip=$ipaddress}
+    $postParams = @{topic="vm.ready";payload=$payload}
+    $headers = @{"cookie"="Cookie"}
+    [void](Invoke-WebRequest -Uri "http://dispatch-event-manager.dispatch/v1/event" -Headers $headers -Method "POST" -ContentType "application/json" -Body (ConvertTo-Json $postParams))
+}

--- a/examples/powershell/requirements.psd1
+++ b/examples/powershell/requirements.psd1
@@ -1,0 +1,3 @@
+@{
+  PSSlack = 'latest'
+}

--- a/examples/powershell/test-slack.ps1
+++ b/examples/powershell/test-slack.ps1
@@ -1,0 +1,12 @@
+#######################################################################
+## Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+#######################################################################
+
+# Executes Test-SlackApi cmdlet and returns result
+function handle($context, $payload) {
+    $result=Test-SlackApi
+    return @{result=$result}
+}
+
+

--- a/examples/seed.yaml
+++ b/examples/seed.yaml
@@ -16,7 +16,7 @@ tags:
 ---
 kind: BaseImage
 name: powershell-base
-dockerUrl: vmware/dispatch-powershell-base:0.0.1-dev1
+dockerUrl: vmware/dispatch-powershell-base:0.0.2
 language: powershell
 tags:
   - key: role

--- a/images/base-images/powershell/Dockerfile
+++ b/images/base-images/powershell/Dockerfile
@@ -1,45 +1,19 @@
-### Downloader image: Download & install Power{CLI,NSX,vRA}
-FROM vmware/photon:2.0 as downloader
+FROM microsoft/powershell:ubuntu16.04 as builder
 
-RUN tdnf install -y unzip
+RUN mkdir /powershell
 
-WORKDIR /powershell
-ARG POWERCLI_PACKAGE=PowerCLI.ViCore.zip
-ARG POWERCLI_VDS_PACKAGE=PowerCLI.Vds.zip
-ARG POWERCLI_CIS_PACKAGE=PowerCLI.Cis.zip
+RUN pwsh -command 'Save-Module -Name PowerShellGet -RequiredVersion "1.6.0" -Path /powershell' > /dev/null
 
-# Add PowerCLI
-ADD https://download3.vmware.com/software/vmw-tools/powerclicore/PowerCLI_Core.zip /powershell
-RUN unzip /powershell/PowerCLI_Core.zip -d /powershell && \
-    mkdir -p /root/.local/share/powershell/Modules && \
-    unzip /powershell/$POWERCLI_PACKAGE -d /root/.local/share/powershell/Modules && \
-    unzip /powershell/$POWERCLI_VDS_PACKAGE -d /root/.local/share/powershell/Modules && \
-    unzip /powershell/$POWERCLI_CIS_PACKAGE -d /root/.local/share/powershell/Modules
+# PSDepend dependency manager
+RUN pwsh -command 'Save-Module -Name PSDepend -RequiredVersion "0.1.64" -Path /powershell' > /dev/null
 
-# Add PowerNSX
-ADD https://raw.githubusercontent.com/vmware/powernsx/master/module/platform/core/PowerNSX/PowerNSX.psd1 /root/.local/share/powershell/Modules/PowerNSX/
-ADD https://raw.githubusercontent.com/vmware/powernsx/master/module/platform/core/PowerNSX/PowerNSX.psm1 /root/.local/share/powershell/Modules/PowerNSX/
+# Fix for https://github.com/RamblingCookieMonster/PSDepend/issues/74
+RUN mv /powershell/PSDepend/0.1.64/PSDependScripts/Noop.ps1 /powershell/PSDepend/0.1.64/PSDependScripts/noop.ps1
 
-# Add PowervRA
-ADD https://github.com/jakkulabs/PowervRA/archive/v2.2.0.zip /powershell
-RUN unzip /powershell/v2.2.0.zip -d /powershell
-RUN mv /powershell/PowervRA-2.2.0/PowervRA ~/.local/share/powershell/Modules/
-RUN rm -rf /powershell/PowervRA-2.2.0 v2.2.0.zip
-
-### Actual image
+# Using photon image as it has smaller footprint than default microsoft/powershell image
 FROM vmware/photon:2.0
 
-# Add PowerShell repository location to Photon OS
-RUN echo $'[powershell]\n\
-name=VMware PowerShell Repo\n\
-baseurl=https://vmware.bintray.com/powershell\n\
-gpgcheck=0\n\
-enabled=1\n\
-skip_if_unavailable=True\n '\
->> /etc/yum.repos.d/powershell.repo && \
- # Install PowerShell on Photon
- tdnf install -y util-linux-libs powershell curl openssl
+RUN tdnf makecache && tdnf install -y powershell && tdnf clean all
+COPY --from=builder /powershell/ /root/.local/share/powershell/Modules/
 
-COPY --from=downloader /root/.local/share/powershell/Modules /root/.local/share/powershell/Modules
-
-WORKDIR /root/
+CMD ["pwsh"]

--- a/images/base-images/powershell/build.sh
+++ b/images/base-images/powershell/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t vmware/dispatch-powershell-base:0.0.1-dev1 .
+docker build -t vmware/dispatch-powershell-base:0.0.2 .

--- a/images/function-manager/templates/openfaas/powershell/Dockerfile
+++ b/images/function-manager/templates/openfaas/powershell/Dockerfile
@@ -8,7 +8,7 @@ COPY index.ps1 .
 
 COPY {{ .FunctionFile }} function/handler.ps1
 
-ENV fprocess="powershell -NoLogo -File index.ps1"
+ENV fprocess="pwsh -NoLogo -File index.ps1"
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/images/function-manager/templates/openfaas/powershell/index.ps1
+++ b/images/function-manager/templates/openfaas/powershell/index.ps1
@@ -1,3 +1,6 @@
+# Don't print warnings to stdout
+$WarningPreference = 'SilentlyContinue'
+
 . .\function\handler.ps1
 
 $stdin_json = [System.Text.StringBuilder]::new()

--- a/pkg/image-manager/runtimes/nodejs6.go
+++ b/pkg/image-manager/runtimes/nodejs6.go
@@ -54,11 +54,11 @@ func (r *Nodejs6Runtime) WriteDockerfile(dockerfile io.Writer, image *imagemanag
 	}
 	tmpl, err := template.New(string(r.Language)).Parse(nodejsDockerfile)
 	if err != nil {
-		return errors.Wrapf(err, "failed to build dockefile template")
+		return errors.Wrapf(err, "failed to build dockerfile template")
 	}
 	err = tmpl.Execute(dockerfile, r)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write dockefile")
+		return errors.Wrapf(err, "failed to write dockerfile")
 	}
 	return nil
 }

--- a/pkg/image-manager/runtimes/powershell.go
+++ b/pkg/image-manager/runtimes/powershell.go
@@ -6,9 +6,13 @@
 package runtimes
 
 import (
+	"html/template"
 	"io"
+	"io/ioutil"
+	"path/filepath"
 
-	imagemanager "github.com/vmware/dispatch/pkg/image-manager"
+	"github.com/pkg/errors"
+	"github.com/vmware/dispatch/pkg/image-manager"
 )
 
 // PowershellRuntime represents nodejs6 image suport
@@ -18,9 +22,11 @@ type PowershellRuntime struct {
 	ManifestFile   string
 }
 
-// Currently dependency management is not supported with powershell.  This
-// requires more research into supporing NuGet or similar for managing packages
-var powershellDockerfile = ``
+// Uses PSDepend as dependency manager: https://github.com/RamblingCookieMonster/PSDepend
+var powershellDockerfile = `
+ADD {{ .ManifestFile }} {{ .ManifestFile }}
+RUN pwsh -command '$ErrorActionPreference="Stop"; {{ .PackageManager }} -Path "//{{ .ManifestFile }}" -Confirm:$false'
+`
 
 // GetPackageManager returns the package manager
 func (r *PowershellRuntime) GetPackageManager() string {
@@ -29,11 +35,31 @@ func (r *PowershellRuntime) GetPackageManager() string {
 
 // PrepareManifest writes and adds the manifest to the Dockerfile
 func (r *PowershellRuntime) PrepareManifest(dir string, image *imagemanager.Image) error {
+	manifestFileContent := []byte(image.RuntimeDependencies.Manifest)
+	if len(manifestFileContent) == 0 {
+		// Don't create manifest, PSDepend does not work with empty manifest
+		return nil
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, r.ManifestFile), manifestFileContent, 0644); err != nil {
+		return errors.Wrapf(err, "failed to write %s", r.ManifestFile)
+	}
 	return nil
 }
 
 // WriteDockerfile writes the runtime Dockerfile
 func (r *PowershellRuntime) WriteDockerfile(dockerfile io.Writer, image *imagemanager.Image) error {
+	if len(image.RuntimeDependencies.Manifest) == 0 {
+		// PSDepend does not work with empty manifest
+		return nil
+	}
+	tmpl, err := template.New(string(r.Language)).Parse(powershellDockerfile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to build dockerfile template")
+	}
+	err = tmpl.Execute(dockerfile, r)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write dockerfile")
+	}
 	return nil
 }
 
@@ -41,8 +67,8 @@ func (r *PowershellRuntime) WriteDockerfile(dockerfile io.Writer, image *imagema
 func NewPowershellRuntime() *PowershellRuntime {
 	return &PowershellRuntime{
 		Language:       imagemanager.LanguagePowershell,
-		PackageManager: "",
-		ManifestFile:   "",
+		PackageManager: "Invoke-PSDepend",
+		ManifestFile:   "requirements.psd1",
 	}
 }
 

--- a/pkg/image-manager/runtimes/powershell_test.go
+++ b/pkg/image-manager/runtimes/powershell_test.go
@@ -1,0 +1,60 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package runtimes
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/dispatch/pkg/entity-store"
+	"github.com/vmware/dispatch/pkg/image-manager"
+)
+
+func TestPowerShellRuntime(t *testing.T) {
+	requirementsPSD := `@{
+    psake        = 'latest'
+    Pester       = 'latest'
+    BuildHelpers = '0.0.20'
+    PSDeploy     = '0.1.21'
+
+    'RamblingCookieMonster/PowerShell' = 'master'
+}
+`
+
+	dockerfile := `
+ADD requirements.psd1 requirements.psd1
+RUN pwsh -command '$ErrorActionPreference="Stop"; Invoke-PSDepend -Path "//requirements.psd1" -Confirm:$false'
+`
+	i := &imagemanager.Image{
+		BaseEntity: entitystore.BaseEntity{
+			Name:   "test",
+			Status: imagemanager.StatusINITIALIZED,
+		},
+		DockerURL: "some/repo:latest",
+		Language:  imagemanager.LanguagePowershell,
+		RuntimeDependencies: imagemanager.RuntimeDependencies{
+			Manifest: requirementsPSD,
+		},
+	}
+	powershellRuntime := NewPowershellRuntime()
+	assert.Equal(t, "Invoke-PSDepend", powershellRuntime.GetPackageManager())
+	dir, err := ioutil.TempDir("", "test")
+	assert.NoError(t, err)
+	// Test manifest
+	err = powershellRuntime.PrepareManifest(dir, i)
+	assert.NoError(t, err)
+	content, err := ioutil.ReadFile(fmt.Sprintf("%s/requirements.psd1", dir))
+	assert.NoError(t, err)
+	assert.Equal(t, i.RuntimeDependencies.Manifest, string(content))
+	// Test Dockerfile
+	b := new(bytes.Buffer)
+	err = powershellRuntime.WriteDockerfile(b, i)
+	assert.NoError(t, err)
+	assert.Equal(t, dockerfile, b.String())
+}

--- a/pkg/image-manager/runtimes/python2.go
+++ b/pkg/image-manager/runtimes/python2.go
@@ -40,11 +40,11 @@ func (r *Python2Runtime) PrepareManifest(dir string, image *imagemanager.Image) 
 func (r *Python2Runtime) WriteDockerfile(dockerfile io.Writer, image *imagemanager.Image) error {
 	tmpl, err := template.New(string(r.Language)).Parse(pythonDockerfile)
 	if err != nil {
-		return errors.Wrapf(err, "failed to build dockefile template")
+		return errors.Wrapf(err, "failed to build dockerfile template")
 	}
 	err = tmpl.Execute(dockerfile, r)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write dockefile")
+		return errors.Wrapf(err, "failed to write dockerfile")
 	}
 	return nil
 }

--- a/pkg/image-manager/runtimes/python3.go
+++ b/pkg/image-manager/runtimes/python3.go
@@ -45,11 +45,11 @@ func (r *Python3Runtime) PrepareManifest(dir string, image *imagemanager.Image) 
 func (r *Python3Runtime) WriteDockerfile(dockerfile io.Writer, image *imagemanager.Image) error {
 	tmpl, err := template.New(string(r.Language)).Parse(pythonDockerfile)
 	if err != nil {
-		return errors.Wrapf(err, "failed to build dockefile template")
+		return errors.Wrapf(err, "failed to build dockerfile template")
 	}
 	err = tmpl.Execute(dockerfile, r)
 	if err != nil {
-		return errors.Wrapf(err, "failed to write dockefile")
+		return errors.Wrapf(err, "failed to write dockerfile")
 	}
 	return nil
 }


### PR DESCRIPTION
**Changes:**
* New powershell base image using PowerShell 6.0.1 GA
* Add dependency manager for PowerShell images. PowerCLI can now be added via dependency.
* Use new image in tests.
* Use new image in seed.
* Add one more example for powerCLI.
* Update openfaas image template for powershell.

**Notes:**
* we could add more tests with PowerCLI based on vcsim, once https://github.com/vmware/govmomi/issues/1063 is fixed.

Fixes #247 