### PR TITLE
Set the binaries version in CI release pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
-# To be bumped by every release
-VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 1
-VERSION_BUILD ?= 7
 
-VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+VERSION ?= dev
 
 GO ?= go
 GOVERSION ?= go1.9

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -123,7 +123,7 @@ jobs:
     - get: dispatch
       resource: dispatch-master
     - task: build-binaries
-      file: dispatch/ci/e2e/binaries.yml
+      file: dispatch/ci/release/binaries.yml
     - task: prepare-images
       file: dispatch/ci/release/release-images.yml
     - task: cli

--- a/ci/release/binaries.yml
+++ b/ci/release/binaries.yml
@@ -10,9 +10,11 @@ image_resource:
 inputs:
 - name: dispatch
   path: src/github.com/vmware/dispatch
+- name: version
 
 outputs:
 - name: dispatch-cli
+- name: dispatch-binaries
 
 run:
   path: /bin/bash
@@ -22,8 +24,11 @@ run:
     set -e -u -x
 
     export GOPATH=$PWD
+    export VERSION="v$(cat version/version)"
+
     cd $GOPATH/src/github.com/vmware/dispatch
-    make cli-linux
+    make linux
     make cli-darwin
-    mv bin/dispatch-* $GOPATH/dispatch-cli/.
-    ln -s $GOPATH/dispatch-cli/dispatch-linux $GOPATH/dispatch-cli/dispatch
+
+    mv bin/dispatch-* $GOPATH/dispatch-cli/
+    mv bin/* $GOPATH/dispatch-binaries/


### PR DESCRIPTION
By default, the version is `dev`. The release pipeline sets
the env variable VERSION, which changes the build tag.

Fixes #315 