### PR TITLE
Adding support for private registries (image pull)

### DIFF
--- a/charts/dispatch/charts/function-manager/templates/config-map.yaml
+++ b/charts/dispatch/charts/function-manager/templates/config-map.yaml
@@ -19,7 +19,8 @@ data:
           "gateway": "{{ .Values.faas.openfaas.gateway }}",
           "funcNamespace": "{{ .Values.faas.openfaas.namespace }}",
           "funcDefaultLimits": {{ toJson .Values.faas.openfaas.funcDefaultLimits }},
-          "funcDefaultRequests": {{ toJson .Values.faas.openfaas.funcDefaultRequests }}
+          "funcDefaultRequests": {{ toJson .Values.faas.openfaas.funcDefaultRequests }},
+          "imagePullSecret": "{{ .Values.faas.openfaas.imagePullSecret }}"
         },
         "riff": {
           "kafkaBrokers": ["{{ join ", " .Values.global.kafka.brokers }}"],

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -46,6 +46,7 @@ faas:
   openfaas:
     gateway: "http://gateway.openfaas:8080/"
     namespace: openfaas
+    imagePullSecret:
     # Set the default resource limits for the function containers
     funcDefaultLimits:
     #  CPU: 500m

--- a/charts/openfaas/templates/rbac.yaml
+++ b/charts/openfaas/templates/rbac.yaml
@@ -34,6 +34,14 @@ rules:
       - create
       - delete
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/cmd/function-manager/main.go
+++ b/cmd/function-manager/main.go
@@ -45,6 +45,7 @@ var drivers = map[string]func(string) functions.FaaSDriver{
 			FuncNamespace:       config.Global.Function.OpenFaas.FuncNamespace,
 			FuncDefaultRequests: config.Global.Function.OpenFaas.FuncDefaultRequests,
 			FuncDefaultLimits:   config.Global.Function.OpenFaas.FuncDefaultLimits,
+			ImagePullSecret:     config.Global.Function.OpenFaas.ImagePullSecret,
 		})
 		if err != nil {
 			log.Fatalf("Error starting OpenFaaS driver: %+v", err)

--- a/docs/_guides/advanced.md
+++ b/docs/_guides/advanced.md
@@ -146,6 +146,25 @@ Docker hub example:
 $ kubectl create secret docker-registry regsecret --docker-server='https://index.docker.io/v1/' --docker-username=dockerhub-user --docker-password='...' --docker-email=dockerhub-user@gmail.com
 ```
 
+### Image Pull Secrets
+
+Depending on the image registry, secrets may be required to pull images.  **Only OpenFaaS supports image
+pull secrets**.  To configure image pull secrets simply configure installation:
+
+```yaml
+apiGateway:
+  ...
+dispatch:
+  ...
+  imagePullSecret: pull-secret
+  imageRegistry:
+    name: some-repo.example.com
+    username: username
+    password: password
+```
+
+The installer will take care of creating a secret and associating it to OpenFaaS.
+
 ## Import self-signed TLS certificates into Kubernetes secret
 
 To be able to securely connect to Dispatch, we need to set up a TLS certificate.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,7 @@ type OpenFaas struct {
 	Gateway             string             `json:"gateway"`
 	K8sConfig           string             `json:"k8sConfig"`
 	FuncNamespace       string             `json:"funcNamespace"`
+	ImagePullSecret     string             `json:"imagePullSecret"`
 	FuncDefaultLimits   *FunctionResources `json:"funcDefaultLimits"`
 	FuncDefaultRequests *FunctionResources `json:"funcDefaultRequests"`
 }

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -127,6 +127,7 @@ dispatch:
   #  username:
   #  email:
   #  password:
+  imagePullSecret:
   service:
     catalog: k8sservicecatalog
     k8sservicecatalog:

--- a/pkg/functions/builder.go
+++ b/pkg/functions/builder.go
@@ -84,8 +84,11 @@ func (ib *DockerImageBuilder) BuildImage(faas, fnID string, exec *Exec) (string,
 	defer os.RemoveAll(tmpDir)
 
 	log.Debugf("Created tmpDir: %s", tmpDir)
-
-	if err := images.DockerError(ib.docker.ImagePull(context.Background(), exec.Image, types.ImagePullOptions{})); err != nil {
+	opts := types.ImagePullOptions{}
+	if ib.registryAuth != "" {
+		opts.RegistryAuth = ib.registryAuth
+	}
+	if err := images.DockerError(ib.docker.ImagePull(context.Background(), exec.Image, opts)); err != nil {
 		return "", errors.Wrapf(err, "failed to pull image '%s'", exec.Image)
 	}
 

--- a/pkg/functions/openfaas/driver.go
+++ b/pkg/functions/openfaas/driver.go
@@ -48,6 +48,7 @@ type Config struct {
 	FuncDefaultLimits   *config.FunctionResources
 	FuncDefaultRequests *config.FunctionResources
 	CreateTimeout       *int
+	ImagePullSecret     string
 }
 
 type ofDriver struct {
@@ -59,7 +60,8 @@ type ofDriver struct {
 
 	deployments v1beta1.DeploymentInterface
 
-	createTimeout int
+	createTimeout   int
+	imagePullSecret string
 
 	funcDefaultLimits   *requests.FunctionResources
 	funcDefaultRequests *requests.FunctionResources
@@ -114,6 +116,9 @@ func New(config *Config) (functions.FaaSDriver, error) {
 	if config.CreateTimeout != nil {
 		d.createTimeout = *config.CreateTimeout
 	}
+	if config.ImagePullSecret != "" {
+		d.imagePullSecret = config.ImagePullSecret
+	}
 
 	return d, nil
 }
@@ -142,6 +147,9 @@ func (d *ofDriver) Create(f *functions.Function, exec *functions.Exec) error {
 		Constraints: []string{},
 		Limits:      d.funcDefaultLimits,
 		Requests:    d.funcDefaultRequests,
+	}
+	if d.imagePullSecret != "" {
+		req.Secrets = []string{d.imagePullSecret}
 	}
 
 	reqBytes, _ := json.Marshal(&req)


### PR DESCRIPTION
* Previously functions could not pull private images
* Also fix single-namespace install
  - transports now install correctly
* Only supports OpenFaaS
  - Riff does not support image pull secrets

Needs e2e tests.  Tested manually on minikube

Fix: #431 #430 