### PR TITLE
Add Bearer Auth handler to other services

### DIFF
--- a/pkg/api-manager/handlers.go
+++ b/pkg/api-manager/handlers.go
@@ -120,6 +120,12 @@ func (h *Handlers) ConfigureHandlers(routableAPI middleware.RoutableAPI) {
 		return token, nil
 	}
 
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.Logger = log.Printf
 	a.EndpointAddAPIHandler = endpoint.AddAPIHandlerFunc(h.addAPI)
 	a.EndpointDeleteAPIHandler = endpoint.DeleteAPIHandlerFunc(h.deleteAPI)

--- a/pkg/application-manager/handlers.go
+++ b/pkg/application-manager/handlers.go
@@ -66,6 +66,12 @@ func (h *Handlers) ConfigureHandlers(routableAPI middleware.RoutableAPI) {
 		return token, nil
 	}
 
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.Logger = log.Printf
 	a.ApplicationAddAppHandler = application.AddAppHandlerFunc(h.addApp)
 	a.ApplicationDeleteAppHandler = application.DeleteAppHandlerFunc(h.deleteApp)

--- a/pkg/event-manager/handlers.go
+++ b/pkg/event-manager/handlers.go
@@ -74,6 +74,12 @@ func (h *Handlers) ConfigureHandlers(api middleware.RoutableAPI) {
 		return token, nil
 	}
 
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.Logger = log.Printf
 
 	h.subscriptions = subscriptions.NewHandlers(h.Store, h.Watcher, Flags.OrgID)

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -279,6 +279,12 @@ func (h *Handlers) ConfigureHandlers(api middleware.RoutableAPI) {
 		return token, nil
 	}
 
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.Logger = log.Printf
 	a.StoreAddFunctionHandler = fnstore.AddFunctionHandlerFunc(h.addFunction)
 	a.StoreGetFunctionHandler = fnstore.GetFunctionHandlerFunc(h.getFunction)

--- a/pkg/identity-manager/gen/client/operations/operations_client.go
+++ b/pkg/identity-manager/gen/client/operations/operations_client.go
@@ -59,7 +59,7 @@ func (a *Client) Auth(params *AuthParams, authInfo runtime.ClientAuthInfoWriter)
 }
 
 /*
-Home ans placehold home page
+Home as placeholder home page
 */
 func (a *Client) Home(params *HomeParams, authInfo runtime.ClientAuthInfoWriter) (*HomeOK, error) {
 	// TODO: Validate the params before sending
@@ -117,7 +117,7 @@ func (a *Client) Redirect(params *RedirectParams, authInfo runtime.ClientAuthInf
 }
 
 /*
-Root ans placehold root page no authentication is required at this point
+Root as placeholder root page no authentication is required for this
 */
 func (a *Client) Root(params *RootParams) (*RootOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/identity-manager/gen/restapi/embedded_spec.go
+++ b/pkg/identity-manager/gen/restapi/embedded_spec.go
@@ -46,7 +46,8 @@ func init() {
   "paths": {
     "/": {
       "get": {
-        "summary": "an placehold root page, no authentication is required at this point",
+        "security": [],
+        "summary": "a placeholder root page, no authentication is required for this",
         "operationId": "root",
         "responses": {
           "200": {
@@ -66,14 +67,6 @@ func init() {
     },
     "/v1/iam/auth": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "summary": "handles authorization",
         "operationId": "auth",
         "responses": {
@@ -100,15 +93,7 @@ func init() {
     },
     "/v1/iam/home": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
-        "summary": "an placehold home page",
+        "summary": "a placeholder home page",
         "operationId": "home",
         "responses": {
           "200": {
@@ -128,14 +113,6 @@ func init() {
     },
     "/v1/iam/policy": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -169,14 +146,6 @@ func init() {
         }
       },
       "post": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -235,14 +204,6 @@ func init() {
     },
     "/v1/iam/policy/{policyName}": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "description": "get an Policy by name",
         "produces": [
           "application/json"
@@ -280,14 +241,6 @@ func init() {
         }
       },
       "put": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -338,14 +291,6 @@ func init() {
         }
       },
       "delete": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -394,14 +339,6 @@ func init() {
     },
     "/v1/iam/redirect": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "summary": "redirect to localhost for vs-cli login (testing)",
         "operationId": "redirect",
         "parameters": [
@@ -433,14 +370,6 @@ func init() {
     },
     "/v1/iam/serviceaccount": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -474,11 +403,6 @@ func init() {
         }
       },
       "post": {
-        "security": [
-          {
-            "cookie": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -537,14 +461,6 @@ func init() {
     },
     "/v1/iam/serviceaccount/{serviceAccountName}": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "description": "get a Service Account by name",
         "produces": [
           "application/json"
@@ -582,14 +498,6 @@ func init() {
         }
       },
       "put": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -640,14 +548,6 @@ func init() {
         }
       },
       "delete": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -864,6 +764,14 @@ func init() {
       "in": "header"
     }
   },
+  "security": [
+    {
+      "cookie": []
+    },
+    {
+      "bearer": []
+    }
+  ],
   "tags": [
     {
       "name": "authentication"
@@ -894,7 +802,8 @@ func init() {
   "paths": {
     "/": {
       "get": {
-        "summary": "an placehold root page, no authentication is required at this point",
+        "security": [],
+        "summary": "a placeholder root page, no authentication is required for this",
         "operationId": "root",
         "responses": {
           "200": {
@@ -914,14 +823,6 @@ func init() {
     },
     "/v1/iam/auth": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "summary": "handles authorization",
         "operationId": "auth",
         "responses": {
@@ -948,15 +849,7 @@ func init() {
     },
     "/v1/iam/home": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
-        "summary": "an placehold home page",
+        "summary": "a placeholder home page",
         "operationId": "home",
         "responses": {
           "200": {
@@ -976,14 +869,6 @@ func init() {
     },
     "/v1/iam/policy": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -1017,14 +902,6 @@ func init() {
         }
       },
       "post": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -1083,14 +960,6 @@ func init() {
     },
     "/v1/iam/policy/{policyName}": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "description": "get an Policy by name",
         "produces": [
           "application/json"
@@ -1128,14 +997,6 @@ func init() {
         }
       },
       "put": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -1186,14 +1047,6 @@ func init() {
         }
       },
       "delete": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -1242,14 +1095,6 @@ func init() {
     },
     "/v1/iam/redirect": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "summary": "redirect to localhost for vs-cli login (testing)",
         "operationId": "redirect",
         "parameters": [
@@ -1281,14 +1126,6 @@ func init() {
     },
     "/v1/iam/serviceaccount": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -1322,11 +1159,6 @@ func init() {
         }
       },
       "post": {
-        "security": [
-          {
-            "cookie": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -1385,14 +1217,6 @@ func init() {
     },
     "/v1/iam/serviceaccount/{serviceAccountName}": {
       "get": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "description": "get a Service Account by name",
         "produces": [
           "application/json"
@@ -1430,14 +1254,6 @@ func init() {
         }
       },
       "put": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "consumes": [
           "application/json"
         ],
@@ -1488,14 +1304,6 @@ func init() {
         }
       },
       "delete": {
-        "security": [
-          {
-            "cookie": []
-          },
-          {
-            "bearer": []
-          }
-        ],
         "produces": [
           "application/json"
         ],
@@ -1712,6 +1520,14 @@ func init() {
       "in": "header"
     }
   },
+  "security": [
+    {
+      "cookie": []
+    },
+    {
+      "bearer": []
+    }
+  ],
   "tags": [
     {
       "name": "authentication"

--- a/pkg/identity-manager/gen/restapi/operations/home.go
+++ b/pkg/identity-manager/gen/restapi/operations/home.go
@@ -36,7 +36,7 @@ func NewHome(ctx *middleware.Context, handler HomeHandler) *Home {
 
 /*Home swagger:route GET /v1/iam/home home
 
-an placehold home page
+a placeholder home page
 
 */
 type Home struct {

--- a/pkg/identity-manager/gen/restapi/operations/root.go
+++ b/pkg/identity-manager/gen/restapi/operations/root.go
@@ -36,7 +36,7 @@ func NewRoot(ctx *middleware.Context, handler RootHandler) *Root {
 
 /*Root swagger:route GET / root
 
-an placehold root page, no authentication is required at this point
+a placeholder root page, no authentication is required for this
 
 */
 type Root struct {

--- a/pkg/image-manager/handlers.go
+++ b/pkg/image-manager/handlers.go
@@ -200,6 +200,13 @@ func (h *Handlers) ConfigureHandlers(api middleware.RoutableAPI) {
 		log.Printf("cookie auth: %s\n", token)
 		return token, nil
 	}
+
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.BaseImageAddBaseImageHandler = baseimage.AddBaseImageHandlerFunc(h.addBaseImage)
 	a.BaseImageGetBaseImageByNameHandler = baseimage.GetBaseImageByNameHandlerFunc(h.getBaseImageByName)
 	a.BaseImageGetBaseImagesHandler = baseimage.GetBaseImagesHandlerFunc(h.getBaseImages)

--- a/pkg/secret-store/web/handlers.go
+++ b/pkg/secret-store/web/handlers.go
@@ -92,6 +92,12 @@ func ConfigureHandlers(api middleware.RoutableAPI, h *Handlers) {
 		return token, nil
 	}
 
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.SecretGetSecretsHandler = secret.GetSecretsHandlerFunc(h.getSecrets)
 	a.SecretAddSecretHandler = secret.AddSecretHandlerFunc(h.addSecret)
 	a.SecretGetSecretHandler = secret.GetSecretHandlerFunc(h.getSecret)

--- a/pkg/service-manager/gen/restapi/configure_service_manager.go
+++ b/pkg/service-manager/gen/restapi/configure_service_manager.go
@@ -41,6 +41,11 @@ func configureAPI(api *operations.ServiceManagerAPI) http.Handler {
 
 	api.JSONProducer = runtime.JSONProducer()
 
+	// Applies when the "Authorization" header is set
+	api.BearerAuth = func(token string) (interface{}, error) {
+		return nil, errors.NotImplemented("api key auth (bearer) Authorization from header param [Authorization] has not yet been implemented")
+	}
+
 	// Applies when the "Cookie" header is set
 	api.CookieAuth = func(token string) (interface{}, error) {
 		return nil, errors.NotImplemented("api key auth (cookie) Cookie from header param [Cookie] has not yet been implemented")

--- a/pkg/service-manager/gen/restapi/embedded_spec.go
+++ b/pkg/service-manager/gen/restapi/embedded_spec.go
@@ -555,6 +555,11 @@ func init() {
     }
   },
   "securityDefinitions": {
+    "bearer": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    },
     "cookie": {
       "description": "use cookies for authentication, when the user already logged in",
       "type": "apiKey",
@@ -565,6 +570,9 @@ func init() {
   "security": [
     {
       "cookie": []
+    },
+    {
+      "bearer": []
     }
   ],
   "tags": [
@@ -1111,6 +1119,11 @@ func init() {
     }
   },
   "securityDefinitions": {
+    "bearer": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    },
     "cookie": {
       "description": "use cookies for authentication, when the user already logged in",
       "type": "apiKey",
@@ -1121,6 +1134,9 @@ func init() {
   "security": [
     {
       "cookie": []
+    },
+    {
+      "bearer": []
     }
   ],
   "tags": [

--- a/pkg/service-manager/gen/restapi/operations/service_manager_api.go
+++ b/pkg/service-manager/gen/restapi/operations/service_manager_api.go
@@ -64,6 +64,10 @@ func NewServiceManagerAPI(spec *loads.Document) *ServiceManagerAPI {
 			return middleware.NotImplemented("operation ServiceInstanceGetServiceInstances has not yet been implemented")
 		}),
 
+		// Applies when the "Authorization" header is set
+		BearerAuth: func(token string) (interface{}, error) {
+			return nil, errors.NotImplemented("api key auth (bearer) Authorization from header param [Authorization] has not yet been implemented")
+		},
 		// Applies when the "Cookie" header is set
 		CookieAuth: func(token string) (interface{}, error) {
 			return nil, errors.NotImplemented("api key auth (cookie) Cookie from header param [Cookie] has not yet been implemented")
@@ -102,6 +106,10 @@ type ServiceManagerAPI struct {
 
 	// JSONProducer registers a producer for a "application/json" mime type
 	JSONProducer runtime.Producer
+
+	// BearerAuth registers a function that takes a token and returns a principal
+	// it performs authentication based on an api key Authorization provided in the header
+	BearerAuth func(string) (interface{}, error)
 
 	// CookieAuth registers a function that takes a token and returns a principal
 	// it performs authentication based on an api key Cookie provided in the header
@@ -185,6 +193,10 @@ func (o *ServiceManagerAPI) Validate() error {
 		unregistered = append(unregistered, "JSONProducer")
 	}
 
+	if o.BearerAuth == nil {
+		unregistered = append(unregistered, "AuthorizationAuth")
+	}
+
 	if o.CookieAuth == nil {
 		unregistered = append(unregistered, "CookieAuth")
 	}
@@ -231,6 +243,10 @@ func (o *ServiceManagerAPI) AuthenticatorsFor(schemes map[string]spec.SecuritySc
 	result := make(map[string]runtime.Authenticator)
 	for name, scheme := range schemes {
 		switch name {
+
+		case "bearer":
+
+			result[name] = o.APIKeyAuthenticator(scheme.Name, scheme.In, o.BearerAuth)
 
 		case "cookie":
 

--- a/pkg/service-manager/handlers.go
+++ b/pkg/service-manager/handlers.go
@@ -58,6 +58,13 @@ func (h *Handlers) ConfigureHandlers(api middleware.RoutableAPI) {
 		log.Printf("cookie auth: %s\n", token)
 		return token, nil
 	}
+
+	a.BearerAuth = func(token string) (interface{}, error) {
+		// TODO: Once IAM issues signed tokens, validate them here.
+		log.Printf("bearer auth: %s\n", token)
+		return token, nil
+	}
+
 	a.ServiceClassGetServiceClassByNameHandler = serviceclass.GetServiceClassByNameHandlerFunc(h.getServiceClassByName)
 	a.ServiceClassGetServiceClassesHandler = serviceclass.GetServiceClassesHandlerFunc(h.getServiceClasses)
 

--- a/swagger/identity-manager.yaml
+++ b/swagger/identity-manager.yaml
@@ -19,7 +19,8 @@ basePath: /
 paths:
   /:
     get:
-      summary: an placehold root page, no authentication is required at this point
+      security: []
+      summary: a placeholder root page, no authentication is required for this 
       operationId: root
       responses:
         200:
@@ -32,10 +33,7 @@ paths:
             $ref: "#/definitions/Error"
   /v1/iam/home:
     get:
-      security:
-        - cookie: []
-        - bearer: []
-      summary: an placehold home page
+      summary: a placeholder home page
       operationId: home
       responses:
         200:
@@ -48,9 +46,6 @@ paths:
             $ref: "#/definitions/Error"
   /v1/iam/auth:
     get:
-      security:
-        - cookie: []
-        - bearer: []
       summary: handles authorization
       operationId: auth
       responses:
@@ -68,9 +63,6 @@ paths:
             $ref: "#/definitions/Error"
   /v1/iam/policy:
     post:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - policy
       summary: Add a new policy
@@ -108,9 +100,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     get:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - policy
       summary: List all existing policies
@@ -141,9 +130,6 @@ paths:
       type: string
       pattern: '^[\w\d\-]+$'
     get:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - policy
       summary: Find Policy by name
@@ -169,9 +155,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - policy
       summary: Update a Policy
@@ -205,9 +188,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - policy
       summary: Deletes an Policy
@@ -233,8 +213,6 @@ paths:
             $ref: '#/definitions/Error'
   /v1/iam/serviceaccount:
     post:
-      security:
-        - cookie: []
       tags:
       - serviceaccount
       summary: Add a new service account
@@ -272,9 +250,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     get:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - serviceaccount
       summary: List all existing service accounts
@@ -305,9 +280,6 @@ paths:
       type: string
       pattern: '^[\w\d\-]+$'
     get:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - serviceaccount
       summary: Find Service Account by name
@@ -333,9 +305,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - serviceaccount
       summary: Update a Service Account
@@ -369,9 +338,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      security:
-        - cookie: []
-        - bearer: []
       tags:
       - serviceaccount
       summary: Deletes an Service Account
@@ -397,9 +363,6 @@ paths:
             $ref: '#/definitions/Error'
   /v1/iam/redirect:
     get:
-      security:
-        - cookie: []
-        - bearer: []
       summary: redirect to localhost for vs-cli login (testing)
       operationId: redirect
       parameters:
@@ -418,6 +381,9 @@ paths:
           description: error
           schema:
             $ref: "#/definitions/Error"
+security:
+  - cookie: []
+  - bearer: []
 securityDefinitions:
   cookie:
     type: apiKey

--- a/swagger/service-manager.yaml
+++ b/swagger/service-manager.yaml
@@ -208,12 +208,17 @@ paths:
             $ref: '#/definitions/Error'
 security:
   - cookie: []
+  - bearer: []
 securityDefinitions:
   cookie:
     type: apiKey
     description: use cookies for authentication, when the user already logged in
     in: header
     name: Cookie
+  bearer:
+    type: apiKey
+    name: Authorization
+    in: header
 definitions:
   Error:
     type: object


### PR DESCRIPTION
Service accounts can login using bearer tokens which are validated by identity manager. However, we still need a dummy bearer token handler in all services else the request will get rejected by go-openapi runtime.

In the future, this handler func will validate token issued by identity-manager and will form a second layer of security.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/360)
<!-- Reviewable:end -->
