### PR TITLE
Make tests logs optional when collecting logs

### DIFF
--- a/ci/e2e/collect-logs.yml
+++ b/ci/e2e/collect-logs.yml
@@ -12,6 +12,7 @@ inputs:
 - name: dispatch
 - name: cluster
 - name: tests-logs
+  optional: true
 
 params:
   GKE_KEY:
@@ -76,7 +77,9 @@ run:
     fi
 
     # Bats log
-    cp tests-logs/bats.log .
+    if [ -d "tests-logs" ]; then
+      cp tests-logs/bats.log .
+    fi
 
 
 


### PR DESCRIPTION
If job fails before it gets to run tests step, the tests-logs resource won't exist. However, we stil want to collect logs.