### PR TITLE
[function/timeout] Add function timeout to function context

### DIFF
--- a/pkg/api/v1/function.go
+++ b/pkg/api/v1/function.go
@@ -73,6 +73,9 @@ type Function struct {
 	// status
 	Status Status `json:"status,omitempty"`
 
+	// timeout
+	Timeout int64 `json:"timeout,omitempty"`
+
 	// tags
 	Tags []*Tag `json:"tags"`
 }

--- a/pkg/dispatchcli/cmd/create_function.go
+++ b/pkg/dispatchcli/cmd/create_function.go
@@ -33,6 +33,7 @@ var (
 	schemaOutFile         = ""
 	fnSecrets             = []string{}
 	fnServices            = []string{}
+	timeout               int64
 )
 
 // NewCmdCreateFunction creates command responsible for dispatch function creation.
@@ -55,6 +56,7 @@ func NewCmdCreateFunction(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&schemaOutFile, "schema-out", "", "path to file with output validation schema")
 	cmd.Flags().StringArrayVar(&fnSecrets, "secret", []string{}, "Function secrets, can be specified multiple times or a comma-delimited string")
 	cmd.Flags().StringArrayVar(&fnServices, "service", []string{}, "Service instances this function uses, can be specified multiple times or a comma-delimited string")
+	cmd.Flags().Int64Var(&timeout, "timeout", 0, "A timeout to limit function execution time.")
 	cmd.MarkFlagRequired("image")
 	return cmd
 }
@@ -105,6 +107,7 @@ func createFunction(out, errOut io.Writer, cmd *cobra.Command, args []string) er
 		Handler:  handler,
 		Secrets:  fnSecrets,
 		Services: fnServices,
+		Timeout:  timeout,
 		Tags:     []*v1.Tag{},
 	}
 	if cmdFlagApplication != "" {

--- a/pkg/function-manager/controller.go
+++ b/pkg/function-manager/controller.go
@@ -228,6 +228,8 @@ func (h *runEntityHandler) Add(ctx context.Context, obj entitystore.Entity) (err
 		fctx[functions.HTTPContextKey] = run.HTTPContext
 	}
 
+	fctx[functions.TimeoutKey] = f.Timeout
+
 	output, err := h.Runner.Run(&functions.FunctionExecution{
 		Context:        fctx,
 		OrganizationID: run.OrganizationID,

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -1164,6 +1164,12 @@ func init() {
             "$ref": "#/definitions/functionTagsItems"
           },
           "x-go-name": "Tags"
+        },
+        "timeout": {
+          "description": "timeout",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Timeout"
         }
       },
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -70,6 +70,7 @@ func functionEntityToModel(f *functions.Function) *v1.Function {
 		},
 		Secrets:  f.Secrets,
 		Services: f.Services,
+		Timeout:  f.Timeout,
 		Tags:     tags,
 		Status:   v1.Status(f.Status),
 	}
@@ -112,6 +113,7 @@ func functionModelOntoEntity(m *v1.Function, e *functions.Function) error {
 	e.Handler = m.Handler
 	e.ImageName = *m.Image
 	e.FaasID = string(m.FaasID)
+	e.Timeout = m.Timeout
 	e.Tags = map[string]string{}
 	for _, t := range m.Tags {
 		e.Tags[t.Key] = t.Value

--- a/pkg/functions/context.go
+++ b/pkg/functions/context.go
@@ -21,6 +21,7 @@ const (
 	EventKey       = "event"
 	ErrorKey       = "error"
 	HTTPContextKey = "httpContext"
+	TimeoutKey     = "timeout"
 )
 
 // Logs returns the logs as a list of strings

--- a/pkg/functions/entities.go
+++ b/pkg/functions/entities.go
@@ -29,6 +29,7 @@ type Function struct {
 	Schema           *Schema  `json:"schema,omitempty"`
 	Secrets          []string `json:"secrets,omitempty"`
 	Services         []string `json:"services,omitempty"`
+	Timeout          int64    `json:"timeout,omitempty"`
 }
 
 // Schema struct stores input and output validation schemas

--- a/swagger/models.json
+++ b/swagger/models.json
@@ -641,6 +641,12 @@
             "$ref": "#/definitions/Tag"
           },
           "x-go-name": "Tags"
+        },
+        "timeout": {
+          "description": "timeout",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Timeout"
         }
       },
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"


### PR DESCRIPTION
This simply adds a new timeout field to our function model. Timeouts are inserted to the context passed to function runs. Adds a flag to the function creation cli to set the timeout. A 0 means no timeout. At the moment the timeout is just a number of milliseconds to wait. Is there another format we should use? Look for separate updated base-images that support this change.