### PR TITLE
Support bearer token in bootstrap mode

### DIFF
--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -69,6 +69,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: bootstrap_user
+            - name: IAM_BOOTSTRAP_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: bootstrap_public_key
             {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/dispatch/charts/identity-manager/templates/secret.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/secret.yaml
@@ -10,7 +10,8 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.enableBootstrapMode }}
-  bootstrap_user: {{ default "" .Values.bootstrapUser             | trim | b64enc | quote }}
+  bootstrap_user:       {{ default "" .Values.bootstrapUser             | trim | b64enc | quote }}
+  bootstrap_public_key: {{ default "" .Values.bootstrapPublicKey        | trim | b64enc | quote }}
   {{- end }}
   client_id:      {{ default "" .Values.oauth2proxy.clientID      | trim | b64enc | quote }}
   client_secret:  {{ default "" .Values.oauth2proxy.clientSecret  | trim | b64enc | quote }}

--- a/charts/dispatch/charts/identity-manager/values.yaml
+++ b/charts/dispatch/charts/identity-manager/values.yaml
@@ -4,8 +4,13 @@
 replicaCount: 1
 maxUnavailable: 0
 maxSurge: 1
-bootstrapUser:
+
+# Bootstrap mode settings
 enableBootstrapMode: false
+bootstrapUser:
+# Base64 Encoded public key for the bootstrap user
+bootstrapPublicKey:
+
 image:
   # host: vmware
   repository: dispatch-identity-manager

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -142,24 +142,25 @@ type serviceCatalogConfig struct {
 	K8sServiceCatalog *k8sServiceCatalogConfig `json:"k8sservicecatalog,omitempty"`
 }
 type dispatchInstallConfig struct {
-	Chart          *chartConfig          `json:"chart,omitempty" validate:"required"`
-	Host           string                `json:"host,omitempty" validate:"required,hostname|ip"`
-	Port           int                   `json:"port,omitempty" validate:"required"`
-	Organization   string                `json:"organization,omitempty" validate:"required"`
-	BootstrapUser  string                `json:"bootstrapUser,omitempty" validate:"omitempty"`
-	Image          *imageConfig          `json:"image,omitempty" validate:"omitempty"`
-	Debug          bool                  `json:"debug,omitempty" validate:"omitempty"`
-	Trace          bool                  `json:"trace,omitempty" validate:"omitempty"`
-	Database       string                `json:"database,omitempty" validate:"required,eq=postgres"`
-	PersistData    bool                  `json:"persistData,omitempty" validate:"omitempty"`
-	ImageRegistry  *imageRegistryConfig  `json:"imageRegistry,omitempty" validate:"omitempty"`
-	OAuth2Proxy    *oauth2ProxyConfig    `json:"oauth2Proxy,omitempty" validate:"required"`
-	TLS            *tlsConfig            `json:"tls,omitempty" validate:"required"`
-	SkipAuth       bool                  `json:"skipAuth,omitempty" validate:"omitempty"`
-	Insecure       bool                  `json:"insecure,omitempty" validate:"omitempty"`
-	Faas           string                `json:"faas,omitempty" validate:"required,eq=openfaas|eq=riff"`
-	EventTransport string                `json:"eventTransport,omitempty" validate:"required,eq=kafka|eq=rabbitmq"`
-	Service        *serviceCatalogConfig `json:"service,omitemtpy" validate:"required"`
+	Chart              *chartConfig          `json:"chart,omitempty" validate:"required"`
+	Host               string                `json:"host,omitempty" validate:"required,hostname|ip"`
+	Port               int                   `json:"port,omitempty" validate:"required"`
+	Organization       string                `json:"organization,omitempty" validate:"required"`
+	BootstrapUser      string                `json:"bootstrapUser,omitempty" validate:"omitempty"`
+	BootstrapPublicKey string                `json:"bootstrapPublicKey,omitempty" validate:"omitempty"`
+	Image              *imageConfig          `json:"image,omitempty" validate:"omitempty"`
+	Debug              bool                  `json:"debug,omitempty" validate:"omitempty"`
+	Trace              bool                  `json:"trace,omitempty" validate:"omitempty"`
+	Database           string                `json:"database,omitempty" validate:"required,eq=postgres"`
+	PersistData        bool                  `json:"persistData,omitempty" validate:"omitempty"`
+	ImageRegistry      *imageRegistryConfig  `json:"imageRegistry,omitempty" validate:"omitempty"`
+	OAuth2Proxy        *oauth2ProxyConfig    `json:"oauth2Proxy,omitempty" validate:"required"`
+	TLS                *tlsConfig            `json:"tls,omitempty" validate:"required"`
+	SkipAuth           bool                  `json:"skipAuth,omitempty" validate:"omitempty"`
+	Insecure           bool                  `json:"insecure,omitempty" validate:"omitempty"`
+	Faas               string                `json:"faas,omitempty" validate:"required,eq=openfaas|eq=riff"`
+	EventTransport     string                `json:"eventTransport,omitempty" validate:"required,eq=kafka|eq=rabbitmq"`
+	Service            *serviceCatalogConfig `json:"service,omitemtpy" validate:"required"`
 }
 
 type installConfig struct {
@@ -903,6 +904,9 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 		if config.DispatchConfig.BootstrapUser != "" {
 			dispatchOpts["identity-manager.enableBootstrapMode"] = "true"
 			dispatchOpts["identity-manager.bootstrapUser"] = config.DispatchConfig.BootstrapUser
+			if config.DispatchConfig.BootstrapPublicKey != "" {
+				dispatchOpts["identity-manager.bootstrapPublicKey"] = config.DispatchConfig.BootstrapPublicKey
+			}
 		}
 		if installDebug {
 			for k, v := range dispatchOpts {

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -103,6 +103,7 @@ dispatch:
   persistData: false
   skipAuth: false
   bootstrapUser:
+  bootstrapPublicKey:
   insecure: false
   faas: openfaas
   eventTransport: kafka


### PR DESCRIPTION
Adds support for bearer token based auth in bootstrap mode. Reads `IAM_BOOTSTRAP_PUBLIC_KEY` env var injected from secrets and uses it to authenticate the bootstrap user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/362)
<!-- Reviewable:end -->
