### PR TITLE
Encode public key when enable bootstrap mode

### DIFF
--- a/pkg/dispatchcli/cmd/manage.go
+++ b/pkg/dispatchcli/cmd/manage.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -143,7 +144,8 @@ func runManage(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
 		// get public key if provided
 		if publicKeyPath != "" {
 			if publicKeyBytes, err := ioutil.ReadFile(publicKeyPath); err == nil {
-				data["bootstrap_public_key"] = publicKeyBytes
+				encodedPublicKeyString := base64.StdEncoding.EncodeToString(publicKeyBytes)
+				data["bootstrap_public_key"] = []byte(encodedPublicKeyString)
 			} else {
 				return errors.Wrap(err, "Failed to load public key file")
 			}


### PR DESCRIPTION
Solve #383. 

Tests:
```bash
$ dispatch manage --enable-bootstrap-mode -f install.yaml --bootstrap-user bootstrap_user --public-key ./bootstrap.key.pub
bootstrap mode enabled, please turn off in production mode

$ dispatch iam get policy --service-account bootstrap_user --jwt-private-key ./bootstrap.key
Note: rule contents are omitted, please use --wide or -w to print them
          NAME         |         CREATED DATE
-----------------------------------------------------
  example-user-policy  | Sat Jan  1 14:30:51 PST 0000
```