### PR TITLE
Retry stalled/failed image building

### DIFF
--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - "--tls-certificate=/data/tls/tls.crt"
             - "--tls-key=/data/tls/tls.key"
             - "--tracer={{ .Values.global.tracer.endpoint }}"
-            {{- if .Values.global.debug }}
+            {{- if default .Values.global.debug .Values.debug }}
             - "--debug"
             {{- end }}
           ports:
@@ -84,7 +84,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
         - name: {{ .Chart.Name }}-docker
-          image: docker:dind
+          image: docker:18.03.0-dind
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
           {{- if default .Values.global.registry.insecure .Values.registry.insecure }}
           args:

--- a/charts/dispatch/charts/image-manager/values.yaml
+++ b/charts/dispatch/charts/image-manager/values.yaml
@@ -26,20 +26,21 @@ ingress:
   tls: {}
     # Secrets must be manually created in the namespace.
     # secretName: dispatch-tls
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  #requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 4Gi
+  requests:
+    cpu: 250m
+    memory: 2Gi
 registry: {}
   # insecure: false
   # uri: docker-docker-registry.docker.svc.cluster.local:5000
 data:
   # persist: false
   hostPath: /var/image-manager
+# debug: false

--- a/cmd/image-manager/main.go
+++ b/cmd/image-manager/main.go
@@ -102,6 +102,7 @@ func main() {
 
 	c := &imagemanager.ControllerConfig{
 		ResyncPeriod:   time.Duration(imagemanager.ImageManagerFlags.ResyncPeriod) * time.Second,
+		Timeout:        time.Duration(imagemanager.ImageManagerFlags.Timeout) * time.Second,
 		OrganizationID: imagemanager.ImageManagerFlags.OrgID,
 	}
 

--- a/pkg/dispatchcli/cmd/create.go
+++ b/pkg/dispatchcli/cmd/create.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -36,6 +37,19 @@ type modelAction func(interface{}) error
 
 type importFunction struct {
 	v1.Function
+}
+
+func resolveFileReference(ref string) (string, error) {
+	if strings.HasPrefix(ref, "@") {
+		filePath := path.Join(workDir, (ref)[1:])
+		fileContent, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return "", errors.Wrapf(err, "Error when reading content of %s", filePath)
+		}
+		encoded := string(fileContent)
+		return encoded, nil
+	}
+	return ref, nil
 }
 
 func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []string, actionMap map[string]modelAction) error {
@@ -105,6 +119,11 @@ func importFile(out io.Writer, errOut io.Writer, cmd *cobra.Command, args []stri
 			if err != nil {
 				return errors.Wrapf(err, "Error decoding image document %s", string(doc))
 			}
+			manifest, err := resolveFileReference(m.RuntimeDependencies.Manifest)
+			if err != nil {
+				return err
+			}
+			m.RuntimeDependencies.Manifest = manifest
 			err = actionMap[docKind](m)
 			if err != nil {
 				return err

--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -631,7 +631,7 @@ func getK8sServiceClusterIP(service, namespace string) (string, error) {
 	return string(kubectlOut), nil
 }
 
-func getK8sServiceLoadBalancerIP(service, namespace string) (string, error) {
+func getK8sServiceLoadBalancerIPorHost(service, namespace string) (string, error) {
 
 	kubectl := exec.Command(
 		"kubectl", "get", "svc", service, "-n", namespace,
@@ -641,7 +641,19 @@ func getK8sServiceLoadBalancerIP(service, namespace string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, string(kubectlOut))
 	}
-	return string(kubectlOut), nil
+	ip := string(kubectlOut)
+	if ip == "" {
+		kubectl := exec.Command(
+			"kubectl", "get", "svc", service, "-n", namespace,
+			"-o", fmt.Sprintf("jsonpath={.status.loadBalancer.ingress[].hostname}"))
+
+		kubectlOut, err := kubectl.CombinedOutput()
+		if err != nil {
+			return "", errors.Wrapf(err, string(kubectlOut))
+		}
+		return string(kubectlOut), nil
+	}
+	return ip, nil
 }
 
 func installCertManager(out, errOut io.Writer, config *installConfig) error {
@@ -796,7 +808,7 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 				return err
 			}
 		} else if config.Ingress.ServiceType == "LoadBalancer" {
-			config.DispatchConfig.Host, err = getK8sServiceLoadBalancerIP(service, config.Ingress.Chart.Namespace)
+			config.DispatchConfig.Host, err = getK8sServiceLoadBalancerIPorHost(service, config.Ingress.Chart.Namespace)
 			if err != nil {
 				return err
 			}
@@ -851,7 +863,7 @@ func runInstall(out, errOut io.Writer, cmd *cobra.Command, args []string) error 
 			}
 
 		} else if config.Ingress.ServiceType == "LoadBalancer" {
-			config.APIGateway.Host, err = getK8sServiceLoadBalancerIP(service, config.APIGateway.Chart.Namespace)
+			config.APIGateway.Host, err = getK8sServiceLoadBalancerIPorHost(service, config.APIGateway.Chart.Namespace)
 			if err != nil {
 				return err
 			}

--- a/pkg/dispatchcli/cmd/log.go
+++ b/pkg/dispatchcli/cmd/log.go
@@ -57,6 +57,7 @@ func NewCmdLog(out, errOut io.Writer) *cobra.Command {
 		Long:    logLong,
 		Example: logExample,
 		Args:    cobra.MinimumNArgs(1),
+		Aliases: []string{"logs"},
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runLog(out, errOut, cmd, args)
 			CheckErr(err)

--- a/pkg/dispatchcli/cmd/manage.go
+++ b/pkg/dispatchcli/cmd/manage.go
@@ -180,7 +180,7 @@ func runManage(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		fmt.Println("bootstrap mode disabled")
+		fmt.Println("bootstrap mode disabled (takes up to 30s to take effect)")
 	}
 
 	return nil

--- a/pkg/image-manager/controller.go
+++ b/pkg/image-manager/controller.go
@@ -8,6 +8,7 @@ package imagemanager
 import (
 	"context"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,6 +22,7 @@ import (
 // ControllerConfig defines the image manager controller configuration
 type ControllerConfig struct {
 	ResyncPeriod   time.Duration
+	Timeout        time.Duration
 	OrganizationID string
 }
 
@@ -94,6 +96,42 @@ func (h *baseImageEntityHandler) Error(ctx context.Context, obj entitystore.Enti
 type imageEntityHandler struct {
 	Store   entitystore.EntityStore
 	Builder *ImageBuilder
+	// TODO (bjung): This is a temporary workaround for concurrency issues
+	// while building images.  A holistic solution for all controllers is
+	// needed.
+	lock    sync.Map
+	timeout time.Duration
+}
+
+// CheckAndLock checks to see if the entity is currently being worked on if not
+// stores the entity
+func (h *imageEntityHandler) CheckAndLock(obj entitystore.Entity) bool {
+	// Only do a single image create at a time (for a given image)
+	now := time.Now()
+	v, loaded := h.lock.LoadOrStore(obj.GetID(), now)
+	if loaded {
+		lockTime := v.(time.Time)
+		duration := now.Sub(lockTime)
+		if duration > h.timeout {
+			log.Errorf("Timeout waiting for lock on %s/%s", obj.GetOrganizationID(), obj.GetName())
+			// Reset the clock and continue
+			h.lock.Store(obj.GetID(), now)
+		} else {
+			log.Infof("Operation in progress on %s/%s", obj.GetOrganizationID(), obj.GetName())
+			return true
+		}
+	}
+	return false
+}
+
+// ForceLock grabs the lock regardless of status
+func (h *imageEntityHandler) ForceLock(obj entitystore.Entity) {
+	h.lock.Store(obj.GetID(), time.Now())
+}
+
+// Unlock releases the lock
+func (h *imageEntityHandler) Unlock(obj entitystore.Entity) {
+	h.lock.Delete(obj.GetID())
 }
 
 func (h *imageEntityHandler) Type() reflect.Type {
@@ -113,12 +151,22 @@ func (h *imageEntityHandler) Add(ctx context.Context, obj entitystore.Entity) (e
 		log.Error(err)
 	}
 
+	if h.CheckAndLock(i) {
+		return nil
+	}
+
+	defer h.Unlock(i)
 	defer func() { h.Store.UpdateWithError(ctx, i, err) }()
 
+	log.Infof("Creating image %s/%s", i.OrganizationID, i.Name)
 	if err = h.Builder.imageCreate(ctx, i, &bi); err != nil {
+		i.Status = entitystore.StatusERROR
+		i.Reason = []string{err.Error()}
 		span.LogKV("error", err)
-		log.Error(err)
+		log.Errorf("Failed to create image %s/%s: %s", i.OrganizationID, i.Name, err)
+		return
 	}
+	log.Infof("Successfully created image %s/%s", i.OrganizationID, i.Name)
 	return
 }
 
@@ -134,6 +182,9 @@ func (h *imageEntityHandler) Delete(ctx context.Context, obj entitystore.Entity)
 	defer span.Finish()
 
 	i := obj.(*Image)
+
+	h.ForceLock(i)
+	defer h.Unlock(i)
 
 	err := h.Builder.imageDelete(ctx, i)
 	if err != nil {
@@ -173,7 +224,7 @@ func NewController(config *ControllerConfig, store entitystore.EntityStore, base
 	})
 
 	c.AddEntityHandler(&baseImageEntityHandler{Store: store, Builder: baseImageBuilder})
-	c.AddEntityHandler(&imageEntityHandler{Store: store, Builder: imageBuilder})
+	c.AddEntityHandler(&imageEntityHandler{Store: store, Builder: imageBuilder, timeout: config.Timeout})
 
 	return c
 }

--- a/pkg/image-manager/controller_test.go
+++ b/pkg/image-manager/controller_test.go
@@ -1,0 +1,29 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package imagemanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vmware/dispatch/pkg/entity-store"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageEntityHandlerCheckAndLock(t *testing.T) {
+	ih := imageEntityHandler{timeout: time.Millisecond}
+	e := &Image{
+		BaseEntity: entitystore.BaseEntity{
+			OrganizationID: "test",
+			ID:             "deadbeef",
+		},
+	}
+	assert.False(t, ih.CheckAndLock(e))
+	assert.True(t, ih.CheckAndLock(e))
+	time.Sleep(time.Millisecond)
+	assert.False(t, ih.CheckAndLock(e))
+}

--- a/pkg/image-manager/handlers.go
+++ b/pkg/image-manager/handlers.go
@@ -35,6 +35,7 @@ var ImageManagerFlags = struct {
 	DbDatabase   string `long:"db-database" description:"Backend DB Name" default:"dispatch"`
 	OrgID        string `long:"organization" description:"(temporary) Static organization id" default:"dispatch"`
 	ResyncPeriod int    `long:"resync-period" description:"The time period (in seconds) to sync with image repository" default:"10"`
+	Timeout      int    `long:"timeout" description:"The max time for image operations (in seconds)" default:"300"`
 	Tracer       string `long:"tracer" description:"Open Tracing Tracer endpoint" default:""`
 }{}
 

--- a/pkg/image-manager/image_builder.go
+++ b/pkg/image-manager/image_builder.go
@@ -159,12 +159,17 @@ func DockerImageStatus(ctx context.Context, client docker.ImageAPIClient, images
 		}
 
 		if _, ok := imageMap[url]; !ok {
+			switch s := i.GetStatus(); s {
 			// If we are READY, but the image is missing from the
 			// repo, move to ERROR state
-			switch s := i.GetStatus(); s {
 			case entitystore.StatusREADY:
 				i.SetStatus(entitystore.StatusMISSING)
 				entities = append(entities, i)
+				log.Errorf("image %s/%s missing from image repository", i.GetOrganizationID(), i.GetName())
+			// If we are INITIALIZED, the image needs to be processed
+			case entitystore.StatusINITIALIZED:
+				entities = append(entities, i)
+				log.Infof("image %s/%s found in INITIALIZED state", i.GetOrganizationID(), i.GetName())
 			}
 		} else {
 			// If the image is present, move to READY if in a
@@ -312,25 +317,30 @@ func (b *ImageBuilder) imageCreate(ctx context.Context, image *Image, baseImage 
 
 	tmpDir, err := ioutil.TempDir("", "image-build")
 	if err != nil {
+		log.Errorf("failed to create temp directory for building image %s: %s", image.Name, err)
 		return errors.Wrap(err, "failed to create a temp dir")
 	}
 	defer os.RemoveAll(tmpDir)
 
 	if err := images.DockerError(b.dockerClient.ImagePull(context.Background(), baseImage.DockerURL, dockerTypes.ImagePullOptions{})); err != nil {
+		log.Errorf("failed to pull base image %s: %s", baseImage.DockerURL, err)
 		return errors.Wrapf(err, "failed to pull image '%s'", baseImage.DockerURL)
 	}
 
 	if err := b.copyImageTemplate(tmpDir, baseImage.DockerURL); err != nil {
+		log.Errorf("failed to copy image template from image %s: %s", image.Name, err)
 		return err
 	}
 
 	spFile := filepath.Join(tmpDir, systemPackagesFile)
 	if err := b.writeSystemPackagesFile(spFile, image); err != nil {
+		log.Errorf("failed to write packages file for image %s [%s]: %s", image.Name, spFile, err)
 		return errors.Wrapf(err, "failed to write packages file %s", spFile)
 	}
 
 	pFile := filepath.Join(tmpDir, packagesFile)
 	if err := b.writePackagesFile(pFile, image); err != nil {
+		log.Errorf("failed to write packages file for image %s [%s]: %s", image.Name, pFile, err)
 		return errors.Wrapf(err, "failed to write %s", pFile)
 	}
 
@@ -342,6 +352,7 @@ func (b *ImageBuilder) imageCreate(ctx context.Context, image *Image, baseImage 
 	}
 	err = images.BuildAndPushFromDir(ctx, b.dockerClient, tmpDir, dockerURL, b.registryAuth, buildArgs)
 	if err != nil {
+		log.Errorf("failed build image %s: %s", image.Name, err)
 		return err
 	}
 	image.DockerURL = dockerURL

--- a/pkg/images/builder.go
+++ b/pkg/images/builder.go
@@ -66,7 +66,7 @@ func Build(ctx context.Context, client docker.ImageAPIClient, dir, name string, 
 
 	files, _ := ioutil.ReadDir(dir)
 	for _, f := range files {
-		log.Debugf("Packing %s", f.Name())
+		log.Infof("Packing %s", f.Name())
 		b, _ := ioutil.ReadFile(filepath.Join(dir, f.Name()))
 		log.Debug(string(b))
 	}
@@ -76,8 +76,8 @@ func Build(ctx context.Context, client docker.ImageAPIClient, dir, name string, 
 		return errors.Wrap(err, "failed to create a tarball archive")
 	}
 
-	log.Debugf("Building image %s from tarball", name)
-	r, err := client.ImageBuild(ctx, tarBall, types.ImageBuildOptions{
+	log.Infof("Building image %s from tarball", name)
+	r, err := client.ImageBuild(context.Background(), tarBall, types.ImageBuildOptions{
 		BuildArgs: buildArgs,
 		Tags:      []string{name},
 	})


### PR DESCRIPTION
* Retry image creation if entity is still INITIALIZED after timeout
  - Also will pick up in progress or interrupted work across restarts
* Fix installer to work with both IPs and ELB/DNS names for exposed services
* Add some additonal logging to image manager
* Set resource requirements for image builder container
* Pin DIND to version