### PR TITLE
CLI: payload can be any value, not necessarily a map

### DIFF
--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -107,6 +107,10 @@ load variables
     run_with_retry "dispatch exec http --wait --json | jq -r .output.status" "200" 5 5
 }
 
+@test "Execute function with a literal value payload" {
+    run_with_retry "dispatch exec http --input='42' --wait --json | jq -r .output.status" "200" 5 5
+}
+
 @test "Update function python" {
     skip_if_faas riff
 

--- a/pkg/dispatchcli/cmd/exec.go
+++ b/pkg/dispatchcli/cmd/exec.go
@@ -61,7 +61,7 @@ func validateFnExecFunc(errOut io.Writer) func(cmd *cobra.Command, args []string
 
 func runExec(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
 	functionName := args[0]
-	var input map[string]interface{}
+	var input interface{}
 	err := json.Unmarshal([]byte(execInput), &input)
 	if err != nil {
 		fmt.Fprintf(errOut, "Error when parsing function parameters %s\n", execInput)


### PR DESCRIPTION
Well, any JSON-encodable value.