### PR TITLE
Make RabbitMQ chart configurable

### DIFF
--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -38,8 +38,7 @@ spec:
             - "--db-database={{ .Values.global.db.database }}"
             - "--function-manager={{ .Release.Name }}-function-manager"
             - "--secret-store={{ .Release.Name }}-secret-store"
-            # TODO: Read password from secret
-            - "--rabbitmq-url=amqp://user:serverless@{{ .Release.Name }}-rabbitmq:5672/"
+            - "--rabbitmq-url=amqp://{{ .Values.global.rabbitmq.username }}:{{ .Values.global.rabbitmq.password }}@{{ .Values.global.rabbitmq.host }}:{{ .Values.global.rabbitmq.port }}/"
             - "--namespace={{ .Release.Namespace }}"
             - "--event-driver-image={{ default .Values.global.image.host .Values.eventdriver.host }}/{{ .Values.eventdriver.repository }}:{{ default .Values.global.image.tag .Values.eventdriver.tag }}"
             - "--event-sidecar-image={{ default .Values.global.image.host .Values.eventsidecar.host }}/{{ .Values.eventsidecar.repository }}:{{ default .Values.global.image.tag .Values.eventsidecar.tag }}"

--- a/charts/dispatch/requirements.lock
+++ b/charts/dispatch/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: rabbitmq
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.6.9
-digest: sha256:6474f6bae5d525bb127ee0899f6239f39a7d6beda621aa02343ac901379def42
-generated: 2017-12-05T11:38:42.054425-08:00

--- a/charts/dispatch/requirements.yaml
+++ b/charts/dispatch/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: rabbitmq
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 0.6.9
-    condition: event-manager.enabled, global.event-manager.enabled

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -35,7 +35,9 @@ global:
   registry:
     insecure: false
     uri: docker-docker-registry.docker.svc.cluster.local:5000
+  rabbitmq:
+    username: dispatch
+    password: dispatch
+    port: 5672
   tls:
     secretName: dispatch-tls
-rabbitmq:
-  rabbitmqPassword: serverless

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -58,6 +58,18 @@ kafka:
     release: transport
     repo: https://riff-charts.storage.googleapis.com
     version: 0.0.1
+rabbitmq:
+  chart:
+    chart: rabbitmq
+    namespace: dispatch
+    release: rabbitmq
+    repo: https://kubernetes-charts.storage.googleapis.com
+    version: 0.6.26
+  username: dispatch
+  password: dispatch
+  host:
+  persist: false
+  port: 5672
 riff:
   chart:
     chart: riff

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -207,6 +207,12 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 			return errors.Wrapf(err, "Error uninstalling kafka chart")
 		}
 	}
+	if uninstallService("rabbitmq") {
+		err = helmUninstall(out, errOut, config.RabbitMQ.Chart.Namespace, config.RabbitMQ.Chart.Release, false)
+		if err != nil {
+			return errors.Wrapf(err, "Error uninstalling rabbitmq chart")
+		}
+	}
 	if uninstallService("api-gateway") {
 		err = helmUninstall(out, errOut, config.APIGateway.Chart.Namespace, config.APIGateway.Chart.Release, true)
 		if err != nil {


### PR DESCRIPTION
Makes RabbitMQ chart more configurable, including an option to not install it at all.

**Changes:**
* RabbitMQ chart is now installed separately, similarly to other dependent charts.
* RabbitMQ username & password can be set through install config
* RabbitMQ won't use persistent volume by default anymore. This should make it easier for people to play with dispatch. Persistence can still be enabled with a flag.

Fixes #47 