### PR TITLE
Update CI k8s image to use latest helm and kubectl

### DIFF
--- a/ci/e2e/cleanup.yml
+++ b/ci/e2e/cleanup.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.11
+    tag: v0.0.12
 
 # dispatch must be dispatch git repo.
 inputs:

--- a/ci/e2e/collect-logs.yml
+++ b/ci/e2e/collect-logs.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.10
+    tag: v0.0.12
 
 # dispatch must be dispatch git repo.
 inputs:

--- a/ci/e2e/deploy-dispatch.yml
+++ b/ci/e2e/deploy-dispatch.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.8
+    tag: v0.0.12
 
 params:
   GKE_KEY:

--- a/ci/e2e/gke-cluster-create.yml
+++ b/ci/e2e/gke-cluster-create.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.8
+    tag: v0.0.12
 
 params:
   GKE_KEY:
@@ -29,12 +29,11 @@ run:
 
     source dispatch/ci/e2e/config-gke-env.sh
 
-    export cluster_name=dispatch-ci-${CLUSTER_NAME_SUFFIX}-$(date +%s)
+    export cluster_name=dispatch-ci-${CLUSTER_NAME_SUFFIX}-$(date +%s)-${RANDOM}
     echo ${cluster_name} > k8s-cluster/name
 
     gcloud container clusters create -m n1-standard-2 --cluster-version ${K8S_VERSION} ${cluster_name}
     gcloud container clusters get-credentials ${cluster_name}
     kubectl create clusterrolebinding tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
-    # Workaround for https://github.com/kubernetes/helm/issues/3379 & https://github.com/kubernetes/helm/issues/3409
-    for i in $(seq 1 5); do helm init --tiller-image powerhome/tiller:git-3b22ecd --wait && break || sleep 5; done
+    helm init --wait

--- a/ci/e2e/run-tests.yml
+++ b/ci/e2e/run-tests.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.10
+    tag: v0.0.12
 
 params:
   GKE_KEY:

--- a/ci/e2e/uninstall-dispatch.yml
+++ b/ci/e2e/uninstall-dispatch.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: vmware/dispatch-k8s-ci
-    tag: v0.0.8
+    tag: v0.0.12
 
 params:
   GKE_KEY:


### PR DESCRIPTION
* Uses image v0.0.12 which has helm 2.9.1, kubectl 1.10.0 and updated gcloud CLI
* should not require the workaround for helm anymore
* adds a random number to cluster name to avoid possible race condition (two clusters with the same name being created at the same exact second)