### PR TITLE
Upgrade gke cluster version

### DIFF
--- a/ci/e2e/gke-cluster-create.yml
+++ b/ci/e2e/gke-cluster-create.yml
@@ -10,7 +10,7 @@ image_resource:
 params:
   GKE_KEY:
   GKE_PROJECT_ID:
-  K8S_VERSION: 1.8.9-gke.1
+  K8S_VERSION: 1.8.10-gke.0
   GKE_ZONE: us-west1-c
   CLUSTER_NAME_SUFFIX: job
 


### PR DESCRIPTION
Cluster version 1.8.9-gke.1 seems to have been pulled out due to a security vulnerability which is causing the CI to fail.
https://ci.dispatchframework.io/builds/2023