### PR TITLE
Batch resource creation file path to function definition and CLI output

### DIFF
--- a/docs/_guides/quickstart.md
+++ b/docs/_guides/quickstart.md
@@ -78,8 +78,7 @@ At this point, the environment is up and working.  Let's seed the service
 with some images and functions.  In order to get the examples, you will need
 to clone the repository (if you haven't already):
 ```bash
-$ cd examples/
-$ dispatch create --file seed.yaml
+$ dispatch create --file examples/seed.yaml
 $ dispatch get images
    NAME   |                    URL                           |  BASEIMAGE   |   STATUS    |         CREATED DATE
 ------------------------------------------------------------------------------------------------------------------------

--- a/examples/seed.yaml
+++ b/examples/seed.yaml
@@ -47,33 +47,7 @@ tags:
 ---
 kind: Function
 name: hello-py
-code: |
-  #!/usr/bin/env python
-  #######################################################################
-  ## Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-  ## SPDX-License-Identifier: Apache-2.0
-  #######################################################################
-  """
-  Example function "Hello World"
-
-  ** REQUIREMENTS **
-
-  * image
-  dispatch create base-image python3 vmware/dispatch-openfaas-python-base:0.0.5-dev1 --language python3
-  dispatch create image python3 python3
-
-  Create a function:
-  dispatch create function python3 hello-python examples/python3/hello.py
-
-  Execute it:
-  dispatch exec hello-python --wait --input='{"name": "Jon", "place": "Winterfell"}'
-
-  """
-
-  def handle(ctx, payload):
-      name = payload.get("name", "Noone")
-      place = payload.get("place", "Nowhere")
-      return {"myField": "Hello, %s from %s" % (name, place)}
+code: '@examples/python3/hello.py'
 image: python3
 schema: {}
 tags:
@@ -82,14 +56,7 @@ tags:
 ---
 kind: Function
 name: http-py
-code: |
-  import time
-
-  import requests
-
-  def handle(ctx, payload):
-      resp = requests.get("http://example.com")
-      return {"status": resp.status_code}
+code: '@examples/python3/http.py'
 image: python3
 schema: {}
 tags:
@@ -98,18 +65,7 @@ tags:
 ---
 kind: Function
 name: hello-js
-code: |
-  module.exports = function (context, params) {
-      let name = "Noone";
-      if (params.name) {
-          name = params.name;
-      }
-      let place = "Nowhere";
-      if (params.place) {
-          place = params.place;
-      }
-      return {myField: 'Hello, ' + name + ' from ' + place}
-  };
+code: '@examples/nodejs6/hello.js'
 image: nodejs6
 schema:
   in:
@@ -136,28 +92,7 @@ tags:
 ---
 kind: Function
 name: hello-ps1
-code: |+
-  #######################################################################
-  ## Copyright (c) 2017 VMware, Inc. All Rights Reserved.
-  ## SPDX-License-Identifier: Apache-2.0
-  #######################################################################
-
-
-  function handle($context, $payload) {
-
-      $name = $payload.name
-      if (!$name) {
-          $name = "Noone"
-      }
-      $place = $payload.place
-      if (!$place) {
-          $place = "Nowhere"
-      }
-
-      return @{myField="Hello, $name from $place"}
-  }
-
-
+code: '@examples/powershell/hello.ps1'
 image: powershell
 schema: {}
 tags: 

--- a/pkg/dispatchcli/cmd/create.go
+++ b/pkg/dispatchcli/cmd/create.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"path"
@@ -84,6 +85,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.APIs = append(o.APIs, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		case utils.BaseImageKind:
 			m := &imageModels.BaseImage{}
 			err = yaml.Unmarshal(doc, &m)
@@ -95,6 +97,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.BaseImages = append(o.BaseImages, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		case utils.ImageKind:
 			m := &imageModels.Image{}
 			err = yaml.Unmarshal(doc, &m)
@@ -106,6 +109,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.Images = append(o.Images, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		case utils.FunctionKind:
 			m := &functionModels.Function{}
 			err = yaml.Unmarshal(doc, &m)
@@ -126,6 +130,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.Functions = append(o.Functions, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		case utils.SecretKind:
 			m := &secretModels.Secret{}
 			err = yaml.Unmarshal(doc, &m)
@@ -137,6 +142,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.Secrets = append(o.Secrets, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		case utils.PolicyKind:
 			m := &policyModels.Policy{}
 			err := yaml.Unmarshal(doc, &m)
@@ -148,6 +154,7 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 				return err
 			}
 			o.Policies = append(o.Policies, m)
+			fmt.Fprintf(out, "Created %s: %s\n", docKind, *m.Name)
 		default:
 			continue
 		}

--- a/pkg/dispatchcli/cmd/create.go
+++ b/pkg/dispatchcli/cmd/create.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -110,6 +111,15 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 			err = yaml.Unmarshal(doc, &m)
 			if err != nil {
 				return errors.Wrapf(err, "Error decoding function document %s", string(doc))
+			}
+			if strings.HasPrefix(*m.Code, "@") {
+				functionPath := (*m.Code)[1:]
+				codeFileContent, err := ioutil.ReadFile(functionPath)
+				if err != nil {
+					return errors.Wrapf(err, "Error when reading content of %s", functionPath)
+				}
+				codeEncoded := string(codeFileContent)
+				m.Code = &codeEncoded
 			}
 			err = actionMap[docKind](m)
 			if err != nil {


### PR DESCRIPTION
Fixes #295 and #288 

* Resource type and name are outputted when created via manifest file
* Function definition can be specified in manifest as a path to file with notation `@pathToFile.py`