### PR TITLE
use Flat JSON which is already generated by Go Swagger

### DIFF
--- a/cmd/api-manager/main.go
+++ b/cmd/api-manager/main.go
@@ -53,7 +53,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 
 func main() {
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/application-manager/main.go
+++ b/cmd/application-manager/main.go
@@ -51,7 +51,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 
 func main() {
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/event-manager/main.go
+++ b/cmd/event-manager/main.go
@@ -56,7 +56,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 }
 
 func main() {
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/function-manager/main.go
+++ b/cmd/function-manager/main.go
@@ -112,7 +112,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 }
 
 func main() {
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/identity-manager/main.go
+++ b/cmd/identity-manager/main.go
@@ -48,7 +48,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 
 func main() {
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/image-manager/main.go
+++ b/cmd/image-manager/main.go
@@ -53,7 +53,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 
 func main() {
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/secret-store/main.go
+++ b/cmd/secret-store/main.go
@@ -51,7 +51,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 
 func main() {
 
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/service-manager/main.go
+++ b/cmd/service-manager/main.go
@@ -54,7 +54,7 @@ func configureFlags() []swag.CommandLineOptionsGroup {
 }
 
 func main() {
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "2.0")
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/api-manager/gen/restapi/configure_api_manager.go
+++ b/pkg/api-manager/gen/restapi/configure_api_manager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/dispatch/pkg/api-manager/gen/restapi/operations/endpoint"
 )
 
-//go:generate swagger generate server --target ../pkg/api-manager/gen --name APIManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/api-manager/gen --name APIManager --spec ../swagger/api-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.APIManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/api-manager/gen/restapi/embedded_spec.go
+++ b/pkg/api-manager/gen/restapi/embedded_spec.go
@@ -72,20 +72,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/api"
+                "$ref": "./models.json#/definitions/API"
               }
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unexpected Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -109,7 +109,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           }
         ],
@@ -117,31 +117,31 @@ func init() {
           "200": {
             "description": "API created",
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           },
           "400": {
             "description": "Invalid Input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -162,25 +162,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "API not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -204,7 +204,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           }
         ],
@@ -212,25 +212,25 @@ func init() {
           "200": {
             "description": "Successful update",
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "API not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -248,25 +248,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/api"
+              "$ref": "./models.json#/definitions/API"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "API not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -291,147 +291,6 @@ func init() {
           "in": "query"
         }
       ]
-    }
-  },
-  "definitions": {
-    "api": {
-      "description": "API API",
-      "type": "object",
-      "required": [
-        "function",
-        "name"
-      ],
-      "properties": {
-        "authentication": {
-          "description": "the authentication method for api consumers (public, basic, oidc, etc.)",
-          "type": "string",
-          "x-go-name": "Authentication"
-        },
-        "cors": {
-          "description": "enable Cross-Origin Resource Sharing (CORS)",
-          "type": "boolean",
-          "x-go-name": "Cors"
-        },
-        "enabled": {
-          "description": "a easy way to disable an API without deleting it.",
-          "type": "boolean",
-          "x-go-name": "Enabled"
-        },
-        "function": {
-          "description": "the name of the function associated with",
-          "type": "string",
-          "x-go-name": "Function"
-        },
-        "hosts": {
-          "description": "a list of domain names that point to the API",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Hosts"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "methods": {
-          "description": "a list of HTTP/S methods that point to the API",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Methods"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "protocols": {
-          "description": "a list of support protocols (i.e. http, https)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Protocols"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiTagsItems"
-          },
-          "x-go-name": "Tags"
-        },
-        "tls": {
-          "description": "the tls credentials (imported from serverless secret) for https connection",
-          "type": "string",
-          "x-go-name": "TLS"
-        },
-        "uris": {
-          "description": "a list of URIs prefixes that point to the API",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Uris"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "apiTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/application-manager/gen/restapi/configure_application_manager.go
+++ b/pkg/application-manager/gen/restapi/configure_application_manager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/dispatch/pkg/application-manager/gen/restapi/operations/application"
 )
 
-//go:generate swagger generate server --target ../pkg/application-manager/gen --name ApplicationManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/application-manager/gen --name ApplicationManager --spec ../swagger/application-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.ApplicationManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/application-manager/gen/restapi/embedded_spec.go
+++ b/pkg/application-manager/gen/restapi/embedded_spec.go
@@ -66,20 +66,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/application"
+                "$ref": "./models.json#/definitions/Application"
               }
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unexpected Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -103,7 +103,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           }
         ],
@@ -111,31 +111,31 @@ func init() {
           "200": {
             "description": "Application created",
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           },
           "400": {
             "description": "Invalid Input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -156,25 +156,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Application not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -198,7 +198,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           }
         ],
@@ -206,25 +206,25 @@ func init() {
           "200": {
             "description": "Successful update",
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Application not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -242,25 +242,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/application"
+              "$ref": "./models.json#/definitions/Application"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Application not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -275,103 +275,6 @@ func init() {
           "required": true
         }
       ]
-    }
-  },
-  "definitions": {
-    "application": {
-      "description": "Application application",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modifiedTime": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/applicationTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "applicationTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/event-manager/gen/restapi/configure_event_manager.go
+++ b/pkg/event-manager/gen/restapi/configure_event_manager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware/dispatch/pkg/event-manager/gen/restapi/operations/subscriptions"
 )
 
-//go:generate swagger generate server --target ../pkg/event-manager/gen --name EventManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/event-manager/gen --name EventManager --spec ../swagger/event-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.EventManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/event-manager/gen/restapi/embedded_spec.go
+++ b/pkg/event-manager/gen/restapi/embedded_spec.go
@@ -58,7 +58,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/emission"
+              "$ref": "./models.json#/definitions/Emission"
             }
           }
         ],
@@ -66,31 +66,31 @@ func init() {
           "200": {
             "description": "Event emitted",
             "schema": {
-              "$ref": "#/definitions/emission"
+              "$ref": "./models.json#/definitions/Emission"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -124,20 +124,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/eventDriver"
+                "$ref": "./models.json#/definitions/EventDriver"
               }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -161,7 +161,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           }
         ],
@@ -169,37 +169,37 @@ func init() {
           "201": {
             "description": "Driver created",
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -220,31 +220,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Driver not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -269,7 +269,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           }
         ],
@@ -277,31 +277,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Driver not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -319,31 +319,31 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriver"
+              "$ref": "./models.json#/definitions/EventDriver"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Driver not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -397,20 +397,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/eventDriverType"
+                "$ref": "./models.json#/definitions/EventDriverType"
               }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -434,7 +434,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           }
         ],
@@ -442,37 +442,37 @@ func init() {
           "201": {
             "description": "Driver Type created",
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -493,31 +493,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Driver not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -542,7 +542,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           }
         ],
@@ -550,31 +550,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "DriverType not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -592,31 +592,31 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/eventDriverType"
+              "$ref": "./models.json#/definitions/EventDriverType"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Driver not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -670,26 +670,26 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/subscription"
+                "$ref": "./models.json#/definitions/Subscription"
               }
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -713,7 +713,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           }
         ],
@@ -721,37 +721,37 @@ func init() {
           "201": {
             "description": "Subscription created",
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -772,31 +772,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Subscription not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -821,7 +821,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           }
         ],
@@ -829,31 +829,31 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Subscription not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unknown error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -871,31 +871,31 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/subscription"
+              "$ref": "./models.json#/definitions/Subscription"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Subscription not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -920,493 +920,6 @@ func init() {
           "required": true
         }
       ]
-    }
-  },
-  "definitions": {
-    "emission": {
-      "description": "Emission emission",
-      "type": "object",
-      "required": [
-        "event"
-      ],
-      "properties": {
-        "emitted-time": {
-          "description": "emitted time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "EmittedTime",
-          "readOnly": true
-        },
-        "event": {
-          "$ref": "#/definitions/emissionEvent"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID",
-          "readOnly": true
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/emissionTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "emissionEvent": {
-      "description": "CloudEvent cloud event",
-      "type": "object",
-      "required": [
-        "cloud-events-version",
-        "event-id",
-        "event-type",
-        "namespace",
-        "source-id",
-        "source-type"
-      ],
-      "properties": {
-        "cloud-events-version": {
-          "description": "cloud events version",
-          "type": "string",
-          "x-go-name": "CloudEventsVersion"
-        },
-        "content-type": {
-          "description": "content type",
-          "type": "string",
-          "x-go-name": "ContentType"
-        },
-        "data": {
-          "description": "data",
-          "type": "string",
-          "x-go-name": "Data"
-        },
-        "event-id": {
-          "description": "event id",
-          "type": "string",
-          "x-go-name": "EventID"
-        },
-        "event-time": {
-          "description": "event time",
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "EventTime"
-        },
-        "event-type": {
-          "description": "event type",
-          "type": "string",
-          "maxLength": 128,
-          "pattern": "^[\\w\\d\\-\\.]+$",
-          "x-go-name": "EventType"
-        },
-        "event-type-version": {
-          "description": "event type version",
-          "type": "string",
-          "x-go-name": "EventTypeVersion"
-        },
-        "extensions": {
-          "description": "extensions",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          },
-          "x-go-name": "Extensions"
-        },
-        "namespace": {
-          "description": "namespace",
-          "type": "string",
-          "x-go-name": "Namespace"
-        },
-        "schema-url": {
-          "description": "schema url",
-          "type": "string",
-          "x-go-name": "SchemaURL"
-        },
-        "source-id": {
-          "description": "source id",
-          "type": "string",
-          "x-go-name": "SourceID"
-        },
-        "source-type": {
-          "description": "source type",
-          "type": "string",
-          "x-go-name": "SourceType"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "emissionTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriver": {
-      "description": "EventDriver driver",
-      "type": "object",
-      "required": [
-        "name",
-        "type"
-      ],
-      "properties": {
-        "config": {
-          "description": "config",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/eventDriverConfigItems"
-          },
-          "x-go-name": "Config"
-        },
-        "created-time": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID",
-          "readOnly": true
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modified-time": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "secrets": {
-          "description": "secrets",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Secrets"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/eventDriverTagsItems"
-          },
-          "x-go-name": "Tags"
-        },
-        "type": {
-          "description": "type",
-          "type": "string",
-          "maxLength": 32,
-          "x-go-name": "Type"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriverConfigItems": {
-      "description": "Config config",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriverTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriverType": {
-      "description": "EventDriverType driver type",
-      "type": "object",
-      "required": [
-        "image",
-        "name"
-      ],
-      "properties": {
-        "built-in": {
-          "description": "built in",
-          "type": "boolean",
-          "x-go-name": "BuiltIn",
-          "readOnly": true
-        },
-        "config": {
-          "description": "config",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/eventDriverTypeConfigItems"
-          },
-          "x-go-name": "Config"
-        },
-        "created-time": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID",
-          "readOnly": true
-        },
-        "image": {
-          "description": "image",
-          "type": "string",
-          "x-go-name": "Image"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modified-time": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "maxLength": 32,
-          "x-go-name": "Name"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/eventDriverTypeTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriverTypeConfigItems": {
-      "description": "Config config",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "eventDriverTypeTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "subscription": {
-      "description": "Subscription subscription",
-      "type": "object",
-      "required": [
-        "event-type",
-        "function",
-        "name",
-        "source-type"
-      ],
-      "properties": {
-        "created-time": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "event-type": {
-          "description": "event type",
-          "type": "string",
-          "maxLength": 128,
-          "pattern": "^[\\w\\d\\-\\.]+$",
-          "x-go-name": "EventType"
-        },
-        "function": {
-          "description": "function",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Function"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID",
-          "readOnly": true
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modified-time": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "secrets": {
-          "description": "secrets",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Secrets"
-        },
-        "source-type": {
-          "description": "source type",
-          "type": "string",
-          "maxLength": 32,
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "SourceType"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/subscriptionTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "subscriptionTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/function-manager/gen/restapi/configure_function_manager.go
+++ b/pkg/function-manager/gen/restapi/configure_function_manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware/dispatch/pkg/function-manager/gen/restapi/operations/store"
 )
 
-//go:generate swagger generate server --target ../pkg/function-manager/gen --name FunctionManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/function-manager/gen --name FunctionManager --spec ../swagger/function-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.FunctionManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -72,26 +72,26 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/function"
+                "$ref": "./models.json#/definitions/Function"
               }
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Custom error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -115,7 +115,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           }
         ],
@@ -123,31 +123,31 @@ func init() {
           "201": {
             "description": "Function created",
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "401": {
             "description": "Unauthorized Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -168,25 +168,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -210,7 +210,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           }
         ],
@@ -218,25 +218,25 @@ func init() {
           "200": {
             "description": "Successful update",
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -254,25 +254,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/function"
+              "$ref": "./models.json#/definitions/Function"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -314,26 +314,26 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/run"
+                "$ref": "./models.json#/definitions/Run"
               }
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -355,7 +355,7 @@ func init() {
             "name": "body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/run"
+              "$ref": "./models.json#/definitions/Run"
             }
           }
         ],
@@ -363,43 +363,43 @@ func init() {
           "200": {
             "description": "Successful execution (blocking call)",
             "schema": {
-              "$ref": "#/definitions/run"
+              "$ref": "./models.json#/definitions/Run"
             }
           },
           "202": {
             "description": "Execution started (non-blocking call)",
             "schema": {
-              "$ref": "#/definitions/run"
+              "$ref": "./models.json#/definitions/Run"
             }
           },
           "400": {
             "description": "User error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "422": {
             "description": "Input object validation failed",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "502": {
             "description": "Function error occurred (blocking call)",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -438,25 +438,25 @@ func init() {
           "200": {
             "description": "Function Run",
             "schema": {
-              "$ref": "#/definitions/run"
+              "$ref": "./models.json#/definitions/Run"
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Function or Run not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -488,436 +488,6 @@ func init() {
           "in": "query"
         }
       ]
-    }
-  },
-  "definitions": {
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "function": {
-      "description": "Function function",
-      "type": "object",
-      "required": [
-        "code",
-        "image",
-        "name"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "string",
-          "x-go-name": "Code"
-        },
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "faasId": {
-          "description": "faas Id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "FaasID"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "image": {
-          "description": "image",
-          "type": "string",
-          "x-go-name": "Image"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "main": {
-          "description": "main",
-          "type": "string",
-          "x-go-name": "Main"
-        },
-        "modifiedTime": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "schema": {
-          "$ref": "#/definitions/functionSchema"
-        },
-        "secrets": {
-          "description": "secrets",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Secrets"
-        },
-        "services": {
-          "description": "services",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Services"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/functionTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "functionSchema": {
-      "description": "Schema schema",
-      "type": "object",
-      "properties": {
-        "in": {
-          "description": "in",
-          "type": "object",
-          "x-go-name": "In"
-        },
-        "out": {
-          "description": "out",
-          "type": "object",
-          "x-go-name": "Out"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "functionTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "run": {
-      "description": "Run run",
-      "type": "object",
-      "properties": {
-        "blocking": {
-          "description": "blocking",
-          "type": "boolean",
-          "x-go-name": "Blocking"
-        },
-        "error": {
-          "$ref": "#/definitions/runError"
-        },
-        "event": {
-          "$ref": "#/definitions/runEvent"
-        },
-        "executedTime": {
-          "description": "executed time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ExecutedTime",
-          "readOnly": true
-        },
-        "faasId": {
-          "description": "faas Id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "FaasID"
-        },
-        "finishedTime": {
-          "description": "finished time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "FinishedTime",
-          "readOnly": true
-        },
-        "functionId": {
-          "description": "function Id",
-          "type": "string",
-          "x-go-name": "FunctionID",
-          "readOnly": true
-        },
-        "functionName": {
-          "description": "function name",
-          "type": "string",
-          "x-go-name": "FunctionName",
-          "readOnly": true
-        },
-        "httpContext": {
-          "description": "http context",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          },
-          "x-go-name": "HTTPContext",
-          "readOnly": true
-        },
-        "input": {
-          "description": "input",
-          "type": "object",
-          "x-go-name": "Input"
-        },
-        "logs": {
-          "$ref": "#/definitions/runLogs"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "Name",
-          "readOnly": true
-        },
-        "output": {
-          "description": "output",
-          "type": "object",
-          "x-go-name": "Output",
-          "readOnly": true
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "secrets": {
-          "description": "secrets",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Secrets"
-        },
-        "services": {
-          "description": "services",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Services"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/runTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "runError": {
-      "description": "InvocationError invocation error",
-      "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
-      "properties": {
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        },
-        "stacktrace": {
-          "description": "stacktrace",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Stacktrace"
-        },
-        "type": {
-          "description": "ErrorType error type",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "runEvent": {
-      "description": "CloudEvent cloud event",
-      "type": "object",
-      "required": [
-        "cloud-events-version",
-        "event-id",
-        "event-type",
-        "namespace",
-        "source-id",
-        "source-type"
-      ],
-      "properties": {
-        "cloud-events-version": {
-          "description": "cloud events version",
-          "type": "string",
-          "x-go-name": "CloudEventsVersion"
-        },
-        "content-type": {
-          "description": "content type",
-          "type": "string",
-          "x-go-name": "ContentType"
-        },
-        "data": {
-          "description": "data",
-          "type": "string",
-          "x-go-name": "Data"
-        },
-        "event-id": {
-          "description": "event id",
-          "type": "string",
-          "x-go-name": "EventID"
-        },
-        "event-time": {
-          "description": "event time",
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "EventTime"
-        },
-        "event-type": {
-          "description": "event type",
-          "type": "string",
-          "maxLength": 128,
-          "pattern": "^[\\w\\d\\-\\.]+$",
-          "x-go-name": "EventType"
-        },
-        "event-type-version": {
-          "description": "event type version",
-          "type": "string",
-          "x-go-name": "EventTypeVersion"
-        },
-        "extensions": {
-          "description": "extensions",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          },
-          "x-go-name": "Extensions"
-        },
-        "namespace": {
-          "description": "namespace",
-          "type": "string",
-          "x-go-name": "Namespace"
-        },
-        "schema-url": {
-          "description": "schema url",
-          "type": "string",
-          "x-go-name": "SchemaURL"
-        },
-        "source-id": {
-          "description": "source id",
-          "type": "string",
-          "x-go-name": "SourceID"
-        },
-        "source-type": {
-          "description": "source type",
-          "type": "string",
-          "x-go-name": "SourceType"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "runLogs": {
-      "description": "Logs logs",
-      "type": "object",
-      "required": [
-        "stderr",
-        "stdout"
-      ],
-      "properties": {
-        "stderr": {
-          "description": "stderr",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Stderr"
-        },
-        "stdout": {
-          "description": "stdout",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Stdout"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "runTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/identity-manager/gen/restapi/configure_identity_manager.go
+++ b/pkg/identity-manager/gen/restapi/configure_identity_manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware/dispatch/pkg/identity-manager/gen/restapi/operations/serviceaccount"
 )
 
-//go:generate swagger generate server --target ../pkg/identity-manager/gen --name IdentityManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/identity-manager/gen --name IdentityManager --spec ../swagger/identity-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.IdentityManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/identity-manager/gen/restapi/embedded_spec.go
+++ b/pkg/identity-manager/gen/restapi/embedded_spec.go
@@ -53,13 +53,13 @@ func init() {
           "200": {
             "description": "home page",
             "schema": {
-              "$ref": "#/definitions/message"
+              "$ref": "./models.json#/definitions/Message"
             }
           },
           "default": {
             "description": "error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -73,7 +73,7 @@ func init() {
           "202": {
             "description": "default response if authorized",
             "schema": {
-              "$ref": "#/definitions/message"
+              "$ref": "./models.json#/definitions/Message"
             }
           },
           "401": {
@@ -85,7 +85,7 @@ func init() {
           "default": {
             "description": "error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -99,13 +99,13 @@ func init() {
           "200": {
             "description": "home page",
             "schema": {
-              "$ref": "#/definitions/message"
+              "$ref": "./models.json#/definitions/Message"
             }
           },
           "default": {
             "description": "error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -127,20 +127,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/policy"
+                "$ref": "./models.json#/definitions/Policy"
               }
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unexpected Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -164,7 +164,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           }
         ],
@@ -172,31 +172,31 @@ func init() {
           "201": {
             "description": "created",
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -217,25 +217,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Policy not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -259,7 +259,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           }
         ],
@@ -267,25 +267,25 @@ func init() {
           "200": {
             "description": "Successful update",
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Policy not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -303,25 +303,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/policy"
+              "$ref": "./models.json#/definitions/Policy"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Policy not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -362,7 +362,7 @@ func init() {
           "default": {
             "description": "error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -384,20 +384,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/serviceAccount"
+                "$ref": "./models.json#/definitions/ServiceAccount"
               }
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Unexpected Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -421,7 +421,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           }
         ],
@@ -429,31 +429,31 @@ func init() {
           "201": {
             "description": "created",
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal Error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -474,25 +474,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service Account not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -516,7 +516,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           }
         ],
@@ -524,25 +524,25 @@ func init() {
           "200": {
             "description": "Successful update",
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service Account not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -560,25 +560,25 @@ func init() {
           "200": {
             "description": "Successful operation",
             "schema": {
-              "$ref": "#/definitions/serviceAccount"
+              "$ref": "./models.json#/definitions/ServiceAccount"
             }
           },
           "400": {
             "description": "Invalid Name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service Account not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "500": {
             "description": "Internal error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -593,198 +593,6 @@ func init() {
           "required": true
         }
       ]
-    }
-  },
-  "definitions": {
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "message": {
-      "description": "Message message",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "policy": {
-      "description": "Policy policy",
-      "type": "object",
-      "required": [
-        "name",
-        "rules"
-      ],
-      "properties": {
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modifiedTime": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "rules": {
-          "description": "rules",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/policyRulesItems"
-          },
-          "x-go-name": "Rules"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "policyRulesItems": {
-      "description": "Rule rule",
-      "type": "object",
-      "required": [
-        "actions",
-        "resources",
-        "subjects"
-      ],
-      "properties": {
-        "actions": {
-          "description": "actions",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Actions"
-        },
-        "resources": {
-          "description": "resources",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Resources"
-        },
-        "subjects": {
-          "description": "subjects",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Subjects"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceAccount": {
-      "description": "ServiceAccount service account",
-      "type": "object",
-      "required": [
-        "name",
-        "publicKey"
-      ],
-      "properties": {
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "domain": {
-          "description": "domain",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-\\.]+$",
-          "x-go-name": "Domain"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "modifiedTime": {
-          "description": "modified time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "ModifiedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-\\.]+$",
-          "x-go-name": "Name"
-        },
-        "publicKey": {
-          "description": "public key",
-          "type": "string",
-          "x-go-name": "PublicKey"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/image-manager/gen/restapi/configure_image_manager.go
+++ b/pkg/image-manager/gen/restapi/configure_image_manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware/dispatch/pkg/image-manager/gen/restapi/operations/image"
 )
 
-//go:generate swagger generate server --target ../pkg/image-manager/gen --name ImageManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/image-manager/gen --name ImageManager --spec ../swagger/image-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.ImageManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/image-manager/gen/restapi/embedded_spec.go
+++ b/pkg/image-manager/gen/restapi/embedded_spec.go
@@ -66,14 +66,14 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/baseImage"
+                "$ref": "./models.json#/definitions/BaseImage"
               }
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -97,7 +97,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           }
         ],
@@ -105,25 +105,25 @@ func init() {
           "201": {
             "description": "created",
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -144,25 +144,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Base image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -184,7 +184,7 @@ func init() {
             "name": "body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           }
         ],
@@ -192,25 +192,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -228,25 +228,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/baseImage"
+              "$ref": "./models.json#/definitions/BaseImage"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Base image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -307,20 +307,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/image"
+                "$ref": "./models.json#/definitions/Image"
               }
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -344,7 +344,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           }
         ],
@@ -352,25 +352,25 @@ func init() {
           "201": {
             "description": "created",
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -391,25 +391,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -431,7 +431,7 @@ func init() {
             "name": "body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           }
         ],
@@ -439,25 +439,25 @@ func init() {
           "200": {
             "description": "updated",
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -475,25 +475,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/image"
+              "$ref": "./models.json#/definitions/Image"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Image not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -518,288 +518,6 @@ func init() {
           "in": "query"
         }
       ]
-    }
-  },
-  "definitions": {
-    "baseImage": {
-      "description": "BaseImage base image",
-      "type": "object",
-      "required": [
-        "dockerUrl",
-        "language",
-        "name"
-      ],
-      "properties": {
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "dockerUrl": {
-          "description": "docker Url",
-          "type": "string",
-          "x-go-name": "DockerURL"
-        },
-        "groups": {
-          "description": "groups",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Groups"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "language": {
-          "description": "language",
-          "type": "string",
-          "x-go-name": "Language"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "spec": {
-          "description": "Spec spec",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/baseImageTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "baseImageTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "image": {
-      "description": "Image image",
-      "type": "object",
-      "required": [
-        "baseImageName",
-        "name"
-      ],
-      "properties": {
-        "baseImageName": {
-          "description": "base image name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "BaseImageName"
-        },
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "dockerUrl": {
-          "description": "docker Url",
-          "type": "string",
-          "x-go-name": "DockerURL"
-        },
-        "groups": {
-          "description": "groups",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Groups"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "language": {
-          "description": "language",
-          "type": "string",
-          "x-go-name": "Language"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "runtimeDependencies": {
-          "$ref": "#/definitions/imageRuntimeDependencies"
-        },
-        "spec": {
-          "description": "Spec spec",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "systemDependencies": {
-          "$ref": "#/definitions/imageSystemDependencies"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/imageTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "imageRuntimeDependencies": {
-      "description": "RuntimeDependencies runtime dependencies",
-      "type": "object",
-      "properties": {
-        "manifest": {
-          "description": "manifest",
-          "type": "string",
-          "x-go-name": "Manifest"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "imageSystemDependencies": {
-      "description": "SystemDependencies system dependencies",
-      "type": "object",
-      "properties": {
-        "packages": {
-          "description": "packages",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/imageSystemDependenciesPackagesItems"
-          },
-          "x-go-name": "Packages"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "imageSystemDependenciesPackagesItems": {
-      "description": "SystemDependency system dependency",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "name",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "version": {
-          "description": "version",
-          "type": "string",
-          "x-go-name": "Version"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "imageTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/secret-store/gen/restapi/configure_secret_store.go
+++ b/pkg/secret-store/gen/restapi/configure_secret_store.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/dispatch/pkg/secret-store/gen/restapi/operations/secret"
 )
 
-//go:generate swagger generate server --target ../pkg/secret-store/gen --name SecretStore --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/secret-store/gen --name SecretStore --spec ../swagger/secret-store.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.SecretStoreAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/secret-store/gen/restapi/embedded_spec.go
+++ b/pkg/secret-store/gen/restapi/embedded_spec.go
@@ -64,20 +64,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/secret"
+                "$ref": "./models.json#/definitions/Secret"
               }
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Standard error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -95,7 +95,7 @@ func init() {
             "name": "secret",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/secret"
+              "$ref": "./models.json#/definitions/Secret"
             }
           }
         ],
@@ -103,25 +103,25 @@ func init() {
           "201": {
             "description": "The created secret.",
             "schema": {
-              "$ref": "#/definitions/secret"
+              "$ref": "./models.json#/definitions/Secret"
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Standard error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -140,25 +140,25 @@ func init() {
           "200": {
             "description": "The secret identified by the secretName",
             "schema": {
-              "$ref": "#/definitions/secret"
+              "$ref": "./models.json#/definitions/Secret"
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Resource Not Found if no secret exists with the given name",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Standard error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -179,7 +179,7 @@ func init() {
             "name": "secret",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/secret"
+              "$ref": "./models.json#/definitions/Secret"
             }
           },
           {
@@ -194,25 +194,25 @@ func init() {
           "201": {
             "description": "The updated secret",
             "schema": {
-              "$ref": "#/definitions/secret"
+              "$ref": "./models.json#/definitions/Secret"
             }
           },
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Resource Not Found if no secret exists with the given name",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "generic error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -238,19 +238,19 @@ func init() {
           "400": {
             "description": "Bad Request",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Resource Not Found if no secret exists with the given name",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "generic error",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -275,93 +275,6 @@ func init() {
           "in": "query"
         }
       ]
-    }
-  },
-  "definitions": {
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "secret": {
-      "description": "Secret secret",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID",
-          "readOnly": true
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "secrets": {
-          "description": "SecretValue secret value",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/secretTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "secretTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/pkg/service-manager/gen/restapi/configure_service_manager.go
+++ b/pkg/service-manager/gen/restapi/configure_service_manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vmware/dispatch/pkg/service-manager/gen/restapi/operations/service_instance"
 )
 
-//go:generate swagger generate server --target ../pkg/service-manager/gen --name ServiceManager --spec ../swagger/swagger-spec-tmp.json --model-package v1 --skip-models --exclude-main
+//go:generate swagger generate server --target ../pkg/service-manager/gen --name ServiceManager --spec ../swagger/service-manager.yaml --model-package v1 --skip-models --exclude-main
 
 func configureFlags(api *operations.ServiceManagerAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/pkg/service-manager/gen/restapi/embedded_spec.go
+++ b/pkg/service-manager/gen/restapi/embedded_spec.go
@@ -72,14 +72,14 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/serviceClass"
+                "$ref": "./models.json#/definitions/ServiceClass"
               }
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -100,25 +100,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/serviceClass"
+              "$ref": "./models.json#/definitions/ServiceClass"
             }
           },
           "400": {
             "description": "Invalid name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service class not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -169,20 +169,20 @@ func init() {
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/serviceInstance"
+                "$ref": "./models.json#/definitions/ServiceInstance"
               }
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -206,7 +206,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/serviceInstance"
+              "$ref": "./models.json#/definitions/ServiceInstance"
             }
           }
         ],
@@ -214,25 +214,25 @@ func init() {
           "201": {
             "description": "created",
             "schema": {
-              "$ref": "#/definitions/serviceInstance"
+              "$ref": "./models.json#/definitions/ServiceInstance"
             }
           },
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "409": {
             "description": "Already Exists",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -253,25 +253,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/serviceInstance"
+              "$ref": "./models.json#/definitions/ServiceInstance"
             }
           },
           "400": {
             "description": "Invalid ID supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service instance not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -289,25 +289,25 @@ func init() {
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/serviceInstance"
+              "$ref": "./models.json#/definitions/ServiceInstance"
             }
           },
           "400": {
             "description": "Invalid name supplied",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "404": {
             "description": "Service instance not found",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           },
           "default": {
             "description": "Generic error response",
             "schema": {
-              "$ref": "#/definitions/error"
+              "$ref": "./models.json#/definitions/Error"
             }
           }
         }
@@ -322,349 +322,6 @@ func init() {
           "required": true
         }
       ]
-    }
-  },
-  "definitions": {
-    "error": {
-      "description": "Error error",
-      "type": "object",
-      "required": [
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "description": "code",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Code"
-        },
-        "message": {
-          "description": "message",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceClass": {
-      "description": "ServiceClass service class",
-      "type": "object",
-      "required": [
-        "broker",
-        "name"
-      ],
-      "properties": {
-        "bindable": {
-          "description": "bindable",
-          "type": "boolean",
-          "x-go-name": "Bindable"
-        },
-        "broker": {
-          "description": "broker",
-          "type": "string",
-          "x-go-name": "Broker"
-        },
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "description": {
-          "description": "description",
-          "type": "string",
-          "x-go-name": "Description"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "plans": {
-          "description": "plans",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceClassPlansItems"
-          },
-          "x-go-name": "Plans"
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceClassTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceClassPlansItems": {
-      "description": "ServicePlan service plan",
-      "type": "object",
-      "properties": {
-        "bindable": {
-          "description": "bindable",
-          "type": "boolean",
-          "x-go-name": "Bindable"
-        },
-        "description": {
-          "description": "description",
-          "type": "string",
-          "x-go-name": "Description"
-        },
-        "free": {
-          "description": "free",
-          "type": "boolean",
-          "x-go-name": "Free"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "metadata": {
-          "description": "metadata",
-          "type": "object",
-          "x-go-name": "Metadata"
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "schema": {
-          "$ref": "#/definitions/serviceClassPlansItemsSchema"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceClassPlansItemsSchema": {
-      "description": "ServicePlanSchema service plan schema",
-      "type": "object",
-      "properties": {
-        "bind": {
-          "description": "bind",
-          "type": "object",
-          "x-go-name": "Bind"
-        },
-        "create": {
-          "description": "create",
-          "type": "object",
-          "x-go-name": "Create"
-        },
-        "update": {
-          "description": "update",
-          "type": "object",
-          "x-go-name": "Update"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceClassTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceInstance": {
-      "description": "ServiceInstance service instance",
-      "type": "object",
-      "required": [
-        "name",
-        "serviceClass",
-        "servicePlan"
-      ],
-      "properties": {
-        "binding": {
-          "$ref": "#/definitions/serviceInstanceBinding"
-        },
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "id": {
-          "description": "id",
-          "type": "string",
-          "format": "uuid",
-          "x-go-name": "ID"
-        },
-        "kind": {
-          "description": "kind",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Kind",
-          "readOnly": true
-        },
-        "name": {
-          "description": "name",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "Name"
-        },
-        "parameters": {
-          "description": "parameters",
-          "type": "object",
-          "x-go-name": "Parameters"
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "secretParameters": {
-          "description": "secret parameters",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "SecretParameters"
-        },
-        "serviceClass": {
-          "description": "service class",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "ServiceClass"
-        },
-        "servicePlan": {
-          "description": "service plan",
-          "type": "string",
-          "pattern": "^[\\w\\d\\-]+$",
-          "x-go-name": "ServicePlan"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        },
-        "tags": {
-          "description": "tags",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/serviceInstanceTagsItems"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceInstanceBinding": {
-      "description": "ServiceBinding service binding",
-      "type": "object",
-      "properties": {
-        "bindingSecret": {
-          "description": "binding secret",
-          "type": "string",
-          "x-go-name": "BindingSecret"
-        },
-        "createdTime": {
-          "description": "created time",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime"
-        },
-        "parameters": {
-          "description": "parameters",
-          "type": "object",
-          "x-go-name": "Parameters"
-        },
-        "reason": {
-          "description": "reason",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Reason"
-        },
-        "secretParameters": {
-          "description": "secret parameters",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "SecretParameters"
-        },
-        "status": {
-          "description": "Status status",
-          "type": "string",
-          "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "serviceInstanceTagsItems": {
-      "description": "Tag tag",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "key",
-          "type": "string",
-          "x-go-name": "Key"
-        },
-        "value": {
-          "description": "value",
-          "type": "string",
-          "x-go-name": "Value"
-        }
-      },
-      "x-go-gen-location": "models",
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     }
   },
   "securityDefinitions": {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -18,9 +18,7 @@ APP=${2}
 SWAGGER=${3}
 
 SERVER_COMMAND="pushd ${WORKDIR} && \
-        swagger flatten ./swagger/${SWAGGER} -o ./swagger/swagger-spec-tmp.json && \
-        swagger generate server ${QUIET} -A ${APP} -t ./pkg/${PACKAGE}/gen -f ./swagger/swagger-spec-tmp.json --existing-models=${MODELS_PACKAGE} --model-package=v1 --skip-models --exclude-main && \
-        rm -rf ./swagger/swagger-spec-tmp.json && \
+        swagger generate server ${QUIET} -A ${APP} -t ./pkg/${PACKAGE}/gen -f ./swagger/${SWAGGER} --existing-models=${MODELS_PACKAGE} --model-package=v1 --skip-models --exclude-main && \
         popd"
 
 CLIENT_COMMAND="pushd ${WORKDIR} && \


### PR DESCRIPTION
Turns out Go swagger generates the flat embedded spec JSON, it's just different variable. By using that, we can avoid running extra flatten command in generate script.