### PR TITLE
[git/validate] Fix swagger validation in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,7 +15,10 @@ echo "==> Running format check..."
 echo "==> Running linters..."
 # gometalinter --disable=gotype --vendor --deadline 30s --fast --errors --severity=golint:error ./...
 gometalinter --disable=gotype --vendor --deadline 30s --fast --errors ./...
-swagger validate ./swagger/*
+for file in  ./swagger/*
+do
+  swagger validate "$file"
+done
 
 echo "==> Running unittest check..."
 # Run header check and fix headers

--- a/pkg/api/v1/doc.go
+++ b/pkg/api/v1/doc.go
@@ -1,0 +1,18 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+/*
+Package v1 Dispatch API.
+
+The API for Dispatch framework instances.
+
+    Version: 1.0.0
+    Contact: <dispatch@vmware.com>
+
+swagger:meta
+*/
+package v1
+
+// NO TEST

--- a/swagger/models.json
+++ b/swagger/models.json
@@ -1,5 +1,13 @@
 {
   "swagger": "2.0",
+  "info": {
+    "description": "The API for Dispatch framework instances.",
+    "title": "Dispatch API.",
+    "contact": {
+      "email": "dispatch@vmware.com"
+    },
+    "version": "1.0.0"
+  },
   "paths": {},
   "definitions": {
     "API": {


### PR DESCRIPTION
Requires go-swagger 0.14.0. I'm not sure if that will require updating CI.