### PR TITLE
[kong/api] Send empty response from gateway if function output is null

### DIFF
--- a/charts/kong/dispatch-transformer/handler.lua
+++ b/charts/kong/dispatch-transformer/handler.lua
@@ -312,11 +312,11 @@ local function substitute_json_response(field, data)
   if not ok then
       return false
   end
-  local result = data
+  local result = nil
   if data[field] then
-    result = data[field]
+    result = cjson.encode(data[field])
   end
-  return true, cjson.encode(result)
+  return true, result
 end
 
 local function substitute_response(conf)


### PR DESCRIPTION
The API gateway will now send an empty response if the function invocation returned null. This is instead of sending the entire function payload with context.