### PR TITLE
Add reason field to function to hold function creation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. For more in
 ### Fixed
 
 - **Fix single file Java support.** Previously Java would fail for single files if no handler argument is provided. [PR #517](https://github.com/vmware/dispatch/pull/517)
+- [[Issue #483](https://github.com/vmware/dispatch/issues/483)] **No helpful error output when an error occurs during function create.**
+Added a `reason` field to the function object to hold function creation errors. [PR #513](https://github.com/vmware/dispatch/pull/513)
 
 ## [0.1.17] - 2018-06-12 - [[Git compare](https://github.com/vmware/dispatch/compare/v0.1.16...v0.1.17)] [[What's new](https://vmware.github.io/dispatch/2018/06/12/v0-1-17-release.html)]
 

--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -168,6 +168,15 @@ load variables
     run_with_retry "dispatch exec http --wait --json | jq -r .output.status" "200" 5 5
 }
 
+@test "Create python function with invalid handler" {
+    run dispatch create function --image=python3 invalid ${DISPATCH_ROOT}/examples/python3 --handler=non_existent_file.handle
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function invalid --json | jq -r .status" "ERROR" 5 5
+    run_with_retry "dispatch get function invalid --json | jq -r '.reason | length'" "1" 5 5
+}
+
 @test "Create python function with logging" {
     src_dir=$(mktemp -d)
     cat << EOF > ${src_dir}/logging_test.py

--- a/pkg/api/v1/function.go
+++ b/pkg/api/v1/function.go
@@ -61,6 +61,9 @@ type Function struct {
 	// Pattern: ^[\w\d\-]+$
 	Name *string `json:"name"`
 
+	// reason
+	Reason []string `json:"reason"`
+
 	// schema
 	Schema *Schema `json:"schema,omitempty"`
 

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -1122,6 +1122,14 @@ func init() {
           "pattern": "^[\\w\\d\\-]+$",
           "x-go-name": "Name"
         },
+        "reason": {
+          "description": "reason",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Reason"
+        },
         "schema": {
           "$ref": "#/definitions/functionSchema"
         },

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -68,6 +68,7 @@ func functionEntityToModel(f *functions.Function) *v1.Function {
 			In:  f.Schema.In,
 			Out: f.Schema.Out,
 		},
+		Reason:   f.Reason,
 		Secrets:  f.Secrets,
 		Services: f.Services,
 		Timeout:  f.Timeout,
@@ -118,6 +119,7 @@ func functionModelOntoEntity(m *v1.Function, e *functions.Function) error {
 	for _, t := range m.Tags {
 		e.Tags[t.Key] = t.Value
 	}
+	e.Reason = m.Reason
 	e.Schema = schema
 	e.Secrets = m.Secrets
 	e.Services = m.Services

--- a/swagger/models.json
+++ b/swagger/models.json
@@ -617,6 +617,14 @@
           "pattern": "^[\\w\\d\\-]+$",
           "x-go-name": "Name"
         },
+        "reason": {
+          "description": "reason",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Reason"
+        },
         "schema": {
           "$ref": "#/definitions/Schema"
         },


### PR DESCRIPTION
Fixes #483 

* Add `reason` field to function object
* When an error occurs during the function image build phase, return the last step that occurred (the one that failed) along with its output as the `reason`
    - It's difficult to determine the exact cause of the error since Docker combines both `stdout` and `stderr` into one stream
    - The only error Docker gives is the last command that failed