### PR TITLE
Fix IAM documentation

### DIFF
--- a/docs/_guides/setup-authentication.md
+++ b/docs/_guides/setup-authentication.md
@@ -116,15 +116,16 @@ dispatch:
     cookieSecret: YVBLBQXd4CZo1vnUTSM/3w==
 ```
 
-## 3. Enable Bootstrap Mode
+## 3. Install Dispatch in Bootstrap Mode
 
 If you are enabling Authentication in dispatch for the first time, you will have to install it in the bootstrap mode.
-In the bootstrap mode, the specified bootstrap user can configure the inital authorization policies. Without any authorization policies, even if the authentication is successful, users will be denied access to protected resources in dispatch.
+In the bootstrap mode, the specified bootstrap user can configure the initial authorization policies. Without any authorization policies, even if the authentication is successful, users will be denied access to protected resources in dispatch.
+
+The bootstrap user is identified by the email address associated with the user in your Identity Provider, e.g. with GitHub, this is the primary email address associated with your github account.
+With OpenID Connect providers, this is normally the email address associated with your user account.
 
 You should always **disable** the bootstrap mode as soon as you have setup the required policies for an admin user.
 
-
-> **Note:** If you have a running dispatch deployment with `skipAuth: true` in the dispatch `config.yaml`, you need to set it to `false` as part of this step for the bootstrap mode to work.
 
 ```yaml
 ...
@@ -136,21 +137,37 @@ dispatch:
 
 ```
 
-## 4. Update Dispatch
-
-Install/Update your Dispatch installation as normal, with
+Install Dispatch with
 ```bash
 dispatch install -f config.yaml
 ```
-> **TIP:** Dispatch install command can be used to update your running dispatch deployment.
 
-If you already have a Dispatch deployment, you can also use *manage* subcommand to enable the bootstrap mode:
+#### 3.1 Enabling Bootstrap Mode for Existing Deployment
+
+If you have an existing dispatch deployment with `skipAuth: true` in the dispatch `config.yaml`, you need to set it to `false` as part of this step for the bootstrap mode to work.
+
+```yaml
+...
+dispatch:
+  # Ensure skipAuth is unset or false (default is false)
+  skipAuth: false
+  # This must be a valid user managed by your identity provider
+  bootstrapUser: xyz@example.com
+
+```
+
+Update Dispatch installation with
+```bash
+dispatch install -f config.yaml
+```
+
+If you already have a Dispatch deployment with `skipAuth: false`, you can use the *manage* subcommand to enable the bootstrap mode:
 ```bash
 dispatch manage --enable-bootstrap-mode --bootstrap-user <BOOTSTRAP_USER> -f config.yaml
 ```
 > **NOTE:** Please wait about 30 seconds for the changes to be applied.
 
-## 5. Login to Dispatch
+## 4. Login to Dispatch
 
 Login to dispatch with
 ```bash
@@ -165,7 +182,7 @@ Sign-in to your Identity Provider as the `bootrstrapUser` that you configured in
 Cookie received. Please close this page.
 ```
 
-## 6. Configure Policies
+## 5. Configure Policies
 
 Once you have logged in as the `bootstrapUser`, you should setup the initial authorization policies for an admin user and then disable the bootstrap mode.
 
@@ -199,7 +216,7 @@ To verify that the admin policy is in effect, logout and login as the admin user
 dispatch logout
 ```
 
-## 7. Disable Bootstrap Mode [**Important!!!**]
+## 6. Disable Bootstrap Mode [**Important!!!**]
 
 The bootstrap mode is only to setup the initial authorization policies and must be disabled as soon as you have created an admin policy. To disable the bootstrap mode, simply use *manage* subcommand:
 ```bash

--- a/docs/_guides/setup-service-acccount-authentication.md
+++ b/docs/_guides/setup-service-acccount-authentication.md
@@ -1,95 +1,54 @@
 ---
 layout: default
 ---
-# Service Account Authentication in Dispatch
-Apart from the [Identity Provider (IDP)]({{ '/documentation/guides/setup-authentication' | relative_url }}) workflow, Dispatch also provides service account authentication workflow.
+# Service Accounts in Dispatch
 
-Service account authentication requires valid public/private key pair to authenticate requests. The private key will be used in client side to sign JWT token and in authentication header of request. The public key will be used in server side to validate the incoming requests that contain JWT authentication header.
+Users in Dispatch are managed by an external [Identity Provider (IDP)]({{ '/documentation/guides/setup-authentication' | relative_url }}) e.g OpenID Connect provider like vIDM, Dex etc. As such, when users login to dispatch they will be redirected to the configured OIDC provider for authentication.
+This authentication step involves the end-user and that works in their best interest. For non-human users, like a CI/CD system, a third-party application or service interacting with Dispatch API's, a special kind of user account is required.
+Dispatch calls them as Service Accounts and they are completely managed by Dispatch's Identity Manager.
 
-Use following to generate key pairs:
+Service accounts can be created and managed using Dispatch CLI or API's. Service account authentication involves the generation of a JWT bearer token by the client and the token must be signed using one of the "RS256/384/512" - JSON Web Signature algorithms. If you are using the CLI, most of the token generation and signing is already taken care.
+
+## 1. Generate a RSA key pair
+Before creating a service account, we need to generate a RSA public/private key pair. You can use any key length greater than 2048 bits.  The private key will be used by the client to sign the JWT token and specify it as a bearer token in the Authorization HTTP header of any API request. The public key will be used on server side to validate the JWT token in the API requests.
+Hence, Dispatch only requires you to specify the public key when creating a service account in Dispatch. Make sure to keep the private key safe with the process or application that will interact with Dispatch.
+
+Use following openssl commands to generate a key pair:
 
 ```bash
 $ openssl genrsa -out <PRIVATE_KEY> 4096
 $ openssl rsa -in <PRIVATE_KEY> -pubout -outform PEM -out <PUBLIC_KEY>
 ```
 
-This document provides instructions for how to setup service account authentication.
-
-> **NOTE:** Setting up service account authentication requires the privileged access to underlying kubernetes cluster
-
-
-## 1. Enable Bootstrap Mode with Public Key
-There are two ways of enabling bootstrap mode using public key:
-### [Option 1] Enable bootstrap mode during Dispatch install
-Provide bootstrap user and bootstrap public key in dispatch's install config file. Edit dispatch's install config.yaml to add the information.
-
-```yaml
-...
-dispatch:
-...
-  bootstrapUser: <BOOTSTRAP_USER>
-  bootstrapPublicKey: <ENCODED_BOOTSTRAP_PUBLIC_KEY>
-```
-
-> **NOTE:** ``boostrapPublicKey`` expects a **base64 encoded** public key, failed to provide encoded public key will cause validation failure on server side.
-
-
-### [Option 2] Enable bootstrap mode using `manage` subcommand
-If using `manage` subcommand, ``bootstrapUser`` and ``bootstrapPublicKey`` are not required during dispatch install. After dispatch installation, use following to enable bootstrap mode by providing a bootstrap user name and public key. (Assume ``install.yaml`` is the dispatch install config file)
+## 2. Create Service Account
+Login to dispatch and use the public key from the previous setup to create a service account:
 
 ```bash
-$ dispatch manage --enable-bootstrap-mode --bootstrap-user <BOOTSTRAP_USER> --public-key <BOOTSTRAP_PUBLIC_KEY_FILE> -f install.yaml
-> bootstrap mode enabled, please turn off in production mode
-```
-
-> **NOTEs:**
-> * public key will be read from `<BOOTSTRAP_PUBLIC_KEY_FILE>` and encoded by dispatch, no need to encode it manually
-> * `manage` operations require k8s cluster access, use `--kubeconfig <K8s_config_file>` flag to speficy file path, see ``dispatch manage -h`` for more
-
-After enabling bootstrap mode, wait a short period of time (~30 seconds) for the changes to be applied.
-
-
-## 2. Create Service Account and Policy
-Now, Dispatch is in bootstrap mode, we need the `bootstrapPrivateKey`, which is associated with above `bootstrapPublicKey` during install, to authenticate and make requests. Put the `bootstrapPrivateKey`
-file path in the following `--jwt-private-key` flag for authenticating.
-
-Then create a public/private key pair for the service account that is going to be created. Use following to create the service account and policy.
-
-```bash
-# Create service account - example-user
+# Create service account - example-svc-account
 $ dispatch iam create serviceaccount \
-      example-user \
-      --public-key ./example-user.key.pub \
-      --service-account <BOOTSTRAP_USER> \
-      --jwt-private-key <BOOTSTRAP_PRIVATE_KEY_FILE>
-> Create service account: example-user
+      example-svc-account \
+      --public-key ./example-user.key.pub
+> Create service account: example-svc-account
+```
+The name of the service account is important when generating the jwt token and it must be specified in the issuer field `iss` of the jwt payload. More about this is covered in the usage section below.
 
+## 3. Create a Policy
+Similar to user accounts, service accounts are not useful unless an access policy is created. Create a policy and associate it with the service account:
+```bash
 # Create policy for the service account
 $ dispatch iam create policy \
-      example-user-policy \
-      --subject example-user --action "*" --resource "*" \
-      --service-account <BOOTSTRAP_USER> \
-      --jwt-private-key <BOOTSTRAP_PRIVATE_KEY_FILE>
-> Created policy: example-user-policy
+      example-svc-policy \
+      --subject example-svc-account --action "*" --resource "function" \
+      --service-account <SERVICE_ACCOUNT_NAME>
+> Created policy: example-svc-policy
 ```
 
-where *example-user.key.pub* is the public key file of service account *example-user*, the associated private key will used during making requests.
-
-
-## 3. Disable Bootstrap Mode
-Bootstrap mode only allows operations on iam resources, and we have created *example-user* with a policy, now we should disable bootstrap mode by `manage` subcommand:
+## 4. Using the Service Account
+When invoking dispatch commands, specify the private key associated with the *example-user.key.pub* that we used to create this service account in the `--jwt-private-key` flag. Dispatch CLI will
+use this private key to sign the generated JWT token.
 
 ```bash
-$ dispatch manage --disable-bootstrap-mode -f install.yaml
-> bootstrap mode disabled
-```
-Just a reminder, please wait about 30 seconds for changes to be applied.
-
-## 4. Verify the Service Account
-After disabling bootstrap mode, we can verify the service account just created as following, where the *example-user.key* is the associated private key of *example-user.key.pub* that we used to create this service account.
-
-```bash
-$ dispatch create -f seed.yaml --service-account example-user --jwt-private-key ../example-user.key
+$ dispatch create -f seed.yaml --service-account example-svc-account --jwt-private-key ../example-user.key
 Created BaseImage: nodejs6-base
 Created BaseImage: python3-base
 Created BaseImage: powershell-base
@@ -102,7 +61,7 @@ Created Function: hello-js
 Created Function: hello-ps1
 Created Secret: open-sesame
 
-$ dispatch get base-image --service-account example-user --jwt-private-key ../example-user.key
+$ dispatch get base-image --service-account example-svc-account --jwt-private-key ../example-user.key
        NAME       |                   URL                   | STATUS |         CREATED DATE
 ------------------------------------------------------------------------------------------------
   python3-base    | vmware/dispatch-python3-base:0.0.2-dev1 | READY  | Sat Jan  1 14:40:18 PST 0000
@@ -110,5 +69,13 @@ $ dispatch get base-image --service-account example-user --jwt-private-key ../ex
   powershell-base | vmware/dispatch-powershell-base:0.0.3   | READY  | Sat Jan  1 14:40:18 PST 0000
 ```
 
-From above, the service account *example-user* can pass the authentication.
+If you are directly calling the API instead of using the CLI, you need to create a JWT payload as follows:
 
+```json
+{
+ "iss": "example-svc-account",
+ "iat": "1525930134",
+ "exp": "1525865330"
+}
+```
+, then sign the payload with the associated private key using one of RS256/384/512 algorithms and present it in the HTTP Authorization header as a bearer token e.g `Authorization : Bearer <JWT_TOKEN>`. You can learn more about JWT tokens [here](https://jwt.io/introduction/).


### PR DESCRIPTION
* Clarify bootstrap mode related doc in auth
* Fix service account documentation
  * Bootstrap mode is independent of service account management. If needed,
  setting up bootstrap mode with a service account user must be a separate
  guide and should not be mentioned alongside service account mgmt. IMO,
  it's an advanced use-case (like for Dispatch CI) and not required for most
  setup. Mentioning it will be cause more confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/425)
<!-- Reviewable:end -->
