### PR TITLE
Workaround for scheduling issue in concourse

### DIFF
--- a/ci/pipelines/e2e.yml
+++ b/ci/pipelines/e2e.yml
@@ -31,6 +31,11 @@ resources:
     access_key_id: ((s3-logs-bucket-access-key))
     secret_access_key: ((s3-logs-bucket-secret-key))
 
+# Workaround for https://github.com/concourse/concourse/issues/736
+- name: time-trigger
+  type: time
+  source: {interval: 24h}
+
 - name: keyval
   type: keyval
 
@@ -176,6 +181,7 @@ jobs:
         build: build-context/service-manager
         dockerfile: build-context/service-manager/Dockerfile
         tag: build-context/tag
+  - put: time-trigger
   - put: dispatch-pr
     params: {path: dispatch, context: dispatch-e2e-images, status: success}
 
@@ -189,6 +195,10 @@ jobs:
       trigger: true
       version: every
     - get: keyval
+      passed: [build-images]
+    - get: time-trigger
+      version: every
+      trigger: true
       passed: [build-images]
   - put: dispatch-pr
     params: {path: dispatch, context: dispatch-e2e-openfaas, status: pending}
@@ -246,6 +256,10 @@ jobs:
       trigger: true
       version: every
     - get: keyval
+      passed: [build-images]
+    - get: time-trigger
+      version: every
+      trigger: true
       passed: [build-images]
   - put: dispatch-pr
     params: {path: dispatch, context: dispatch-e2e-riff, status: pending}


### PR DESCRIPTION
Sometimes jobs are not getting triggered multiple jobs in a single pipeline run together, and they don't finish in order they were triggered by PRs (see issue https://github.com/concourse/concourse/issues/736). This patch adds a workaround mentioned in https://github.com/concourse/concourse/issues/736#issuecomment-264546041. In essence, the `time` resource is used as an additional trigger. When `build-images` finishes, it updates the time resource, effectively creating new version of it, which in turn will trigger the tests jobs. Because the time resource is updated at the end of `build-images` job, it's not affected by the time it takes to finish the job. 