### PR TITLE
Enhance chart controls for RBAC, Resource limits, Ingress

### DIFF
--- a/charts/dispatch/charts/api-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/api-manager/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
           emptyDir: {}

--- a/charts/dispatch/charts/application-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/application-manager/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
           emptyDir: {}

--- a/charts/dispatch/charts/echo-server/templates/deployment.yaml
+++ b/charts/dispatch/charts/echo-server/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               path: /
               port: {{ .Values.service.internalPort }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dispatch/charts/event-manager/templates/cluster-role.yaml
+++ b/charts/dispatch/charts/event-manager/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # A cluster role for create/get/list/delete/update secrets
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -7,3 +8,4 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end -}}

--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "fullname" . }}-service-account
+      serviceAccountName: {{ if .Values.global.rbac.create }}{{ template "fullname" . }}-service-account{{ else }}"{{ .Values.global.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ default .Values.global.image.host .Values.image.host }}/{{ .Values.image.repository }}:{{ default .Values.global.image.tag .Values.image.tag }}"
@@ -92,7 +92,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/event-manager/templates/role-binding.yaml
+++ b/charts/dispatch/charts/event-manager/templates/role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # The role binding to combine the secret-access service account and role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: {{ template "fullname" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/dispatch/charts/event-manager/templates/service-account.yaml
+++ b/charts/dispatch/charts/event-manager/templates/service-account.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.global.rbac.create -}}
 # A service account for event-manager pod
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}-service-account
+{{- end -}}

--- a/charts/dispatch/charts/function-manager/templates/cluster-role-binding.yaml
+++ b/charts/dispatch/charts/function-manager/templates/cluster-role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # The role binding to combine the secret-access service account and role
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11,3 +12,4 @@ roleRef:
   kind: ClusterRole
   name: {{ template "fullname" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/dispatch/charts/function-manager/templates/cluster-role.yaml
+++ b/charts/dispatch/charts/function-manager/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # A cluster role for create/get/list/delete/update secrets
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -10,3 +11,4 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get"]
+{{- end -}}

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "fullname" . }}-service-account
+      serviceAccountName: {{ if .Values.global.rbac.create }}{{ template "fullname" . }}-service-account{{ else }}"{{ .Values.global.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ default .Values.global.image.host .Values.image.host }}/{{ .Values.image.repository }}:{{ default .Values.global.image.tag .Values.image.tag }}"
@@ -88,7 +88,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
         - name: {{ .Chart.Name }}-docker
           image: docker:dind
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -101,6 +101,8 @@ spec:
           volumeMounts:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
+          resources:
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/function-manager/templates/service-account.yaml
+++ b/charts/dispatch/charts/function-manager/templates/service-account.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.global.rbac.create -}}
 # A service account for event-manager pod
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}-service-account
+{{- end -}}

--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 3
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
         - name: oauth2-proxy
           image: {{ .Values.oauth2proxy.image }}
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -155,6 +155,8 @@ spec:
                   key: cookie_secret
           ports:
             - containerPort: {{ .Values.oauth2proxy.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/identity-manager/templates/ingress.noauth.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/ingress.noauth.yaml
@@ -11,10 +11,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    nginx.ingress.kubernetes.io/configuration-snippet: |
+    {{ .Values.global.ingress.annotationsPrefix }}/configuration-snippet: |
       error_page 403 = @403.json;
       error_page 401 = @401.json;
-    nginx.ingress.kubernetes.io/server-snippet: |
+    {{ .Values.global.ingress.annotationsPrefix }}/server-snippet: |
       location @403.json {
         default_type application/json;
         return 403 '{"code": 403,"message": "Forbidden, please make sure you have required privileges"}';

--- a/charts/dispatch/charts/identity-manager/values.yaml
+++ b/charts/dispatch/charts/identity-manager/values.yaml
@@ -17,7 +17,7 @@ service:
   externalPort: 80
   internalPort: 80
 oauth2proxy:
-  image: docker.io/neosab/oauth2-proxy
+  image: neosab/oauth2-proxy
   provider: github
   clientID: <client-id>
   clientSecret: <client-secret>

--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
         - name: {{ .Chart.Name }}-docker
           image: docker:dind
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -97,6 +97,8 @@ spec:
           volumeMounts:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
+          resources:
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/secret-store/templates/cluster-role.yaml
+++ b/charts/dispatch/charts/secret-store/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # A cluster role for create/get/list/delete/update secrets
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -7,3 +8,4 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["secrets"] 
   verbs: ["create", "get", "list", "delete", "update" ]
+{{- end -}}

--- a/charts/dispatch/charts/secret-store/templates/deployment.yaml
+++ b/charts/dispatch/charts/secret-store/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "fullname" . }}-service-account
+      serviceAccountName: {{ if .Values.global.rbac.create }}{{ template "fullname" . }}-service-account{{ else }}"{{ .Values.global.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ default .Values.global.image.host .Values.image.host }}/{{ .Values.image.repository }}:{{ default .Values.global.image.tag .Values.image.tag }}"
@@ -82,7 +82,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/secret-store/templates/role-binding.yaml
+++ b/charts/dispatch/charts/secret-store/templates/role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create -}}
 # The role binding to combine the secret-access service account and role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: {{ template "fullname" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/dispatch/charts/secret-store/templates/service-account.yaml
+++ b/charts/dispatch/charts/secret-store/templates/service-account.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.global.rbac.create -}}
 # A service account for secret-store pod
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}-service-account
+{{- end -}}

--- a/charts/dispatch/templates/_helpers.tpl
+++ b/charts/dispatch/templates/_helpers.tpl
@@ -18,8 +18,8 @@ metadata:
     {{- range $key, $value := $ingress_annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-    nginx.ingress.kubernetes.io/auth-url: "http://{{ .Release.Name }}-identity-manager.{{ .Release.Namespace }}.svc.cluster.local/v1/iam/auth"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
+    {{ .Values.global.ingress.annotationsPrefix }}/auth-url: "http://{{ .Release.Name }}-identity-manager.{{ .Release.Namespace }}.svc.cluster.local/v1/iam/auth"
+    {{ .Values.global.ingress.annotationsPrefix }}/configuration-snippet: |
       error_page 403 = @403.json;
       error_page 401 = @401.json;
 spec:

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -29,6 +29,9 @@ global:
     enabled: true
     # Used to create Ingress record (should used with service.type: ClusterIP).
     # host: dispatch.vmware.com
+    # The annotationsPrefix that your ingress controller requires. default - nginx.ingress.kubernetes.io for
+    # nginx ingress controllers.
+    annotationsPrefix: nginx.ingress.kubernetes.io
     annotations:
       # Specify any additional ingress annotations here. These will be applied to all ingress resources.
       # kubernetes.io/ingress.class: "nginx"
@@ -44,3 +47,14 @@ global:
     - transport-kafka.dispatch:9092
   tls:
     secretName: dispatch-tls
+  rbac:
+    create: true
+    # Ignored, if rbac.create is true
+    serviceAccountName: default
+  resources:
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    #requests:
+    #  cpu: 100m
+    #  memory: 128Mi

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             port: 8001
           initialDelaySeconds: 10
           periodSeconds: 3
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
           - name: kong-conf
             mountPath: /data/kong

--- a/charts/openfaas/templates/faas.yaml
+++ b/charts/openfaas/templates/faas.yaml
@@ -84,6 +84,8 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 ---
 apiVersion: v1
 kind: Service
@@ -146,4 +148,6 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 ---

--- a/charts/openfaas/templates/monitoring.yaml
+++ b/charts/openfaas/templates/monitoring.yaml
@@ -62,6 +62,8 @@ spec:
         - mountPath: /etc/prometheus/alert.rules
           name: prometheus-config
           subPath: alert.rules
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
       volumes:
         - name: prometheus-config
           configMap:
@@ -130,6 +132,8 @@ spec:
         - mountPath: /alertmanager.yml
           name: alertmanager-config
           subPath: alertmanager.yml
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
       volumes:
         - name: alertmanager-config
           configMap:

--- a/charts/openfaas/templates/nats.yaml
+++ b/charts/openfaas/templates/nats.yaml
@@ -56,6 +56,8 @@ spec:
           - memory
           - --cluster_id
           - faas-cluster
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 ---
 apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
 kind: Deployment
@@ -88,5 +90,7 @@ spec:
         - name: faas_function_suffix
           value: .{{ .Values.functionNamespace }}
         {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 ---
 {{- end }}

--- a/charts/openfaas/values.yaml
+++ b/charts/openfaas/values.yaml
@@ -4,6 +4,7 @@ armhf: false
 exposeServices: true
 serviceType: NodePort
 rbac: true
+resources: {}
 
 # images
 images:


### PR DESCRIPTION
This patch enhances chart deployment for production K8S clusters.

   1. Creation of RBAC resources should be optional.
   2. Support for specifying a serviceAccount to run dispatch services
   3. Ability to specify resource limits, requests at a global level
      Also, adds the resource values in missing charts.
   4. Ingress annotation prefix should be configurable since it
      depends on the deployment.
      Ref: https://github.com/kubernetes/ingress-nginx/commit/8f1ff15a6e2c3ec855a3a60a285bd3ddeef9890c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/329)
<!-- Reviewable:end -->
