### PR TITLE
Update GKE cluster version in CI

### DIFF
--- a/ci/e2e/gke-cluster-create.yml
+++ b/ci/e2e/gke-cluster-create.yml
@@ -10,7 +10,7 @@ image_resource:
 params:
   GKE_KEY:
   GKE_PROJECT_ID:
-  K8S_VERSION: 1.8.7-gke.1
+  K8S_VERSION: 1.8.9-gke.1
   GKE_ZONE: us-west1-c
   CLUSTER_NAME_SUFFIX: job
 


### PR DESCRIPTION
1.8.7 has been pulled out due to CVEs, and this is causing failures in our CI: https://ci.dispatchframework.io/builds/1117