### PR TITLE
Remove OrgID config flags in some services

### DIFF
--- a/cmd/event-manager/main.go
+++ b/cmd/event-manager/main.go
@@ -114,7 +114,7 @@ func main() {
 	case "rabbitmq":
 		eventTransport, err = transport.NewRabbitMQ(
 			eventmanager.Flags.RabbitMQURL,
-			eventmanager.Flags.OrgID,
+			eventmanager.RabbitMQDefaultExchange,
 		)
 		if err != nil {
 			log.Fatalf("Error creating RabbitMQ event transport: %+v", err)
@@ -143,7 +143,6 @@ func main() {
 			Tracer:          eventmanager.Flags.Tracer,
 			K8sConfig:       eventmanager.Flags.K8sConfig,
 			DriverNamespace: eventmanager.Flags.K8sNamespace,
-			OrgID:           eventmanager.Flags.OrgID,
 		},
 	)
 	if err != nil {

--- a/pkg/api-manager/handlers_test.go
+++ b/pkg/api-manager/handlers_test.go
@@ -34,8 +34,9 @@ func assertAPIEqual(t *testing.T, expected *v1.API, real *v1.API) {
 func addAPI(t *testing.T, a *operations.APIManagerAPI, apiModel *v1.API) {
 
 	params := apihandler.AddAPIParams{
-		HTTPRequest: httptest.NewRequest("POST", "/v1/api", nil),
-		Body:        apiModel,
+		HTTPRequest:  httptest.NewRequest("POST", "/v1/api", nil),
+		Body:         apiModel,
+		XDispatchOrg: testOrgID,
 	}
 
 	responder := a.EndpointAddAPIHandler.Handle(params, "cookie")
@@ -101,7 +102,8 @@ func TestAPIGetAPIs(t *testing.T) {
 	addAPI(t, a, anotherAPI)
 
 	params := apihandler.GetApisParams{
-		HTTPRequest: httptest.NewRequest("GET", "/v1/api", nil),
+		HTTPRequest:  httptest.NewRequest("GET", "/v1/api", nil),
+		XDispatchOrg: testOrgID,
 	}
 	responder := a.EndpointGetApisHandler.Handle(params, "cookie")
 	var respBody []*v1.API
@@ -139,8 +141,9 @@ func TestAPIGetAPI(t *testing.T) {
 	addAPI(t, a, oneAPI)
 
 	params := apihandler.GetAPIParams{
-		HTTPRequest: httptest.NewRequest("GET", "/v1/api", nil),
-		API:         *oneAPI.Name,
+		HTTPRequest:  httptest.NewRequest("GET", "/v1/api", nil),
+		API:          *oneAPI.Name,
+		XDispatchOrg: testOrgID,
 	}
 	responder := a.EndpointGetAPIHandler.Handle(params, "cookie")
 	var respBody v1.API
@@ -170,8 +173,9 @@ func TestAPIDeleteAPI(t *testing.T) {
 	addAPI(t, a, oneAPI)
 
 	params := apihandler.DeleteAPIParams{
-		HTTPRequest: httptest.NewRequest("GET", "/v1/api", nil),
-		API:         *oneAPI.Name,
+		HTTPRequest:  httptest.NewRequest("GET", "/v1/api", nil),
+		API:          *oneAPI.Name,
+		XDispatchOrg: testOrgID,
 	}
 	responder := a.EndpointDeleteAPIHandler.Handle(params, "cookie")
 	var respBody v1.API
@@ -203,9 +207,10 @@ func TestAPIUpdateAPI(t *testing.T) {
 	oneAPI.Hosts = []string{}
 	oneAPI.Uris = []string{"anothertest", "anotherhello"}
 	params := apihandler.UpdateAPIParams{
-		HTTPRequest: httptest.NewRequest("GET", "/v1/api", nil),
-		API:         *oneAPI.Name,
-		Body:        oneAPI,
+		HTTPRequest:  httptest.NewRequest("GET", "/v1/api", nil),
+		API:          *oneAPI.Name,
+		Body:         oneAPI,
+		XDispatchOrg: testOrgID,
 	}
 	responder := a.EndpointUpdateAPIHandler.Handle(params, "cookie")
 	var respBody v1.API

--- a/pkg/event-manager/drivers/entity_handler_test.go
+++ b/pkg/event-manager/drivers/entity_handler_test.go
@@ -48,8 +48,9 @@ func TestDriverDelete(t *testing.T) {
 	handler := mockDriverHandler(backend, es)
 	driver := &entities.Driver{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   "driver1",
-			Status: entitystore.StatusDELETING,
+			Name:           "driver1",
+			Status:         entitystore.StatusDELETING,
+			OrganizationID: testOrgID,
 		},
 		Type: "vcenter",
 	}

--- a/pkg/event-manager/drivers/http_handlers_test.go
+++ b/pkg/event-manager/drivers/http_handlers_test.go
@@ -20,6 +20,10 @@ import (
 	helpers "github.com/vmware/dispatch/pkg/testing/api"
 )
 
+const (
+	testOrgID = "testOrg"
+)
+
 func testHandlers(store entitystore.EntityStore) *Handlers {
 	return &Handlers{
 		store: store,
@@ -34,8 +38,9 @@ func addDriverEntity(t *testing.T, api *operations.EventManagerAPI, name, driver
 	}
 	r := httptest.NewRequest("POST", "/v1/event/eventdrivers", nil)
 	params := drivers.AddDriverParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.DriversAddDriverHandler.Handle(params, "testCookie")
 	var respBody v1.EventDriver
@@ -65,8 +70,9 @@ func addDriverTypeEntity(t *testing.T, api *operations.EventManagerAPI, name, im
 	}
 	r := httptest.NewRequest("POST", "/v1/event/eventdrivertypes", nil)
 	params := drivers.AddDriverTypeParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.DriversAddDriverTypeHandler.Handle(params, "testCookie")
 	var respBody v1.EventDriverType
@@ -123,8 +129,9 @@ func TestDriversGetDriverHandler(t *testing.T) {
 	createdTime := addBody.CreatedTime
 	r := httptest.NewRequest("GET", "/v1/event/eventdrivers/drivername", nil)
 	get := drivers.GetDriverParams{
-		HTTPRequest: r,
-		DriverName:  "drivername",
+		HTTPRequest:  r,
+		DriverName:   "drivername",
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.DriversGetDriverHandler.Handle(get, "testCookie")
 	var getBody v1.EventDriver
@@ -158,7 +165,8 @@ func TestDriversDeleteDriverHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/event/eventdrivers", nil)
 	get := drivers.GetDriversParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.DriversGetDriversHandler.Handle(get, "testCookie")
 	var getBody []v1.EventDriver
@@ -168,8 +176,9 @@ func TestDriversDeleteDriverHandler(t *testing.T) {
 
 	r = httptest.NewRequest("DELETE", "/v1/events/eventdrivers/mydriver", nil)
 	del := drivers.DeleteDriverParams{
-		HTTPRequest: r,
-		DriverName:  "mydriver",
+		HTTPRequest:  r,
+		DriverName:   "mydriver",
+		XDispatchOrg: testOrgID,
 	}
 	delResponder := api.DriversDeleteDriverHandler.Handle(del, "testCookie")
 	var delBody v1.EventDriver
@@ -216,6 +225,7 @@ func TestDriversGetDriverTypeHandler(t *testing.T) {
 	get := drivers.GetDriverTypeParams{
 		HTTPRequest:    r,
 		DriverTypeName: "typename",
+		XDispatchOrg:   testOrgID,
 	}
 	getResponder := api.DriversGetDriverTypeHandler.Handle(get, "testCookie")
 	var getBody v1.EventDriverType
@@ -246,7 +256,8 @@ func TestDriversDeleteDriverTypeHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/event/eventdrivertypes", nil)
 	get := drivers.GetDriverTypesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.DriversGetDriverTypesHandler.Handle(get, "testCookie")
 	var getBody []v1.EventDriver
@@ -266,6 +277,7 @@ func TestDriversDeleteDriverTypeHandler(t *testing.T) {
 	del := drivers.DeleteDriverTypeParams{
 		HTTPRequest:    r,
 		DriverTypeName: "typename",
+		XDispatchOrg:   testOrgID,
 	}
 	delResponder := api.DriversDeleteDriverTypeHandler.Handle(del, "testCookie")
 	var delBody v1.EventDriverType

--- a/pkg/event-manager/subscriptions/entity_handler_test.go
+++ b/pkg/event-manager/subscriptions/entity_handler_test.go
@@ -31,8 +31,9 @@ func TestSubscriptionAdd(t *testing.T) {
 	handler := mockSubscriptionHandler(manager, es)
 	sub := &entities.Subscription{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   "sub1",
-			Status: entitystore.StatusCREATING,
+			Name:           "sub1",
+			Status:         entitystore.StatusCREATING,
+			OrganizationID: testOrgID,
 		},
 		EventType: "test.topic",
 		Function:  "test.function",
@@ -49,8 +50,9 @@ func TestSubscriptionDelete(t *testing.T) {
 	handler := mockSubscriptionHandler(manager, es)
 	sub := &entities.Subscription{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   "sub1",
-			Status: entitystore.StatusDELETING,
+			Name:           "sub1",
+			Status:         entitystore.StatusDELETING,
+			OrganizationID: testOrgID,
 		},
 		EventType: "test.topic",
 		Function:  "test.function",

--- a/pkg/event-manager/subscriptions/http_handlers_test.go
+++ b/pkg/event-manager/subscriptions/http_handlers_test.go
@@ -28,8 +28,9 @@ func addSubscriptionEntity(t *testing.T, api *operations.EventManagerAPI, name, 
 	}
 	r := httptest.NewRequest("POST", "/v1/event/subscriptions", nil)
 	params := subscriptions.AddSubscriptionParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.SubscriptionsAddSubscriptionHandler.Handle(params, "testCookie")
 	var respBody v1.Subscription
@@ -56,7 +57,7 @@ func addSubscriptionEntityWithError(t *testing.T, api *operations.EventManagerAP
 func TestSubscriptionsAddSubscriptionHandlerError(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := Handlers{"", es, nil}
+	h := Handlers{es, nil}
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	respBody := addSubscriptionEntityWithError(t, api, "test.topic", "testfunction")
@@ -67,7 +68,7 @@ func TestSubscriptionsAddSubscriptionHandlerError(t *testing.T) {
 func TestSubscriptionsAddSubscriptionHandler(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := Handlers{"", es, nil}
+	h := Handlers{es, nil}
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	respBody := addSubscriptionEntity(t, api, "mysubscription", "test.topic", "testfunction")
@@ -78,7 +79,7 @@ func TestSubscriptionsAddSubscriptionHandler(t *testing.T) {
 func TestSubscriptionsGetSubscriptionHandler(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := Handlers{"", es, nil}
+	h := Handlers{es, nil}
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBody := addSubscriptionEntity(t, api, "mysubscription", "test.topic", "testfunction")
@@ -89,6 +90,7 @@ func TestSubscriptionsGetSubscriptionHandler(t *testing.T) {
 	get := subscriptions.GetSubscriptionParams{
 		HTTPRequest:      r,
 		SubscriptionName: "mysubscription",
+		XDispatchOrg:     testOrgID,
 	}
 	getResponder := api.SubscriptionsGetSubscriptionHandler.Handle(get, "testCookie")
 	var getBody v1.Subscription
@@ -114,7 +116,7 @@ func TestSubscriptionsGetSubscriptionHandler(t *testing.T) {
 func TestSubscriptionsDeleteSubscriptionHandler(t *testing.T) {
 	api := operations.NewEventManagerAPI(nil)
 	es := helpers.MakeEntityStore(t)
-	h := Handlers{"", es, nil}
+	h := Handlers{es, nil}
 	helpers.MakeAPI(t, h.ConfigureHandlers, api)
 
 	addBody := addSubscriptionEntity(t, api, "mysubscription", "test.topic", "testfunction")
@@ -122,7 +124,8 @@ func TestSubscriptionsDeleteSubscriptionHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/event/subscriptions", nil)
 	get := subscriptions.GetSubscriptionsParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.SubscriptionsGetSubscriptionsHandler.Handle(get, "testCookie")
 	var getBody []v1.Subscription
@@ -134,6 +137,7 @@ func TestSubscriptionsDeleteSubscriptionHandler(t *testing.T) {
 	del := subscriptions.DeleteSubscriptionParams{
 		HTTPRequest:      r,
 		SubscriptionName: "mysubscription",
+		XDispatchOrg:     testOrgID,
 	}
 	delResponder := api.SubscriptionsDeleteSubscriptionHandler.Handle(del, "testCookie")
 	var delBody v1.Subscription

--- a/pkg/event-manager/subscriptions/manager_test.go
+++ b/pkg/event-manager/subscriptions/manager_test.go
@@ -32,10 +32,10 @@ func TestRunFunction(t *testing.T) {
 	queue := &eventsmocks.Transport{}
 	manager := mockSubscriptionManager(queue, fnClient)
 	ev := &events.CloudEvent{}
-	fnClient.On("RunFunction", mock.Anything, "testOrg", mock.AnythingOfType("*v1.Run")).Return(&v1.Run{}, nil).Once()
-	manager.runFunction(context.Background(), "testOrg", "testFunction", ev, []string{"secret1", "secret2"})
+	fnClient.On("RunFunction", mock.Anything, testOrgID, mock.AnythingOfType("*v1.Run")).Return(&v1.Run{}, nil).Once()
+	manager.runFunction(context.Background(), testOrgID, "testFunction", ev, []string{"secret1", "secret2"})
 
-	fnClient.On("RunFunction", mock.Anything, "testOrg", mock.AnythingOfType("*v1.Run")).Return(&v1.Run{}, errors.New("testerror")).Once()
-	manager.runFunction(context.Background(), "testOrg", "testFunction", ev, nil)
+	fnClient.On("RunFunction", mock.Anything, testOrgID, mock.AnythingOfType("*v1.Run")).Return(&v1.Run{}, errors.New("testerror")).Once()
+	manager.runFunction(context.Background(), testOrgID, "testFunction", ev, nil)
 	fnClient.AssertNumberOfCalls(t, "RunFunction", 2)
 }

--- a/pkg/function-manager/controller_test.go
+++ b/pkg/function-manager/controller_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestFuncEntityHandler_Add_ImageNotReady(t *testing.T) {
 	imgMgr := &mocks.ImageGetter{}
-	imgMgr.On("GetImage", mock.Anything, "testOrg", mock.Anything).Return(
+	imgMgr.On("GetImage", mock.Anything, testOrgID, mock.Anything).Return(
 		&v1.Image{
 			Language: "python3",
 			Status:   v1.StatusINITIALIZED,
@@ -35,7 +35,7 @@ func TestFuncEntityHandler_Add_ImageNotReady(t *testing.T) {
 		BaseEntity: entitystore.BaseEntity{
 			Name:           "testFunction",
 			Status:         entitystore.StatusCREATING,
-			OrganizationID: "testOrg",
+			OrganizationID: testOrgID,
 		},
 		ImageName: "testImage",
 		Handler:   "main",
@@ -67,8 +67,9 @@ func TestFuncEntityHandler_Add_ImageReady(t *testing.T) {
 	faas := &fnmocks.FaaSDriver{}
 	function := &functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   "testFunction",
-			Status: entitystore.StatusCREATING,
+			Name:           "testFunction",
+			Status:         entitystore.StatusCREATING,
+			OrganizationID: testOrgID,
 		},
 		ImageName: "testImage",
 		ImageURL:  "test/image:latest",
@@ -99,8 +100,9 @@ func TestFuncEntityHandler_Delete(t *testing.T) {
 	faas := &fnmocks.FaaSDriver{}
 	function := &functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   "testFunction",
-			Status: entitystore.StatusDELETING,
+			Name:           "testFunction",
+			Status:         entitystore.StatusDELETING,
+			OrganizationID: testOrgID,
 		},
 		ImageName: "testImage",
 		Handler:   "main",
@@ -126,7 +128,7 @@ func TestRunEntityHandler_Add(t *testing.T) {
 		BaseEntity: entitystore.BaseEntity{
 			Name:           "testFunction",
 			Status:         entitystore.StatusDELETING,
-			OrganizationID: "testOrg",
+			OrganizationID: testOrgID,
 		},
 		ImageName: "testImage",
 		Handler:   "main",
@@ -135,7 +137,7 @@ func TestRunEntityHandler_Add(t *testing.T) {
 	fnRun := &functions.FnRun{
 		BaseEntity: entitystore.BaseEntity{
 			Name:           "testRun",
-			OrganizationID: "testOrg",
+			OrganizationID: testOrgID,
 		},
 		FunctionName: "testFunction",
 	}
@@ -151,9 +153,9 @@ func TestRunEntityHandler_Add(t *testing.T) {
 		return f
 	}
 	secretInjector := &fnmocks.SecretInjector{}
-	secretInjector.On("GetMiddleware", "testOrg", mock.Anything, "cookie").Return(simw)
+	secretInjector.On("GetMiddleware", testOrgID, mock.Anything, "cookie").Return(simw)
 	serviceInjector := &fnmocks.ServiceInjector{}
-	serviceInjector.On("GetMiddleware", "testOrg", mock.Anything, "cookie").Return(simw)
+	serviceInjector.On("GetMiddleware", testOrgID, mock.Anything, "cookie").Return(simw)
 
 	h := &runEntityHandler{
 		Store: helpers.MakeEntityStore(t),

--- a/pkg/function-manager/handlers_test.go
+++ b/pkg/function-manager/handlers_test.go
@@ -28,6 +28,10 @@ import (
 
 //go:generate mockery -name ImageGetter -case underscore -dir . -note "CLOSE THIS FILE AS QUICKLY AS POSSIBLE"
 
+const (
+	testOrgID = "testOrg"
+)
+
 func TestStoreAddFunctionHandler(t *testing.T) {
 	handlers := &Handlers{
 		Store: helpers.MakeEntityStore(t),
@@ -57,8 +61,9 @@ func TestStoreAddFunctionHandler(t *testing.T) {
 	}
 	r := httptest.NewRequest("POST", "/v1/function", nil)
 	params := fnstore.AddFunctionParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.StoreAddFunctionHandler.Handle(params, "testCookie")
 	var respBody v1.Function
@@ -87,8 +92,9 @@ func TestHandlers_runFunction_notREADY(t *testing.T) {
 
 	handlers.Store.Add(context.Background(), &functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   testFuncName,
-			Status: entitystore.StatusCREATING,
+			Name:           testFuncName,
+			Status:         entitystore.StatusCREATING,
+			OrganizationID: testOrgID,
 		},
 		// other fields are unimportant for this test
 	})
@@ -102,6 +108,7 @@ func TestHandlers_runFunction_notREADY(t *testing.T) {
 		HTTPRequest:  r,
 		Body:         reqBody,
 		FunctionName: &testFuncName,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.RunnerRunFunctionHandler.Handle(params, "testCookie")
 	var respBody v1.Error
@@ -124,8 +131,9 @@ func TestHandlers_runFunction_READY(t *testing.T) {
 
 	function := &functions.Function{
 		BaseEntity: entitystore.BaseEntity{
-			Name:   testFuncName,
-			Status: entitystore.StatusREADY,
+			Name:           testFuncName,
+			Status:         entitystore.StatusREADY,
+			OrganizationID: testOrgID,
 		},
 		// other fields are unimportant for this test
 	}
@@ -140,6 +148,7 @@ func TestHandlers_runFunction_READY(t *testing.T) {
 		HTTPRequest:  r,
 		Body:         reqBody,
 		FunctionName: &testFuncName,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.RunnerRunFunctionHandler.Handle(params, "testCookie")
 	var respBody v1.Run
@@ -179,8 +188,9 @@ func TestStoreGetFunctionHandler(t *testing.T) {
 	}
 	r := httptest.NewRequest("POST", "/v1/function", nil)
 	add := fnstore.AddFunctionParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	addResponder := api.StoreAddFunctionHandler.Handle(add, "testCookie")
 	var addBody v1.Function
@@ -194,6 +204,7 @@ func TestStoreGetFunctionHandler(t *testing.T) {
 	get := fnstore.GetFunctionParams{
 		HTTPRequest:  r,
 		FunctionName: "testEntity",
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.StoreGetFunctionHandler.Handle(get, "testCookie")
 	var getBody v1.Function

--- a/pkg/image-manager/handlers_test.go
+++ b/pkg/image-manager/handlers_test.go
@@ -22,6 +22,10 @@ import (
 	helpers "github.com/vmware/dispatch/pkg/testing/api"
 )
 
+const (
+	testOrgID = "testOrg"
+)
+
 func addBaseImageEntity(t *testing.T, api *operations.ImageManagerAPI, h *Handlers, name, dockerURL, language string, tags map[string]string) *v1.BaseImage {
 	var entityTags []*v1.Tag
 	for k, v := range tags {
@@ -36,8 +40,9 @@ func addBaseImageEntity(t *testing.T, api *operations.ImageManagerAPI, h *Handle
 	}
 	r := httptest.NewRequest("POST", "/v1/baseimage", nil)
 	params := baseimage.AddBaseImageParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.BaseImageAddBaseImageHandler.Handle(params, "testCookie")
 	var respBody v1.BaseImage
@@ -58,8 +63,9 @@ func addImageEntity(t *testing.T, api *operations.ImageManagerAPI, h *Handlers, 
 	}
 	r := httptest.NewRequest("POST", "/v1/image", nil)
 	params := image.AddImageParams{
-		HTTPRequest: r,
-		Body:        reqBody,
+		HTTPRequest:  r,
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
 	}
 	responder := api.ImageAddImageHandler.Handle(params, "testCookie")
 	var respBody v1.Image
@@ -100,6 +106,7 @@ func TestBaseImageGetBaseImageByNameHandler(t *testing.T) {
 	get := baseimage.GetBaseImageByNameParams{
 		HTTPRequest:   r,
 		BaseImageName: "testEntity",
+		XDispatchOrg:  testOrgID,
 	}
 	getResponder := api.BaseImageGetBaseImageByNameHandler.Handle(get, "testCookie")
 	var getBody v1.BaseImage
@@ -138,7 +145,8 @@ func TestBaseImageGetBaseImagesHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/baseimage", nil)
 	get := baseimage.GetBaseImagesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.BaseImageGetBaseImagesHandler.Handle(get, "testCookie")
 	var getBody []v1.BaseImage
@@ -157,7 +165,8 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/baseimage", nil)
 	get := baseimage.GetBaseImagesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.BaseImageGetBaseImagesHandler.Handle(get, "testCookie")
 	var getBody []v1.BaseImage
@@ -168,6 +177,7 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 	del := baseimage.DeleteBaseImageByNameParams{
 		HTTPRequest:   r,
 		BaseImageName: "testEntity",
+		XDispatchOrg:  testOrgID,
 	}
 	delResponder := api.BaseImageDeleteBaseImageByNameHandler.Handle(del, "testCookie")
 	var delBody v1.BaseImage
@@ -190,7 +200,7 @@ func TestImageAddImageHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", "python3", map[string]string{"role": "test"})
 
 	baseImage := BaseImage{}
-	err := es.Get(context.Background(), "", "testBaseImage", entitystore.Options{}, &baseImage)
+	err := es.Get(context.Background(), testOrgID, "testBaseImage", entitystore.Options{}, &baseImage)
 	assert.NoError(t, err)
 	baseImage.Status = StatusREADY
 	_, err = es.Update(context.Background(), baseImage.Revision, &baseImage)
@@ -217,7 +227,7 @@ func TestImageGetImageByNameHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", "python3", map[string]string{"role": "test"})
 
 	baseImage := BaseImage{}
-	err := es.Get(context.Background(), "", "testBaseImage", entitystore.Options{}, &baseImage)
+	err := es.Get(context.Background(), testOrgID, "testBaseImage", entitystore.Options{}, &baseImage)
 	assert.NoError(t, err)
 	baseImage.Status = StatusREADY
 	_, err = es.Update(context.Background(), baseImage.Revision, &baseImage)
@@ -228,8 +238,9 @@ func TestImageGetImageByNameHandler(t *testing.T) {
 	createdTime := addBody.CreatedTime
 	r := httptest.NewRequest("GET", "/v1/image/testImage", nil)
 	get := image.GetImageByNameParams{
-		HTTPRequest: r,
-		ImageName:   "testImage",
+		HTTPRequest:  r,
+		ImageName:    "testImage",
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.ImageGetImageByNameHandler.Handle(get, "testCookie")
 	var getBody v1.Image
@@ -247,8 +258,9 @@ func TestImageGetImageByNameHandler(t *testing.T) {
 
 	r = httptest.NewRequest("GET", "/v1/image/doesNotExist", nil)
 	get = image.GetImageByNameParams{
-		HTTPRequest: r,
-		ImageName:   "doesNotExist",
+		HTTPRequest:  r,
+		ImageName:    "doesNotExist",
+		XDispatchOrg: testOrgID,
 	}
 	getResponder = api.ImageGetImageByNameHandler.Handle(get, "testCookie")
 	var errorBody v1.Error
@@ -265,7 +277,7 @@ func TestImageGetImagesHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", "python3", map[string]string{"role": "test"})
 
 	baseImage := BaseImage{}
-	err := es.Get(context.Background(), "", "testBaseImage", entitystore.Options{}, &baseImage)
+	err := es.Get(context.Background(), testOrgID, "testBaseImage", entitystore.Options{}, &baseImage)
 	assert.NoError(t, err)
 	baseImage.Status = StatusREADY
 	_, err = es.Update(context.Background(), baseImage.Revision, &baseImage)
@@ -276,7 +288,8 @@ func TestImageGetImagesHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/image", nil)
 	get := image.GetImagesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.ImageGetImagesHandler.Handle(get, "testCookie")
 	var getBody []v1.Image
@@ -294,7 +307,7 @@ func TestImageUpdateImageByNameHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", "python3", map[string]string{"role": "test"})
 
 	baseImage := BaseImage{}
-	err := es.Get(context.Background(), "", "testBaseImage", entitystore.Options{}, &baseImage)
+	err := es.Get(context.Background(), testOrgID, "testBaseImage", entitystore.Options{}, &baseImage)
 	assert.NoError(t, err)
 	baseImage.Status = StatusREADY
 	_, err = es.Update(context.Background(), baseImage.Revision, &baseImage)
@@ -303,7 +316,8 @@ func TestImageUpdateImageByNameHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/image", nil)
 	get := image.GetImagesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.ImageGetImagesHandler.Handle(get, "testCookie")
 	var getBody []v1.Image
@@ -320,6 +334,7 @@ func TestImageUpdateImageByNameHandler(t *testing.T) {
 			Name:          &imageName,
 			BaseImageName: &baseImageName,
 		},
+		XDispatchOrg: testOrgID,
 	}
 	updateReponder := api.ImageUpdateImageByNameHandler.Handle(update, "testCookie")
 	var updateBody v1.Image
@@ -337,7 +352,7 @@ func TestImageDeleteImagesByNameHandler(t *testing.T) {
 	addBaseImageEntity(t, api, h, "testBaseImage", "test/base", "python3", map[string]string{"role": "test"})
 
 	baseImage := BaseImage{}
-	err := es.Get(context.Background(), "", "testBaseImage", entitystore.Options{}, &baseImage)
+	err := es.Get(context.Background(), testOrgID, "testBaseImage", entitystore.Options{}, &baseImage)
 	assert.NoError(t, err)
 	baseImage.Status = StatusREADY
 	_, err = es.Update(context.Background(), baseImage.Revision, &baseImage)
@@ -346,7 +361,8 @@ func TestImageDeleteImagesByNameHandler(t *testing.T) {
 
 	r := httptest.NewRequest("GET", "/v1/image", nil)
 	get := image.GetImagesParams{
-		HTTPRequest: r,
+		HTTPRequest:  r,
+		XDispatchOrg: testOrgID,
 	}
 	getResponder := api.ImageGetImagesHandler.Handle(get, "testCookie")
 	var getBody []v1.Image
@@ -355,8 +371,9 @@ func TestImageDeleteImagesByNameHandler(t *testing.T) {
 
 	r = httptest.NewRequest("DELETE", "/v1/image/testImage", nil)
 	del := image.DeleteImageByNameParams{
-		HTTPRequest: r,
-		ImageName:   "testImage",
+		HTTPRequest:  r,
+		ImageName:    "testImage",
+		XDispatchOrg: testOrgID,
 	}
 	delResponder := api.ImageDeleteImageByNameHandler.Handle(del, "testCookie")
 	var delBody v1.Image


### PR DESCRIPTION
Few services were missed in the previous refactor that removed the static OrgID's from service configuration. This patch also fixes other unit tests that weren't passing OrgID to the store methods.