### PR TITLE
Use command string in generate script to ensure consistency

### DIFF
--- a/ci/units/swagger-generate.yml
+++ b/ci/units/swagger-generate.yml
@@ -22,6 +22,7 @@ run:
     export GOPATH=$PWD
 
     cd $GOPATH/src/github.com/vmware/dispatch
+    export WORKDIR=`pwd`
     make gen-clean
     make generate > /dev/null
     if [[ ! -z $(git status --porcelain) ]]

--- a/scripts/generate-models.sh
+++ b/scripts/generate-models.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-: ${WORKDIR:="-o"}
+: ${WORKDIR:="/root/go/src/github.com/vmware/dispatch"}
 : ${CI_IMAGE:="vmware/dispatch-golang-ci:1.10-20180512"}
 : ${QUIET:="-q"}
 : ${PACKAGE:="github.com/vmware/dispatch/pkg/api/v1"}
@@ -10,9 +10,13 @@ echo Using image ${CI_IMAGE}
 
 TARGET=${1}
 
+GENERATE_COMMAND="pushd ${WORKDIR} && \
+         CGO_ENABLED=0 swagger generate spec ${QUIET} -o ${TARGET} -b ${PACKAGE} -m && \
+         popd"
+
 if [[ -z ${CI} ]]; then
-docker run --rm -v `pwd`:${WORKDIR} ${CI_IMAGE} bash -c "cd ${WORKDIR} && CGO_ENABLED=0 swagger generate spec ${QUIET} -o ${TARGET} -b ${PACKAGE} -m"
+docker run --rm -v `pwd`:${WORKDIR} ${CI_IMAGE} bash -c "${GENERATE_COMMAND}"
 else
     echo "CI is set to ${CI}"
-    CGO_ENABLED=0 swagger generate spec ${QUIET} -o ${TARGET} -b ${PACKAGE} -m
+    bash -c "${GENERATE_COMMAND}"
 fi


### PR DESCRIPTION
In previous patch the generate-models.sh had an incorrect setting for
one of the variables (WORK_DIR). It wasn't caught in CI, because
CI used different command (direct swagger call instead of docker).
This patch fixes the WORK_DIR for generate-models, and also extracts
the command to a shared so variable, so that CI and local execute the
same one.