### PR TITLE
Fix for getting deployment objects in K8S 1.7

### DIFF
--- a/pkg/functions/openfaas/driver.go
+++ b/pkg/functions/openfaas/driver.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vmware/dispatch/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/typed/apps/v1beta2"
+	"k8s.io/client-go/kubernetes/typed/apps/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -55,7 +55,7 @@ type ofDriver struct {
 	httpClient   *http.Client
 	docker       *docker.Client
 
-	deployments v1beta2.DeploymentInterface
+	deployments v1beta1.DeploymentInterface
 
 	createTimeout int
 }
@@ -79,11 +79,12 @@ func New(config *Config) (functions.FaaSDriver, error) {
 		fnNs = "default"
 	}
 	d := &ofDriver{
-		gateway:       strings.TrimRight(config.Gateway, "/"),
-		httpClient:    http.DefaultClient,
-		imageBuilder:  functions.NewDockerImageBuilder(config.ImageRegistry, config.RegistryAuth, config.TemplateDir, dc),
-		docker:        dc,
-		deployments:   k8sClient.AppsV1beta2().Deployments(fnNs),
+		gateway:      strings.TrimRight(config.Gateway, "/"),
+		httpClient:   http.DefaultClient,
+		imageBuilder: functions.NewDockerImageBuilder(config.ImageRegistry, config.RegistryAuth, config.TemplateDir, dc),
+		docker:       dc,
+		// Use AppsV1beta1 until we remove support for Kubernetes 1.7
+		deployments:   k8sClient.AppsV1beta1().Deployments(fnNs),
 		createTimeout: defaultCreateTimeout,
 	}
 	if config.CreateTimeout != nil {


### PR DESCRIPTION
Currently, function manager can't fetch deployments from a K8S 1.7 Cluster. This will result in failed function creations even though it was successful on OpenFaaS and a deployment object was created on K8S. This is because we use `apps/v1beta2` API group which was introduced only in K8S 1.8.

Let's switch to `apps/v1beta1` which will still be auto-converted post 1.9. Once we remove support for 1.7 clusters, we can switch to `apps/v1beta2` or `apps/v1` when we move to 1.9.

Reference:- https://kubernetes.io/docs/reference/workloads-18-19/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/331)
<!-- Reviewable:end -->
