### PR TITLE
Add Kafka backend for events and make it default

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,14 +27,20 @@
 
 [[projects]]
   name = "github.com/Shopify/sarama"
-  packages = ["."]
+  packages = [
+    ".",
+    "mocks"
+  ]
   revision = "f7be6aa2bc7b2e38edf816b08b582782194a1c02"
   version = "v1.16.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/apache/incubator-openwhisk-client-go"
-  packages = ["whisk","wski18n"]
+  packages = [
+    "whisk",
+    "wski18n"
+  ]
   revision = "c6e512b136e8c27bb144c0f8b625e833fbae878a"
 
 [[projects]]
@@ -57,7 +63,15 @@
 
 [[projects]]
   name = "github.com/casbin/casbin"
-  packages = [".","config","file-adapter","model","persist","rbac","util"]
+  packages = [
+    ".",
+    "config",
+    "file-adapter",
+    "model",
+    "persist",
+    "rbac",
+    "util"
+  ]
   revision = "9566491e9fe1898000031bba3e2b354dd633904a"
   version = "v1.3.0"
 
@@ -75,19 +89,43 @@
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digest","reference"]
+  packages = [
+    "digest",
+    "reference"
+  ]
   revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
   version = "v2.6.2"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/reference",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/tlsconfig"
+  ]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
@@ -99,7 +137,11 @@
 
 [[projects]]
   name = "github.com/docker/libkv"
-  packages = [".","store","store/boltdb"]
+  packages = [
+    ".",
+    "store",
+    "store/boltdb"
+  ]
   revision = "aabc039ad04deb721e234f99cd1b4aa28ac71a40"
   version = "v0.2.1"
 
@@ -129,7 +171,10 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
   version = "v2.4.0"
 
@@ -178,13 +223,25 @@
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/loads"
-  packages = [".","fmts"]
+  packages = [
+    ".",
+    "fmts"
+  ]
   revision = "a80dea3052f00e5f032e860dd7355cd0cc67e24d"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/runtime"
-  packages = [".","client","flagext","middleware","middleware/denco","middleware/header","middleware/untyped","security"]
+  packages = [
+    ".",
+    "client",
+    "flagext",
+    "middleware",
+    "middleware/denco",
+    "middleware/header",
+    "middleware/untyped",
+    "security"
+  ]
   revision = "bf2ff8f7150788b1c7256abb0805ba0410cbbabb"
 
 [[projects]]
@@ -213,7 +270,10 @@
 
 [[projects]]
   name = "github.com/go-playground/locales"
-  packages = [".","currency"]
+  packages = [
+    ".",
+    "currency"
+  ]
   revision = "e4cbcb5d0652150d40ad0646651076b6bd2be4f6"
   version = "v0.11.2"
 
@@ -225,7 +285,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
@@ -238,7 +301,13 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
@@ -255,7 +324,12 @@
 
 [[projects]]
   name = "github.com/google/go-cmp"
-  packages = ["cmp","cmp/internal/diff","cmp/internal/function","cmp/internal/value"]
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value"
+  ]
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
@@ -273,14 +347,21 @@
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/gregjones/httpcache"
-  packages = [".","diskcache"]
+  packages = [
+    ".",
+    "diskcache"
+  ]
   revision = "2bcd89a1743fd4b373f7370ce8ddc14dfbd18229"
 
 [[projects]]
@@ -297,7 +378,17 @@
 
 [[projects]]
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
 
 [[projects]]
@@ -333,7 +424,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
-  packages = [".","reflectx","types"]
+  packages = [
+    ".",
+    "reflectx",
+    "types"
+  ]
   revision = "de8647470aafe4854c976707c431dbe1eb2822c6"
 
 [[projects]]
@@ -356,14 +451,27 @@
 
 [[projects]]
   name = "github.com/kubernetes-incubator/service-catalog"
-  packages = ["pkg/apis/servicecatalog","pkg/apis/servicecatalog/v1beta1","pkg/apis/settings","pkg/apis/settings/v1alpha1","pkg/client/clientset_generated/clientset","pkg/client/clientset_generated/clientset/scheme","pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1","pkg/client/clientset_generated/clientset/typed/settings/v1alpha1","pkg/svcat/service-catalog"]
+  packages = [
+    "pkg/apis/servicecatalog",
+    "pkg/apis/servicecatalog/v1beta1",
+    "pkg/apis/settings",
+    "pkg/apis/settings/v1alpha1",
+    "pkg/client/clientset_generated/clientset",
+    "pkg/client/clientset_generated/clientset/scheme",
+    "pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1",
+    "pkg/client/clientset_generated/clientset/typed/settings/v1alpha1",
+    "pkg/svcat/service-catalog"
+  ]
   revision = "01e652ff75a7b418f23d8173cc7191e986d16a77"
   version = "v0.1.10"
 
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "83612a56d3dd153a94a629cd64925371c9adad78"
 
 [[projects]]
@@ -375,7 +483,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
 
 [[projects]]
@@ -410,7 +522,12 @@
 
 [[projects]]
   name = "github.com/nicksnyder/go-i18n"
-  packages = ["i18n","i18n/bundle","i18n/language","i18n/translation"]
+  packages = [
+    "i18n",
+    "i18n/bundle",
+    "i18n/language",
+    "i18n/translation"
+  ]
   revision = "ca33e78c8a430e2df435b02f63a3944fa8e9ea11"
   version = "v1.9.0"
 
@@ -434,7 +551,10 @@
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -489,7 +609,16 @@
 [[projects]]
   branch = "master"
   name = "github.com/projectriff/riff"
-  packages = ["kubernetes-crds/pkg/apis/projectriff.io","kubernetes-crds/pkg/apis/projectriff.io/v1","kubernetes-crds/pkg/client/clientset/versioned","kubernetes-crds/pkg/client/clientset/versioned/scheme","kubernetes-crds/pkg/client/clientset/versioned/typed/projectriff/v1","message-transport/pkg/message","message-transport/pkg/transport","message-transport/pkg/transport/kafka"]
+  packages = [
+    "kubernetes-crds/pkg/apis/projectriff.io",
+    "kubernetes-crds/pkg/apis/projectriff.io/v1",
+    "kubernetes-crds/pkg/client/clientset/versioned",
+    "kubernetes-crds/pkg/client/clientset/versioned/scheme",
+    "kubernetes-crds/pkg/client/clientset/versioned/typed/projectriff/v1",
+    "message-transport/pkg/message",
+    "message-transport/pkg/transport",
+    "message-transport/pkg/transport/kafka"
+  ]
   revision = "dfd25546b9620dbcae278433fe13a64cd10f8bda"
 
 [[projects]]
@@ -513,7 +642,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b"
 
 [[projects]]
@@ -560,7 +692,11 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock","require"]
+  packages = [
+    "assert",
+    "mock",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -578,7 +714,24 @@
 
 [[projects]]
   name = "github.com/vmware/govmomi"
-  packages = [".","event","nfc","object","property","session","task","view","vim25","vim25/debug","vim25/methods","vim25/mo","vim25/progress","vim25/soap","vim25/types","vim25/xml"]
+  packages = [
+    ".",
+    "event",
+    "nfc",
+    "object",
+    "property",
+    "session",
+    "task",
+    "view",
+    "vim25",
+    "vim25/debug",
+    "vim25/methods",
+    "vim25/mo",
+    "vim25/progress",
+    "vim25/soap",
+    "vim25/types",
+    "vim25/xml"
+  ]
   revision = "7d879bac14d09f2f2a45a0477c1e45fbf52240f5"
   version = "v0.16.0"
 
@@ -591,7 +744,15 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex","proxy"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+    "proxy"
+  ]
   revision = "66aacef3dd8a676686c7ae3716979581e8b03c47"
 
 [[projects]]
@@ -603,13 +764,27 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "5513e650ab47a692d3a036d49be8fa52ddd09b65"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "bd91bbf73e9a4a801adbfb97133c992678533126"
 
 [[projects]]
@@ -627,7 +802,10 @@
 [[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
-  packages = ["bson","internal/json"]
+  packages = [
+    "bson",
+    "internal/json"
+  ]
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
@@ -638,19 +816,163 @@
 
 [[projects]]
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1"
+  ]
   revision = "006a217681ae70cbacdd66a5e2fca1a61a8ff28e"
   version = "kubernetes-1.9.1"
 
 [[projects]]
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/clock","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1alpha1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/rand",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "68f9c3a1feb3140df59c67ced62d3a5df8e6c9c2"
   version = "kubernetes-1.9.1"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/admissionregistration/v1beta1","kubernetes/typed/admissionregistration/v1beta1/fake","kubernetes/typed/apps/v1","kubernetes/typed/apps/v1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/events/v1beta1","kubernetes/typed/events/v1beta1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1alpha1","kubernetes/typed/storage/v1alpha1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","rest","rest/watch","testing","tools/auth","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = [
+    "discovery",
+    "discovery/fake",
+    "kubernetes",
+    "kubernetes/fake",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1alpha1/fake",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/admissionregistration/v1beta1/fake",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1/fake",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta1/fake",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/apps/v1beta2/fake",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1/fake",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authentication/v1beta1/fake",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1/fake",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/authorization/v1beta1/fake",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v1/fake",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta1/fake",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1/fake",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v1beta1/fake",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/batch/v2alpha1/fake",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/certificates/v1beta1/fake",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/core/v1/fake",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/events/v1beta1/fake",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/extensions/v1beta1/fake",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1/fake",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/policy/v1beta1/fake",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1/fake",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1alpha1/fake",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/rbac/v1beta1/fake",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1alpha1/fake",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1/fake",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1/fake",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1alpha1/fake",
+    "kubernetes/typed/storage/v1beta1",
+    "kubernetes/typed/storage/v1beta1/fake",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "testing",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/reference",
+    "transport",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer"
+  ]
   revision = "9389c055a838d4f208b699b3c7c51b70f2368861"
   version = "kubernetes-1.9.1"
 
@@ -663,6 +985,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3551cf316f03d8b1f9525cd5edce1aa3aecc2553747d5d589c6665cb2babff07"
+  inputs-digest = "46569e00db18fcf53439fe4598e8ebe07bea61908754e454f83df5b31bed00e4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - "--db-database={{ .Values.global.db.database }}"
             - "--function-manager={{ .Release.Name }}-function-manager"
             - "--secret-store={{ .Release.Name }}-secret-store"
+            - "--transport={{ .Values.transport }}"
+            {{- range .Values.global.kafka.brokers }}
+            - "--kafka-broker={{ . }}"
+            {{- end }}
             - "--rabbitmq-url=amqp://{{ .Values.global.rabbitmq.username }}:{{ .Values.global.rabbitmq.password }}@{{ .Values.global.rabbitmq.host }}:{{ .Values.global.rabbitmq.port }}/"
             - "--namespace={{ .Release.Namespace }}"
             - "--event-driver-image={{ default .Values.global.image.host .Values.eventdriver.host }}/{{ .Values.eventdriver.repository }}:{{ default .Values.global.image.tag .Values.eventdriver.tag }}"

--- a/charts/dispatch/charts/event-manager/values.yaml
+++ b/charts/dispatch/charts/event-manager/values.yaml
@@ -51,3 +51,5 @@ eventsidecar:
   # host: vmware
   repository: dispatch-event-sidecar
   # tag: latest
+
+transport: kafka

--- a/charts/dispatch/charts/function-manager/templates/config-map.yaml
+++ b/charts/dispatch/charts/function-manager/templates/config-map.yaml
@@ -22,7 +22,7 @@ data:
           "funcDefaultRequests": {{ toJson .Values.faas.openfaas.funcDefaultRequests }}
         },
         "riff": {
-          "kafkaBrokers": ["{{ join ", " .Values.faas.riff.kafkaBrokers }}"],
+          "kafkaBrokers": ["{{ join ", " .Values.global.kafka.brokers }}"],
           "funcNamespace": "{{ .Values.faas.riff.namespace }}",
           "funcDefaultLimits": {{ toJson .Values.faas.riff.funcDefaultLimits }},
           "funcDefaultRequests": {{ toJson .Values.faas.riff.funcDefaultRequests }}

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -54,8 +54,6 @@ faas:
     #  CPU: 100m
     #  Memory: 64Mi
   riff:
-    kafkaBrokers:
-    - transport-kafka.riff-system:9092
     namespace: riff
     funcDefaultLimits:
     #  CPU: 500m

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -39,5 +39,8 @@ global:
     username: dispatch
     password: dispatch
     port: 5672
+  kafka:
+    brokers:
+    - transport-kafka.dispatch:9092
   tls:
     secretName: dispatch-tls

--- a/ci/e2e/cleanup.yml
+++ b/ci/e2e/cleanup.yml
@@ -39,7 +39,7 @@ run:
           # Wait until LB is deleted asynchronously before deleting cluster (Workaround for https://github.com/kubernetes/kubernetes/issues/51701)
           until (kubectl get -n ${namespace} events | grep ${svc_name} | grep -q DeletedLoadBalancer); do
               sleep ${TIMEOUT}
-              ((attempts++))
+              attempts=$((attempts+1))
 
               # Prevent possible infinite loop
               if [[ ${attempts} -ge ${MAX_ATTEMPTS} ]]; then

--- a/docs/_guides/working-with-events.md
+++ b/docs/_guides/working-with-events.md
@@ -47,7 +47,7 @@ to the system, these functions will be executed. Events that do not match any su
 To add a new subscription for the `vm.being.created` event in a vcenter event driver, run:
 
 ```
-dispatch create subscription --event-type vm.being.created myFunction
+dispatch create subscription --source-type vcenter --event-type vm.being.created myFunction
 ```
 
 The above command will print output similar to the following:
@@ -55,12 +55,12 @@ The above command will print output similar to the following:
 ```
            NAME          | SOURCE TYPE |    EVENT TYPE    | FUNCTION NAME | STATUS |         CREATED DATE
 ---------------------------------------------------------------------------------------------------------
-  complete-cicada-410962 | *           | vm.being.created | myFunctio     | READY  | Fri Dec 31 17:18:54 PST -0001
+  complete-cicada-410962 | vcenter     | vm.being.created | myFunction    | READY  | Fri Dec 31 17:18:54 PST -0001
 ```
 
 The above subscription will cause dispatch to execute function `myFunction` for every event of type `vm.being.created`. 
-Note the asterisk in  `SOURCE TYPE` column. This is the default value and means "match all source types".
-What is source type? If you create event driver of `vcenter` type, `vcenter` is your source type. 
+What is source type? If you create event driver of `vcenter` type, `vcenter` is your source type. When source type is not specified,
+it defaults to "dispatch" (when you emit an event using CLI, source type also defaults to "dispatch").
 
 You can also specify a name for your subscription using `--name` parameter. if you don't, a random, human-readable name will be created.  
 

--- a/e2e/tests/events.bats
+++ b/e2e/tests/events.bats
@@ -61,7 +61,7 @@ load variables
 @test "Create event driver subscription" {
     initial_runs=$(dispatch get runs node-echo-back --json | jq -r '. | length')
 
-    run dispatch create subscription --source-type ticker --name tickersub node-echo-back
+    run dispatch create subscription --source-type ticker --event-type ticker.tick --name tickersub node-echo-back
     echo_to_log
     assert_success
 

--- a/pkg/dispatchcli/cmd/create_subscription.go
+++ b/pkg/dispatchcli/cmd/create_subscription.go
@@ -47,8 +47,8 @@ func NewCmdCreateSubscription(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().StringArrayVar(&createSubscriptionSecrets, "secret", []string{}, "Function secrets, can be specified multiple times or a comma-delimited string")
 
 	cmd.Flags().StringVar(&createSubscriptionName, "name", "", "Subscription name. If not specified, will be randomly generated.")
-	cmd.Flags().StringVar(&createSubscriptionEventType, "event-type", "*", "Event Type to filter on.")
-	cmd.Flags().StringVar(&createSubscriptionSourceType, "source-type", "*", "Source type to filter on. Most often it will be your event driver type.")
+	cmd.Flags().StringVar(&createSubscriptionEventType, "event-type", "", "Event Type to filter on.")
+	cmd.Flags().StringVar(&createSubscriptionSourceType, "source-type", "dispatch", "Source type to filter on. Most often it will be your event driver type.")
 
 	return cmd
 }

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -54,10 +54,14 @@ openfaas:
 kafka:
   chart:
     chart: kafka
-    namespace: riff-system
+    namespace: dispatch
     release: transport
     repo: https://riff-charts.storage.googleapis.com
     version: 0.0.1
+  brokers:
+  - transport-kafka.dispatch:9092
+  zookeeperNodes:
+  - transport-zookeeper.dispatch:2181
 rabbitmq:
   chart:
     chart: rabbitmq
@@ -101,6 +105,7 @@ dispatch:
   bootstrapUser:
   insecure: false
   faas: openfaas
+  eventTransport: kafka
   #imageRegistry:
   #  name:
   #  username:

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -202,7 +202,7 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 		}
 	}
 	if uninstallService("kafka") {
-		err = helmUninstall(out, errOut, config.Kafka.Chart.Namespace, config.Kafka.Chart.Release, true)
+		err = helmUninstall(out, errOut, config.Kafka.Chart.Namespace, config.Kafka.Chart.Release, false)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling kafka chart")
 		}

--- a/pkg/event-manager/drivers/http_handlers.go
+++ b/pkg/event-manager/drivers/http_handlers.go
@@ -47,6 +47,7 @@ type ConfigOpts struct {
 	SidecarImage    string
 	TransportType   string
 	RabbitMQURL     string
+	KafkaBrokers    []string
 	TracerURL       string
 	K8sConfig       string
 	DriverNamespace string

--- a/pkg/event-manager/drivers/k8s_backend.go
+++ b/pkg/event-manager/drivers/k8s_backend.go
@@ -264,6 +264,10 @@ func (k *k8sBackend) getSecrets(secretNames []string) (map[string]string, error)
 func (k *k8sBackend) buildSidecarEnv(d *entities.Driver) []corev1.EnvVar {
 	vars := []corev1.EnvVar{
 		{
+			Name:  "DISPATCH_KAFKA_BROKERS",
+			Value: strings.Join(k.config.KafkaBrokers, ","),
+		},
+		{
 			Name:  "DISPATCH_RABBITMQ_URL",
 			Value: k.config.RabbitMQURL,
 		},

--- a/pkg/event-manager/gen/models/subscription.go
+++ b/pkg/event-manager/gen/models/subscription.go
@@ -31,7 +31,7 @@ type Subscription struct {
 	// event type
 	// Required: true
 	// Max Length: 128
-	// Pattern: ^[\*\w\d\-\.]+$
+	// Pattern: ^[\w\d\-\.]+$
 	EventType *string `json:"event-type"`
 
 	// function
@@ -63,7 +63,7 @@ type Subscription struct {
 	// source type
 	// Required: true
 	// Max Length: 32
-	// Pattern: ^(\*|[\w\d\-]+)$
+	// Pattern: ^[\w\d\-]+$
 	SourceType *string `json:"source-type"`
 
 	// status
@@ -139,7 +139,7 @@ func (m *Subscription) validateEventType(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("event-type", "body", string(*m.EventType), `^[\*\w\d\-\.]+$`); err != nil {
+	if err := validate.Pattern("event-type", "body", string(*m.EventType), `^[\w\d\-\.]+$`); err != nil {
 		return err
 	}
 
@@ -217,7 +217,7 @@ func (m *Subscription) validateSourceType(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("source-type", "body", string(*m.SourceType), `^(\*|[\w\d\-]+)$`); err != nil {
+	if err := validate.Pattern("source-type", "body", string(*m.SourceType), `^[\w\d\-]+$`); err != nil {
 		return err
 	}
 

--- a/pkg/event-manager/gen/restapi/embedded_spec.go
+++ b/pkg/event-manager/gen/restapi/embedded_spec.go
@@ -992,7 +992,7 @@ func init() {
         "event-type": {
           "type": "string",
           "maxLength": 128,
-          "pattern": "^[\\*\\w\\d\\-\\.]+$"
+          "pattern": "^[\\w\\d\\-\\.]+$"
         },
         "function": {
           "type": "string",
@@ -1025,7 +1025,7 @@ func init() {
         "source-type": {
           "type": "string",
           "maxLength": 32,
-          "pattern": "^(\\*|[\\w\\d\\-]+)$"
+          "pattern": "^[\\w\\d\\-]+$"
         },
         "status": {
           "$ref": "#/definitions/Status",
@@ -2049,7 +2049,7 @@ func init() {
         "event-type": {
           "type": "string",
           "maxLength": 128,
-          "pattern": "^[\\*\\w\\d\\-\\.]+$"
+          "pattern": "^[\\w\\d\\-\\.]+$"
         },
         "function": {
           "type": "string",
@@ -2082,7 +2082,7 @@ func init() {
         "source-type": {
           "type": "string",
           "maxLength": 32,
-          "pattern": "^(\\*|[\\w\\d\\-]+)$"
+          "pattern": "^[\\w\\d\\-]+$"
         },
         "status": {
           "$ref": "#/definitions/Status",

--- a/pkg/event-manager/handlers_test.go
+++ b/pkg/event-manager/handlers_test.go
@@ -43,7 +43,7 @@ func TestEventsEmitEvent(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := testhelpers.MakeEntityStore(t)
 	queue := &eventsmocks.Transport{}
-	h := Handlers{Store: es, EQ: queue}
+	h := Handlers{Store: es, Transport: queue}
 	testhelpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	queue.On("Publish", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -69,7 +69,7 @@ func TestEventsEmitError(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := testhelpers.MakeEntityStore(t)
 	queue := &eventsmocks.Transport{}
-	h := Handlers{Store: es, EQ: queue}
+	h := Handlers{Store: es, Transport: queue}
 	testhelpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	queue.On("Publish", mock.Anything).Return(nil)

--- a/pkg/event-manager/subscriptions/http_handlers_test.go
+++ b/pkg/event-manager/subscriptions/http_handlers_test.go
@@ -24,7 +24,7 @@ func addSubscriptionEntity(t *testing.T, api *operations.EventManagerAPI, name, 
 		Name:       swag.String(name),
 		EventType:  swag.String(eventType),
 		Function:   swag.String(function),
-		SourceType: swag.String("*"),
+		SourceType: swag.String("dispatch"),
 	}
 	r := httptest.NewRequest("POST", "/v1/event/subscriptions", nil)
 	params := subscriptions.AddSubscriptionParams{

--- a/pkg/event-manager/subscriptions/manager.go
+++ b/pkg/event-manager/subscriptions/manager.go
@@ -74,7 +74,7 @@ func (m *defaultManager) Create(ctx context.Context, sub *entities.Subscription)
 	topic := fmt.Sprintf("%s.%s", sub.SourceType, sub.EventType)
 	eventSub, err := m.queue.Subscribe(ctx, topic, m.handler(sub))
 	if err != nil {
-		err = errors.Wrapf(err, "unable to create an EventQueue subscription for event %s and function %s", sub.EventType, sub.Function)
+		err = errors.Wrapf(err, "unable to create a subscription for event %s and function %s", sub.EventType, sub.Function)
 		log.Error(err)
 		return err
 	}

--- a/pkg/events/transport/kafka.go
+++ b/pkg/events/transport/kafka.go
@@ -5,4 +5,198 @@
 
 package transport
 
-// NO TESTS
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/Shopify/sarama"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/vmware/dispatch/pkg/events"
+	"github.com/vmware/dispatch/pkg/trace"
+)
+
+// Kafka Implements transport interface using Kafka broker.
+type Kafka struct {
+	producer     sarama.SyncProducer
+	consumer     sarama.Consumer
+	producerOnly bool
+}
+
+// OptKafkaSendOnly creates producer only. Subscribe operation will panic
+func OptKafkaSendOnly() func(k *Kafka) error {
+	return func(k *Kafka) error {
+		k.producerOnly = true
+		return nil
+	}
+}
+
+// NewKafka creates an instance of transport based on Kafka broker.
+func NewKafka(brokerAddrs []string, options ...func(k *Kafka) error) (*Kafka, error) {
+	syncProducer, err := sarama.NewSyncProducer(brokerAddrs, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	k := Kafka{
+		producer: syncProducer,
+	}
+	for _, option := range options {
+		// TODO: handle errors from options
+		option(&k)
+	}
+	if k.producerOnly {
+		return &k, nil
+	}
+
+	k.consumer, err = sarama.NewConsumer(brokerAddrs, nil)
+	return &k, err
+}
+
+// Publish publishes an event
+func (k *Kafka) Publish(ctx context.Context, event *events.CloudEvent, topic string, tenant string) error {
+	defer trace.Tracef("topic: %s", event.EventType)()
+	sp, _ := opentracing.StartSpanFromContext(
+		ctx,
+		"Kafka.Publish",
+	)
+	defer sp.Finish()
+
+	msg, err := fromEvent(event)
+	if err != nil {
+		return errors.Wrapf(err, "error when creating Kafka message from CloudEvent for topic %s", topic)
+	}
+	msg.Topic = topic
+
+	err = injectSpan(sp, msg)
+	if err != nil {
+		return errors.Wrap(err, "error injecting opentracing span to Kafka message")
+	}
+
+	if _, _, err = k.producer.SendMessage(msg); err != nil {
+		return errors.Wrap(err, "error sending Kafka message")
+	}
+
+	return nil
+}
+
+// Subscribe subscribes to an event
+func (k *Kafka) Subscribe(ctx context.Context, topic string, handler events.Handler) (events.Subscription, error) {
+	defer trace.Tracef("topic: %s", topic)()
+	sp, _ := opentracing.StartSpanFromContext(
+		ctx,
+		"Kafka.Subscribe",
+	)
+	defer sp.Finish()
+
+	doneChan := make(chan struct{})
+
+	// create partition consumer. Since we are creating only one consumer, we should messages from all partitions
+	// regardless of the partition number we select
+	partitionConsumer, err := k.consumer.ConsumePartition(topic, 0, sarama.OffsetNewest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating a partition consumer for topic %s", topic)
+	}
+
+	go func() {
+		defer trace.Tracef("listening for messages on topic: %s", topic)()
+		for {
+			select {
+			case msg, open := <-partitionConsumer.Messages():
+				if !open {
+					partitionConsumer.Close()
+					return
+				}
+				spCtx, _ := extractSpan(msg)
+				spSub := opentracing.StartSpan(
+					"Kafka.SubscriptionHandler",
+					opentracing.FollowsFrom(spCtx),
+				)
+				func() {
+					defer spSub.Finish()
+					// Update the context with the span for the subsequent reference.
+					ctx = opentracing.ContextWithSpan(context.Background(), spSub)
+					event, err := toEvent(msg)
+					if err != nil {
+						log.Errorf("Error when converting Kafka message to event: %+v", err)
+						return
+					}
+					log.Debugf("Got an event %+v", event)
+					handler(ctx, event)
+				}()
+
+			case <-doneChan:
+				partitionConsumer.Close()
+				return
+			}
+		}
+	}()
+
+	return &subscription{done: doneChan}, nil
+}
+
+// Close closes the transport
+func (k *Kafka) Close() {
+	err := k.producer.Close()
+	if err != nil {
+		log.Warnf("error when closing Kafka transport: %+v", err)
+	}
+}
+
+// injectSpan injects OpenTracing Span into sarama.ProducerMessage.Headers structure.
+func injectSpan(span opentracing.Span, message *sarama.ProducerMessage) error {
+	headers := kafkaProducerMsgHeaders(message.Headers)
+	if err := span.Tracer().Inject(span.Context(), opentracing.TextMap, &headers); err != nil {
+		return err
+	}
+	message.Headers = headers
+	return nil
+}
+
+// extractSpan extracts OpenTracing Span from sarama.ConsumerMessage.Headers structure.
+func extractSpan(message *sarama.ConsumerMessage) (opentracing.SpanContext, error) {
+	headers := kafkaConsumerMsgHeaders(message.Headers)
+	return opentracing.GlobalTracer().Extract(opentracing.TextMap, headers)
+}
+
+// kafkaProducerMsgHeaders implements opentracing.TextMapWriter interface
+type kafkaProducerMsgHeaders []sarama.RecordHeader
+
+// Set sets value val for given key.
+func (h *kafkaProducerMsgHeaders) Set(key, val string) {
+	// This has an obvious problem of O(n) complexity, but the structure
+	// used in sarama for headers does not leave any other options
+	for i, rec := range *h {
+		if string(rec.Key) == key {
+			(*h)[i].Value = []byte(val)
+			return
+		}
+	}
+	*h = append(*h, sarama.RecordHeader{Key: []byte(key), Value: []byte(val)})
+}
+
+// kafkaConsumerMsgHeaders implements opentracing.TextMapReader interface
+type kafkaConsumerMsgHeaders []*sarama.RecordHeader
+
+// ForeachKey executes handler for each key/value  tuple in headers
+func (h *kafkaConsumerMsgHeaders) ForeachKey(handler func(key, val string) error) error {
+	for _, rec := range *h {
+		if err := handler(string(rec.Key), string(rec.Value)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func toEvent(message *sarama.ConsumerMessage) (*events.CloudEvent, error) {
+	event := &events.CloudEvent{}
+	err := json.Unmarshal(message.Value, event)
+	return event, err
+}
+
+func fromEvent(event *events.CloudEvent) (*sarama.ProducerMessage, error) {
+	data, err := json.Marshal(event)
+	return &sarama.ProducerMessage{Value: sarama.ByteEncoder(data)}, err
+}

--- a/pkg/events/transport/kafka_test.go
+++ b/pkg/events/transport/kafka_test.go
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/dispatch/pkg/events"
+)
+
+func TestPublish(t *testing.T) {
+	producer := mocks.NewSyncProducer(t, nil)
+	event := events.NewCloudEventWithDefaults("dispatch")
+	producer.ExpectSendMessageWithCheckerFunctionAndSucceed(func(input []byte) error {
+		var e events.CloudEvent
+		err := json.Unmarshal(input, &e)
+		if err != nil {
+			return err
+		}
+		if e.EventID != event.EventID {
+			return errors.New("not equal")
+		}
+		return nil
+	})
+	kafka := &Kafka{
+		producer: producer,
+	}
+
+	err := kafka.Publish(context.Background(), &event, "dispatch", "dispatch")
+	assert.NoError(t, err)
+	err = producer.Close()
+	assert.NoError(t, err)
+}
+
+func TestSubscribe(t *testing.T) {
+	consumer := mocks.NewConsumer(t, nil)
+	pc := consumer.ExpectConsumePartition("dispatch", 0, sarama.OffsetNewest)
+	pc.ExpectMessagesDrainedOnClose()
+
+	event := events.NewCloudEventWithDefaults("dispatch")
+	eventBytes, _ := json.Marshal(event)
+	pc.YieldMessage(&sarama.ConsumerMessage{
+		Value: eventBytes,
+	})
+
+	kafka := &Kafka{
+		consumer: consumer,
+	}
+
+	done := make(chan struct{})
+
+	_, err := kafka.Subscribe(context.Background(), "dispatch", func(ctx context.Context, e *events.CloudEvent) {
+		assert.Equal(t, event.EventID, e.EventID)
+		done <- struct{}{}
+	})
+	assert.NoError(t, err)
+
+	<-done
+
+}

--- a/swagger/event-manager.yaml
+++ b/swagger/event-manager.yaml
@@ -538,11 +538,11 @@ definitions:
         readOnly: true
       source-type:
         type: string
-        pattern: '^(\*|[\w\d\-]+)$'
+        pattern: '^[\w\d\-]+$'
         maxLength: 32
       event-type:
         type: string
-        pattern: '^[\*\w\d\-\.]+$'
+        pattern: '^[\w\d\-\.]+$'
         maxLength: 128
       function:
         type: string

--- a/vendor/github.com/Shopify/sarama/mocks/README.md
+++ b/vendor/github.com/Shopify/sarama/mocks/README.md
@@ -1,0 +1,13 @@
+# sarama/mocks
+
+The `mocks` subpackage includes mock implementations that implement the interfaces of the major sarama types.
+You can use them to test your sarama applications using dependency injection.
+
+The following mock objects are available:
+
+- [Consumer](https://godoc.org/github.com/Shopify/sarama/mocks#Consumer), which will create [PartitionConsumer](https://godoc.org/github.com/Shopify/sarama/mocks#PartitionConsumer) mocks.
+- [AsyncProducer](https://godoc.org/github.com/Shopify/sarama/mocks#AsyncProducer)
+- [SyncProducer](https://godoc.org/github.com/Shopify/sarama/mocks#SyncProducer)
+
+The mocks allow you to set expectations on them. When you close the mocks, the expectations will be verified,
+and the results will be reported to the `*testing.T` object you provided when creating the mock.

--- a/vendor/github.com/Shopify/sarama/mocks/async_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/async_producer.go
@@ -1,0 +1,174 @@
+package mocks
+
+import (
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// AsyncProducer implements sarama's Producer interface for testing purposes.
+// Before you can send messages to it's Input channel, you have to set expectations
+// so it knows how to handle the input; it returns an error if the number of messages
+// received is bigger then the number of expectations set. You can also set a
+// function in each expectation so that the message value is checked by this function
+// and an error is returned if the match fails.
+type AsyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	closed       chan struct{}
+	input        chan *sarama.ProducerMessage
+	successes    chan *sarama.ProducerMessage
+	errors       chan *sarama.ProducerError
+	lastOffset   int64
+}
+
+// NewAsyncProducer instantiates a new Producer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is used to determine whether it
+// should ack successes on the Successes channel.
+func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	mp := &AsyncProducer{
+		t:            t,
+		closed:       make(chan struct{}, 0),
+		expectations: make([]*producerExpectation, 0),
+		input:        make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		successes:    make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		errors:       make(chan *sarama.ProducerError, config.ChannelBufferSize),
+	}
+
+	go func() {
+		defer func() {
+			close(mp.successes)
+			close(mp.errors)
+		}()
+
+		for msg := range mp.input {
+			mp.l.Lock()
+			if mp.expectations == nil || len(mp.expectations) == 0 {
+				mp.expectations = nil
+				mp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+			} else {
+				expectation := mp.expectations[0]
+				mp.expectations = mp.expectations[1:]
+				if expectation.CheckFunction != nil {
+					if val, err := msg.Value.Encode(); err != nil {
+						mp.t.Errorf("Input message encoding failed: %s", err.Error())
+						mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+					} else {
+						err = expectation.CheckFunction(val)
+						if err != nil {
+							mp.t.Errorf("Check function returned an error: %s", err.Error())
+							mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+						}
+					}
+				}
+				if expectation.Result == errProduceSuccess {
+					mp.lastOffset++
+					if config.Producer.Return.Successes {
+						msg.Offset = mp.lastOffset
+						mp.successes <- msg
+					}
+				} else {
+					if config.Producer.Return.Errors {
+						mp.errors <- &sarama.ProducerError{Err: expectation.Result, Msg: msg}
+					}
+				}
+			}
+			mp.l.Unlock()
+		}
+
+		mp.l.Lock()
+		if len(mp.expectations) > 0 {
+			mp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(mp.expectations))
+		}
+		mp.l.Unlock()
+
+		close(mp.closed)
+	}()
+
+	return mp
+}
+
+////////////////////////////////////////////////
+// Implement Producer interface
+////////////////////////////////////////////////
+
+// AsyncClose corresponds with the AsyncClose method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) AsyncClose() {
+	close(mp.input)
+}
+
+// Close corresponds with the Close method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) Close() error {
+	mp.AsyncClose()
+	<-mp.closed
+	return nil
+}
+
+// Input corresponds with the Input method of sarama's Producer implementation.
+// You have to set expectations on the mock producer before writing messages to the Input
+// channel, so it knows how to handle them. If there is no more remaining expectations and
+// a messages is written to the Input channel, the mock producer will write an error to the test
+// state object.
+func (mp *AsyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return mp.input
+}
+
+// Successes corresponds with the Successes method of sarama's Producer implementation.
+func (mp *AsyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return mp.successes
+}
+
+// Errors corresponds with the Errors method of sarama's Producer implementation.
+func (mp *AsyncProducer) Errors() <-chan *sarama.ProducerError {
+	return mp.errors
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectInputWithCheckerFunctionAndSucceed sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will call the given function to check
+// the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make
+// it available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndSucceed(cf ValueChecker) {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+}
+
+// ExpectInputWithCheckerFunctionAndFail sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will first call the given function to
+// check the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it failed to produce successfully. This means
+// it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndFail(cf ValueChecker, err error) {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+}
+
+// ExpectInputAndSucceed sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it is produced successfully,
+// i.e. it will make it available on the Successes channel if the Producer.Return.Successes setting
+// is set to true.
+func (mp *AsyncProducer) ExpectInputAndSucceed() {
+	mp.ExpectInputWithCheckerFunctionAndSucceed(nil)
+}
+
+// ExpectInputAndFail sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it failed to produce
+// successfully. This means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputAndFail(err error) {
+	mp.ExpectInputWithCheckerFunctionAndFail(nil, err)
+}

--- a/vendor/github.com/Shopify/sarama/mocks/consumer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/consumer.go
@@ -1,0 +1,315 @@
+package mocks
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/Shopify/sarama"
+)
+
+// Consumer implements sarama's Consumer interface for testing purposes.
+// Before you can start consuming from this consumer, you have to register
+// topic/partitions using ExpectConsumePartition, and set expectations on them.
+type Consumer struct {
+	l                  sync.Mutex
+	t                  ErrorReporter
+	config             *sarama.Config
+	partitionConsumers map[string]map[int32]*PartitionConsumer
+	metadata           map[string][]int32
+}
+
+// NewConsumer returns a new mock Consumer instance. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument can be set to nil.
+func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+
+	c := &Consumer{
+		t:                  t,
+		config:             config,
+		partitionConsumers: make(map[string]map[int32]*PartitionConsumer),
+	}
+	return c
+}
+
+///////////////////////////////////////////////////
+// Consumer interface implementation
+///////////////////////////////////////////////////
+
+// ConsumePartition implements the ConsumePartition method from the sarama.Consumer interface.
+// Before you can start consuming a partition, you have to set expectations on it using
+// ExpectConsumePartition. You can only consume a partition once per consumer.
+func (c *Consumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil || c.partitionConsumers[topic][partition] == nil {
+		c.t.Errorf("No expectations set for %s/%d", topic, partition)
+		return nil, errOutOfExpectations
+	}
+
+	pc := c.partitionConsumers[topic][partition]
+	if pc.consumed {
+		return nil, sarama.ConfigurationError("The topic/partition is already being consumed")
+	}
+
+	if pc.offset != AnyOffset && pc.offset != offset {
+		c.t.Errorf("Unexpected offset when calling ConsumePartition for %s/%d. Expected %d, got %d.", topic, partition, pc.offset, offset)
+	}
+
+	pc.consumed = true
+	return pc, nil
+}
+
+// Topics returns a list of topics, as registered with SetMetadata
+func (c *Consumer) Topics() ([]string, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+
+	var result []string
+	for topic := range c.metadata {
+		result = append(result, topic)
+	}
+	return result, nil
+}
+
+// Partitions returns the list of parititons for the given topic, as registered with SetMetadata
+func (c *Consumer) Partitions(topic string) ([]int32, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+	if c.metadata[topic] == nil {
+		return nil, sarama.ErrUnknownTopicOrPartition
+	}
+
+	return c.metadata[topic], nil
+}
+
+func (c *Consumer) HighWaterMarks() map[string]map[int32]int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	hwms := make(map[string]map[int32]int64, len(c.partitionConsumers))
+	for topic, partitionConsumers := range c.partitionConsumers {
+		hwm := make(map[int32]int64, len(partitionConsumers))
+		for partition, pc := range partitionConsumers {
+			hwm[partition] = pc.HighWaterMarkOffset()
+		}
+		hwms[topic] = hwm
+	}
+
+	return hwms
+}
+
+// Close implements the Close method from the sarama.Consumer interface. It will close
+// all registered PartitionConsumer instances.
+func (c *Consumer) Close() error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			_ = partitionConsumer.Close()
+		}
+	}
+
+	return nil
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// SetTopicMetadata sets the clusters topic/partition metadata,
+// which will be returned by Topics() and Partitions().
+func (c *Consumer) SetTopicMetadata(metadata map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	c.metadata = metadata
+}
+
+// ExpectConsumePartition will register a topic/partition, so you can set expectations on it.
+// The registered PartitionConsumer will be returned, so you can set expectations
+// on it using method chaining. Once a topic/partition is registered, you are
+// expected to start consuming it using ConsumePartition. If that doesn't happen,
+// an error will be written to the error reporter once the mock consumer is closed. It will
+// also expect that the
+func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset int64) *PartitionConsumer {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil {
+		c.partitionConsumers[topic] = make(map[int32]*PartitionConsumer)
+	}
+
+	if c.partitionConsumers[topic][partition] == nil {
+		c.partitionConsumers[topic][partition] = &PartitionConsumer{
+			t:         c.t,
+			topic:     topic,
+			partition: partition,
+			offset:    offset,
+			messages:  make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			errors:    make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
+		}
+	}
+
+	return c.partitionConsumers[topic][partition]
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer mock type
+///////////////////////////////////////////////////
+
+// PartitionConsumer implements sarama's PartitionConsumer interface for testing purposes.
+// It is returned by the mock Consumers ConsumePartitionMethod, but only if it is
+// registered first using the Consumer's ExpectConsumePartition method. Before consuming the
+// Errors and Messages channel, you should specify what values will be provided on these
+// channels using YieldMessage and YieldError.
+type PartitionConsumer struct {
+	highWaterMarkOffset     int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	l                       sync.Mutex
+	t                       ErrorReporter
+	topic                   string
+	partition               int32
+	offset                  int64
+	messages                chan *sarama.ConsumerMessage
+	errors                  chan *sarama.ConsumerError
+	singleClose             sync.Once
+	consumed                bool
+	errorsShouldBeDrained   bool
+	messagesShouldBeDrained bool
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer interface implementation
+///////////////////////////////////////////////////
+
+// AsyncClose implements the AsyncClose method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) AsyncClose() {
+	pc.singleClose.Do(func() {
+		close(pc.messages)
+		close(pc.errors)
+	})
+}
+
+// Close implements the Close method from the sarama.PartitionConsumer interface. It will
+// verify whether the partition consumer was actually started.
+func (pc *PartitionConsumer) Close() error {
+	if !pc.consumed {
+		pc.t.Errorf("Expectations set on %s/%d, but no partition consumer was started.", pc.topic, pc.partition)
+		return errPartitionConsumerNotStarted
+	}
+
+	if pc.errorsShouldBeDrained && len(pc.errors) > 0 {
+		pc.t.Errorf("Expected the errors channel for %s/%d to be drained on close, but found %d errors.", pc.topic, pc.partition, len(pc.errors))
+	}
+
+	if pc.messagesShouldBeDrained && len(pc.messages) > 0 {
+		pc.t.Errorf("Expected the messages channel for %s/%d to be drained on close, but found %d messages.", pc.topic, pc.partition, len(pc.messages))
+	}
+
+	pc.AsyncClose()
+
+	var (
+		closeErr error
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		var errs = make(sarama.ConsumerErrors, 0)
+		for err := range pc.errors {
+			errs = append(errs, err)
+		}
+
+		if len(errs) > 0 {
+			closeErr = errs
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.messages {
+			// drain
+		}
+	}()
+
+	wg.Wait()
+	return closeErr
+}
+
+// Errors implements the Errors method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return pc.errors
+}
+
+// Messages implements the Messages method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return pc.messages
+}
+
+func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
+	return atomic.LoadInt64(&pc.highWaterMarkOffset) + 1
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// YieldMessage will yield a messages Messages channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this
+// message was consumed from the Messages channel, because there are legitimate
+// reasons forthis not to happen. ou can call ExpectMessagesDrainedOnClose so it will
+// verify that the channel is empty on close.
+func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	msg.Topic = pc.topic
+	msg.Partition = pc.partition
+	msg.Offset = atomic.AddInt64(&pc.highWaterMarkOffset, 1)
+
+	pc.messages <- msg
+}
+
+// YieldError will yield an error on the Errors channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this error was
+// consumed from the Errors channel, because there are legitimate reasons for this
+// not to happen. You can call ExpectErrorsDrainedOnClose so it will verify that
+// the channel is empty on close.
+func (pc *PartitionConsumer) YieldError(err error) {
+	pc.errors <- &sarama.ConsumerError{
+		Topic:     pc.topic,
+		Partition: pc.partition,
+		Err:       err,
+	}
+}
+
+// ExpectMessagesDrainedOnClose sets an expectation on the partition consumer
+// that the messages channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectMessagesDrainedOnClose() {
+	pc.messagesShouldBeDrained = true
+}
+
+// ExpectErrorsDrainedOnClose sets an expectation on the partition consumer
+// that the errors channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectErrorsDrainedOnClose() {
+	pc.errorsShouldBeDrained = true
+}

--- a/vendor/github.com/Shopify/sarama/mocks/mocks.go
+++ b/vendor/github.com/Shopify/sarama/mocks/mocks.go
@@ -1,0 +1,48 @@
+/*
+Package mocks provides mocks that can be used for testing applications
+that use Sarama. The mock types provided by this package implement the
+interfaces Sarama exports, so you can use them for dependency injection
+in your tests.
+
+All mock instances require you to set expectations on them before you
+can use them. It will determine how the mock will behave. If an
+expectation is not met, it will make your test fail.
+
+NOTE: this package currently does not fall under the API stability
+guarantee of Sarama as it is still considered experimental.
+*/
+package mocks
+
+import (
+	"errors"
+
+	"github.com/Shopify/sarama"
+)
+
+// ErrorReporter is a simple interface that includes the testing.T methods we use to report
+// expectation violations when using the mock objects.
+type ErrorReporter interface {
+	Errorf(string, ...interface{})
+}
+
+// ValueChecker is a function type to be set in each expectation of the producer mocks
+// to check the value passed.
+type ValueChecker func(val []byte) error
+
+var (
+	errProduceSuccess              error = nil
+	errOutOfExpectations                 = errors.New("No more expectations set on mock")
+	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+)
+
+const AnyOffset int64 = -1000
+
+type producerExpectation struct {
+	Result        error
+	CheckFunction ValueChecker
+}
+
+type consumerExpectation struct {
+	Err error
+	Msg *sarama.ConsumerMessage
+}

--- a/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
@@ -1,0 +1,157 @@
+package mocks
+
+import (
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// SyncProducer implements sarama's SyncProducer interface for testing purposes.
+// Before you can use it, you have to set expectations on the mock SyncProducer
+// to tell it how to handle calls to SendMessage, so you can easily test success
+// and failure scenarios.
+type SyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	lastOffset   int64
+}
+
+// NewSyncProducer instantiates a new SyncProducer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is currently unused, but is
+// maintained to be compatible with the async Producer.
+func NewSyncProducer(t ErrorReporter, config *sarama.Config) *SyncProducer {
+	return &SyncProducer{
+		t:            t,
+		expectations: make([]*producerExpectation, 0),
+	}
+}
+
+////////////////////////////////////////////////
+// Implement SyncProducer interface
+////////////////////////////////////////////////
+
+// SendMessage corresponds with the SendMessage method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessage, so it knows
+// how to handle them. You can set a function in each expectation so that the message value
+// checked by this function and an error is returned if the match fails.
+// If there is no more remaining expectation when SendMessage is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		expectation := sp.expectations[0]
+		sp.expectations = sp.expectations[1:]
+		if expectation.CheckFunction != nil {
+			val, err := msg.Value.Encode()
+			if err != nil {
+				sp.t.Errorf("Input message encoding failed: %s", err.Error())
+				return -1, -1, err
+			}
+
+			errCheck := expectation.CheckFunction(val)
+			if errCheck != nil {
+				sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+				return -1, -1, errCheck
+			}
+		}
+		if expectation.Result == errProduceSuccess {
+			sp.lastOffset++
+			msg.Offset = sp.lastOffset
+			return 0, msg.Offset, nil
+		}
+		return -1, -1, expectation.Result
+	}
+	sp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+	return -1, -1, errOutOfExpectations
+}
+
+// SendMessages corresponds with the SendMessages method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessages, so it knows
+// how to handle them. If there is no more remaining expectations when SendMessages is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) >= len(msgs) {
+		expectations := sp.expectations[0:len(msgs)]
+		sp.expectations = sp.expectations[len(msgs):]
+
+		for i, expectation := range expectations {
+			if expectation.CheckFunction != nil {
+				val, err := msgs[i].Value.Encode()
+				if err != nil {
+					sp.t.Errorf("Input message encoding failed: %s", err.Error())
+					return err
+				}
+				errCheck := expectation.CheckFunction(val)
+				if errCheck != nil {
+					sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+					return errCheck
+				}
+			}
+			if expectation.Result != errProduceSuccess {
+				return expectation.Result
+			}
+		}
+		return nil
+	}
+	sp.t.Errorf("Insufficient expectations set on this mock producer to handle the input messages.")
+	return errOutOfExpectations
+}
+
+// Close corresponds with the Close method of sarama's SyncProducer implementation.
+// By closing a mock syncproducer, you also tell it that no more SendMessage calls will follow,
+// so it will write an error to the test state if there's any remaining expectations.
+func (sp *SyncProducer) Close() error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		sp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(sp.expectations))
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectSendMessageWithCheckerFunctionAndSucceed sets an expectation on the mock producer that SendMessage
+// will be called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it produced
+// successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndSucceed(cf ValueChecker) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+}
+
+// ExpectSendMessageWithCheckerFunctionAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it failed
+// to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndFail(cf ValueChecker, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+}
+
+// ExpectSendMessageAndSucceed sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it produced successfully, i.e. by
+// returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageAndSucceed() {
+	sp.ExpectSendMessageWithCheckerFunctionAndSucceed(nil)
+}
+
+// ExpectSendMessageAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it failed to produce
+// successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageAndFail(err error) {
+	sp.ExpectSendMessageWithCheckerFunctionAndFail(nil, err)
+}


### PR DESCRIPTION
**Changes**:
* Adds new event transport based on Kafka Broker
* Kafka is now the default transport regardless of FaaS used. RabbitMQ can still be enabled via config flag.
* Kafka is now deployed to dispatch namespace instead of separate one, and an external deployment can be used (before it was hardcoded to use the built-in one).
* Fixes small issue in CI cleanup task, that was causing failure when deleting orphaned k8s services
* Also includes updated Gopkg.lock caused by the latest `dep`, which lists packages one per line.

**Pending Issues**
Kafka does not support wildcard topic matching. Because of that, subscriptions are now 1:1 (source and event types must be set without `*`). I will create a separate issue to discuss wildcard subscriptions (as it's related to multi-tenancy, performance, and other aspects).

Fixes #255 