### PR TITLE
Add tracing context to function context

### DIFF
--- a/pkg/function-manager/controller.go
+++ b/pkg/function-manager/controller.go
@@ -226,6 +226,8 @@ func (h *runEntityHandler) Add(ctx context.Context, obj entitystore.Entity) (err
 		fctx[functions.HTTPContextKey] = run.HTTPContext
 	}
 
+	fctx[functions.GoContext] = ctx
+
 	output, err := h.Runner.Run(&functions.FunctionExecution{
 		Context:    fctx,
 		RunID:      run.ID,

--- a/pkg/functions/context.go
+++ b/pkg/functions/context.go
@@ -21,6 +21,9 @@ const (
 	EventKey       = "event"
 	ErrorKey       = "error"
 	HTTPContextKey = "httpContext"
+	// GoContext key is used for data that is not propagated to the FaaS function. it uses
+	// context.Context underneath.
+	GoContext = "goContext"
 )
 
 // Logs returns the logs as a list of strings

--- a/pkg/functions/injectors/contextstripper.go
+++ b/pkg/functions/injectors/contextstripper.go
@@ -1,0 +1,20 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package injectors
+
+import (
+	"github.com/vmware/dispatch/pkg/functions"
+)
+
+// StripContextMiddleware creates a middleware that cleans context from keys that should not be passed to the function.
+func StripContextMiddleware() functions.Middleware {
+	return func(f functions.Runnable) functions.Runnable {
+		return func(ctx functions.Context, in interface{}) (interface{}, error) {
+			delete(ctx, functions.GoContext)
+			return f(ctx, in)
+		}
+	}
+}

--- a/pkg/functions/injectors/secretinjector.go
+++ b/pkg/functions/injectors/secretinjector.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/vmware/dispatch/pkg/client"
 	"github.com/vmware/dispatch/pkg/functions"
+	"github.com/vmware/dispatch/pkg/trace"
 )
 
 type secretInjector struct {
@@ -26,11 +27,12 @@ func NewSecretInjector(secretClient client.SecretsClient) functions.SecretInject
 	}
 }
 
-func getSecrets(client client.SecretsClient, secretNames []string) (map[string]interface{}, error) {
-
+func getSecrets(ctx context.Context, client client.SecretsClient, secretNames []string) (map[string]interface{}, error) {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
 	secrets := make(map[string]interface{})
 	for _, name := range secretNames {
-		resp, err := client.GetSecret(context.Background(), name)
+		resp, err := client.GetSecret(ctx, name)
 		if err != nil {
 			return secrets, errors.Wrapf(err, "failed to get secrets from secret store")
 		}
@@ -50,7 +52,15 @@ func getSecrets(client client.SecretsClient, secretNames []string) (map[string]i
 func (i *secretInjector) GetMiddleware(secretNames []string, cookie string) functions.Middleware {
 	return func(f functions.Runnable) functions.Runnable {
 		return func(ctx functions.Context, in interface{}) (interface{}, error) {
-			secrets, err := getSecrets(i.secretClient, secretNames)
+			gctx := context.Background()
+			if ctxValue, ok := ctx[functions.GoContext]; ok {
+				gctx = ctxValue.(context.Context)
+				span, newCtx := trace.Trace(gctx, "Secret Injector")
+				defer span.Finish()
+				gctx = newCtx
+				ctx[functions.GoContext] = newCtx
+			}
+			secrets, err := getSecrets(gctx, i.secretClient, secretNames)
 			if err != nil {
 				log.Errorf("error when getting secrets from secret store %+v", err)
 				return nil, &injectorError{errors.Wrap(err, "error when retrieving secrets from secret store")}

--- a/pkg/functions/runner/runner.go
+++ b/pkg/functions/runner/runner.go
@@ -7,6 +7,7 @@ package runner
 
 import (
 	"github.com/vmware/dispatch/pkg/functions"
+	"github.com/vmware/dispatch/pkg/functions/injectors"
 )
 
 // Config contains the configuration for a FaaS runner
@@ -32,6 +33,7 @@ func (r *impl) Run(fn *functions.FunctionExecution, in interface{}) (interface{}
 		r.Validator.GetMiddleware(fn.Schemas),
 		r.SecretInjector.GetMiddleware(fn.Secrets, fn.Cookie),
 		r.ServiceInjector.GetMiddleware(fn.Services, fn.Cookie),
+		injectors.StripContextMiddleware(),
 	)
 	return m(f)(fn.Context, in)
 }


### PR DESCRIPTION
Function manager uses dedicated Context type, not compatible with `context.Context`. This patch adds tracing context as one of the keys in function context, and adds a middleware to remove it right before function execution. The tracing context is used to trace middlewares and correlate requests to other services (secret and service managers).