### PR TITLE
Multi-tenancy Enhancements and New E2E Tests

### DIFF
--- a/ci/e2e/deploy-dispatch.yml
+++ b/ci/e2e/deploy-dispatch.yml
@@ -82,14 +82,13 @@ run:
     openssl rsa -in ci-keys/ci-user.key -pubout -outform PEM -out ci-keys/ci-user.key.pub
 
     # Create ci-user service account for e2e tests
-    svcCmd="dispatch iam create serviceaccount \
+    dispatch iam create serviceaccount \
       ci-user \
-      --public-key ci-keys/ci-user.key.pub"
+      --public-key ci-keys/ci-user.key.pub
 
-    # Temporary workaround until we get to the bottom of the intermittent CI failure with the prev command
-    n=5; until $svcCmd; do if [ $n -gt 0 ] ; then echo "Failed - Retrying attempt $((6-n))"; sleep 5; ((n--)); else break; fi; done
 
-    # Create admin policy for the service account
+    # Create super-admin policy for the service account
     dispatch iam create policy \
       ci-user-admin-policy \
-      --subject ci-user --action "*" --resource "*"
+      --subject ci-user --action "*" --resource "*" \
+      --global

--- a/ci/e2e/run-tests.yml
+++ b/ci/e2e/run-tests.yml
@@ -36,7 +36,7 @@ run:
     export CI=true
     export TERM=linux
     export DISPATCH_ORGANIZATION=ci-org
-    export DISPATCH_SERVICE_ACCOUNT=ci-user
+    export DISPATCH_SERVICE_ACCOUNT="ci-org/ci-user"
     export DISPATCH_JWT_PRIVATE_KEY=$(pwd)/ci-keys/ci-user.key
 
     cp dispatch-cli/dispatch /usr/local/bin/dispatch

--- a/e2e/tests/login.bats
+++ b/e2e/tests/login.bats
@@ -5,62 +5,93 @@ set -o pipefail
 load helpers
 load variables
 
+
+
 @test "Login with service account" {
 
+    tmp_dir=$(mktemp -d)
+    create_test_svc_account login-with-svc-acc ${tmp_dir}
+
+    # Unset the CI accounts (if any)
     svc_acct=${DISPATCH_SERVICE_ACCOUNT}
     pri_key=${DISPATCH_JWT_PRIVATE_KEY}
     unset DISPATCH_SERVICE_ACCOUNT
     unset DISPATCH_JWT_PRIVATE_KEY
 
-    run dispatch login --service-account ${svc_acct} --jwt-private-key ${pri_key}
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account login-with-svc-acc-user --jwt-private-key ${tmp_dir}/private.key
     echo_to_log
-
-    run dispatch get functions
     assert_success
 
+    run dispatch get functions
+    echo_to_log
+    assert_success
+
+    run dispatch logout
+    assert_success
+
+    unset DISPATCH_CONFIG
+
+    # Cleanup
+    rm -r ${tmp_dir}
+
+    # Reset the CI accounts (if any) and custom config file
     export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
     export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
 
-    # using enviroment var in CI, delete login info in dispatch config
-    run dispatch logout
+    delete_test_svc_account login-with-svc-acc
 }
 
 @test "Login with invalid service account" {
 
+    tmp_dir=$(mktemp -d)
+    create_test_svc_account login-invalid-svc-acc ${tmp_dir}
+
+    # Unset the CI accounts (if any)
     svc_acct=${DISPATCH_SERVICE_ACCOUNT}
     pri_key=${DISPATCH_JWT_PRIVATE_KEY}
     unset DISPATCH_SERVICE_ACCOUNT
     unset DISPATCH_JWT_PRIVATE_KEY
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
 
-    run dispatch login --service-account ${svc_acct}_invalid --jwt-private-key ${pri_key}
+    run dispatch login --service-account login-invalid-svc-acc-user-invalid --jwt-private-key ${tmp_dir}/private.key
     echo_to_log
-
-    run dispatch get functions
     assert_failure
+
+    unset DISPATCH_CONFIG
 
     export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
     export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
 
-    # using enviroment var, delete login info in dispatch config
-    run dispatch logout
+    delete_test_svc_account login-invalid-svc-acc
 }
 
 @test "Login with service account with invalid private key" {
 
+    tmp_dir=$(mktemp -d)
+    create_test_svc_account login-invalid-pvt-key ${tmp_dir}
+
+    # Unset the CI accounts (if any)
     svc_acct=${DISPATCH_SERVICE_ACCOUNT}
     pri_key=${DISPATCH_JWT_PRIVATE_KEY}
     unset DISPATCH_SERVICE_ACCOUNT
     unset DISPATCH_JWT_PRIVATE_KEY
 
-    run dispatch login --service-account ${svc_acct}_invalid --jwt-private-key ${pri_key}_invalid
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account login-invalid-pvt-key-user --jwt-private-key ${tmp_dir}/test-invalid.key
     echo_to_log
-
-    run dispatch get functions
     assert_failure
+
+    unset DISPATCH_CONFIG
 
     export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
     export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
 
-    # using enviroment var in CI, delete login info in dispatch config
-    run dispatch logout
+    delete_test_svc_account login-invalid-pvt-key
 }

--- a/e2e/tests/organizations.bats
+++ b/e2e/tests/organizations.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+load variables
+
+
+
+@test "Verify multi-tenancy by creating resources in two different orgs" {
+
+    #######
+    # Setup
+    #######
+    tmp_dir_a=$(mktemp -d)
+    tmp_dir_b=$(mktemp -d)
+    setup_test_org test-org-a ${tmp_dir_a}
+    setup_test_org test-org-b ${tmp_dir_b}
+
+    # Unset the CI accounts (if any)
+    svc_acct=${DISPATCH_SERVICE_ACCOUNT}
+    pri_key=${DISPATCH_JWT_PRIVATE_KEY}
+    org=${DISPATCH_ORGANIZATION}
+    unset DISPATCH_SERVICE_ACCOUNT
+    unset DISPATCH_JWT_PRIVATE_KEY
+    unset DISPATCH_ORGANIZATION
+
+    #####################
+    # Login to test-org-a
+    #####################
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir_a}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account test-org-a-user --jwt-private-key ${tmp_dir_a}/private.key --organization test-org-a
+    echo_to_log
+    assert_success
+
+    # Create images in test-org-a
+    batch_create_images
+
+    # Create function in test-org-a
+    run dispatch create function --image=nodejs node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 15 5
+
+    # Should not be able to view resources in test-org-b
+    run dispatch get functions --organization test-org-b
+    echo_to_log
+    assert_failure
+
+    run dispatch logout
+    assert_success
+
+    unset DISPATCH_CONFIG
+
+    #####################
+    # Login to test-org-b
+    #####################
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir_b}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account test-org-b-user --jwt-private-key ${tmp_dir_b}/private.key --organization test-org-b
+    echo_to_log
+    assert_success
+
+    # Ensure no images exist in test-org-b
+    run bash -c "dispatch get base-image --json | jq '. | length'"
+    assert_equal 0 $output
+
+    # Ensure no functions exist in test-org-b
+    run bash -c "dispatch get functions --json | jq '. | length'"
+    assert_equal 0 $output
+
+    # Create images in test-org-b
+    batch_create_images
+
+    # Create function with same name in test-org-b
+    run dispatch create function --image=nodejs node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 15 5
+
+    run dispatch logout
+    assert_success
+
+    unset DISPATCH_CONFIG
+
+    #########
+    # Cleanup
+    #########
+    # Reset the CI accounts (if any)
+    export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
+    export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
+    export DISPATCH_ORGANIZATION=${org}
+
+    # Cleanup resources
+    rm -r ${tmp_dir_a} ${tmp_dir_b}
+    DISPATCH_ORGANIZATION=test-org-a cleanup
+    DISPATCH_ORGANIZATION=test-org-b cleanup
+    delete_test_org test-org-a
+    delete_test_org test-org-b
+
+}

--- a/pkg/client/identity.go
+++ b/pkg/client/identity.go
@@ -242,9 +242,10 @@ func listPoliciesSwaggerError(err error) error {
 
 // CreateOrganization creates new policy
 func (c *DefaultIdentityClient) CreateOrganization(ctx context.Context, organizationID string, policy *v1.Organization) (*v1.Organization, error) {
+	orgID := c.getOrgID(organizationID)
 	params := swaggerorgs.AddOrganizationParams{
 		Body:         policy,
-		XDispatchOrg: c.getOrgID(organizationID),
+		XDispatchOrg: &orgID,
 		Context:      ctx,
 	}
 	response, err := c.client.Organization.AddOrganization(&params, c.auth)
@@ -380,9 +381,10 @@ func getOrganizationSwaggerError(err error) error {
 
 // ListOrganizations lists all functions
 func (c *DefaultIdentityClient) ListOrganizations(ctx context.Context, organizationID string) ([]v1.Organization, error) {
+	orgID := c.getOrgID(organizationID)
 	params := swaggerorgs.GetOrganizationsParams{
 		Context:      ctx,
-		XDispatchOrg: c.getOrgID(organizationID),
+		XDispatchOrg: &orgID,
 	}
 	response, err := c.client.Organization.GetOrganizations(&params, c.auth)
 	if err != nil {

--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -71,6 +71,8 @@ func initConfig() {
 	if dispatchConfigPath != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(dispatchConfigPath)
+	} else if config := os.Getenv("DISPATCH_CONFIG"); config != "" {
+		viper.SetConfigFile(config)
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
@@ -100,7 +102,6 @@ func initConfig() {
 		viperCtx.BindPFlag("serviceAccount", cmds.PersistentFlags().Lookup("service-account"))
 		viperCtx.BindPFlag("jwtPrivateKey", cmds.PersistentFlags().Lookup("jwt-private-key"))
 		// Limited support for env variables
-		viperCtx.BindEnv("config", "DISPATCH_CONFIG")
 		viperCtx.BindEnv("insecure", "DISPATCH_INSECURE")
 		viperCtx.BindEnv("token", "DISPATCH_TOKEN")
 		viperCtx.BindEnv("organization", "DISPATCH_ORGANIZATION")

--- a/pkg/identity-manager/casbin_entity_adapter.go
+++ b/pkg/identity-manager/casbin_entity_adapter.go
@@ -42,17 +42,17 @@ func (a *CasbinEntityAdapter) LoadPolicy(model casbinModel.Model) error {
 	for _, policy := range policies {
 		// Casbin authorization rules are of the form (org, subject, resource, action) and hence the need to iterate over all rule fields.
 		log.Debugf("Loading policy %s", policy.Name)
-		var orgAttr string
+		var global string
 		if policy.Global {
-			orgAttr = "*"
+			global = "y"
 		} else {
-			orgAttr = policy.OrganizationID
+			global = "n"
 		}
 		for _, rule := range policy.Rules {
 			for _, subject := range rule.Subjects {
 				for _, resource := range rule.Resources {
 					for _, action := range rule.Actions {
-						lineText := fmt.Sprintf("p, %s, %s, %s, %s", orgAttr, subject, resource, action)
+						lineText := fmt.Sprintf("p, %s, %s, %s, %s, %s", global, policy.OrganizationID, subject, resource, action)
 						persist.LoadPolicyLine(lineText, model)
 					}
 				}

--- a/pkg/identity-manager/gen/client/operations/auth_parameters.go
+++ b/pkg/identity-manager/gen/client/operations/auth_parameters.go
@@ -68,7 +68,7 @@ for the auth operation typically these are written to a http.Request
 type AuthParams struct {
 
 	/*XDispatchOrg*/
-	XDispatchOrg string
+	XDispatchOrg *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -109,13 +109,13 @@ func (o *AuthParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithXDispatchOrg adds the xDispatchOrg to the auth params
-func (o *AuthParams) WithXDispatchOrg(xDispatchOrg string) *AuthParams {
+func (o *AuthParams) WithXDispatchOrg(xDispatchOrg *string) *AuthParams {
 	o.SetXDispatchOrg(xDispatchOrg)
 	return o
 }
 
 // SetXDispatchOrg adds the xDispatchOrg to the auth params
-func (o *AuthParams) SetXDispatchOrg(xDispatchOrg string) {
+func (o *AuthParams) SetXDispatchOrg(xDispatchOrg *string) {
 	o.XDispatchOrg = xDispatchOrg
 }
 
@@ -127,9 +127,13 @@ func (o *AuthParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry
 	}
 	var res []error
 
-	// header param X-Dispatch-Org
-	if err := r.SetHeaderParam("X-Dispatch-Org", o.XDispatchOrg); err != nil {
-		return err
+	if o.XDispatchOrg != nil {
+
+		// header param X-Dispatch-Org
+		if err := r.SetHeaderParam("X-Dispatch-Org", *o.XDispatchOrg); err != nil {
+			return err
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/pkg/identity-manager/gen/client/organization/add_organization_parameters.go
+++ b/pkg/identity-manager/gen/client/organization/add_organization_parameters.go
@@ -70,7 +70,7 @@ for the add organization operation typically these are written to a http.Request
 type AddOrganizationParams struct {
 
 	/*XDispatchOrg*/
-	XDispatchOrg string
+	XDispatchOrg *string
 	/*Body
 	  Organization Object
 
@@ -116,13 +116,13 @@ func (o *AddOrganizationParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithXDispatchOrg adds the xDispatchOrg to the add organization params
-func (o *AddOrganizationParams) WithXDispatchOrg(xDispatchOrg string) *AddOrganizationParams {
+func (o *AddOrganizationParams) WithXDispatchOrg(xDispatchOrg *string) *AddOrganizationParams {
 	o.SetXDispatchOrg(xDispatchOrg)
 	return o
 }
 
 // SetXDispatchOrg adds the xDispatchOrg to the add organization params
-func (o *AddOrganizationParams) SetXDispatchOrg(xDispatchOrg string) {
+func (o *AddOrganizationParams) SetXDispatchOrg(xDispatchOrg *string) {
 	o.XDispatchOrg = xDispatchOrg
 }
 
@@ -145,9 +145,13 @@ func (o *AddOrganizationParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	var res []error
 
-	// header param X-Dispatch-Org
-	if err := r.SetHeaderParam("X-Dispatch-Org", o.XDispatchOrg); err != nil {
-		return err
+	if o.XDispatchOrg != nil {
+
+		// header param X-Dispatch-Org
+		if err := r.SetHeaderParam("X-Dispatch-Org", *o.XDispatchOrg); err != nil {
+			return err
+		}
+
 	}
 
 	if o.Body != nil {

--- a/pkg/identity-manager/gen/client/organization/get_organizations_parameters.go
+++ b/pkg/identity-manager/gen/client/organization/get_organizations_parameters.go
@@ -68,7 +68,7 @@ for the get organizations operation typically these are written to a http.Reques
 type GetOrganizationsParams struct {
 
 	/*XDispatchOrg*/
-	XDispatchOrg string
+	XDispatchOrg *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -109,13 +109,13 @@ func (o *GetOrganizationsParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithXDispatchOrg adds the xDispatchOrg to the get organizations params
-func (o *GetOrganizationsParams) WithXDispatchOrg(xDispatchOrg string) *GetOrganizationsParams {
+func (o *GetOrganizationsParams) WithXDispatchOrg(xDispatchOrg *string) *GetOrganizationsParams {
 	o.SetXDispatchOrg(xDispatchOrg)
 	return o
 }
 
 // SetXDispatchOrg adds the xDispatchOrg to the get organizations params
-func (o *GetOrganizationsParams) SetXDispatchOrg(xDispatchOrg string) {
+func (o *GetOrganizationsParams) SetXDispatchOrg(xDispatchOrg *string) {
 	o.XDispatchOrg = xDispatchOrg
 }
 
@@ -127,9 +127,13 @@ func (o *GetOrganizationsParams) WriteToRequest(r runtime.ClientRequest, reg str
 	}
 	var res []error
 
-	// header param X-Dispatch-Org
-	if err := r.SetHeaderParam("X-Dispatch-Org", o.XDispatchOrg); err != nil {
-		return err
+	if o.XDispatchOrg != nil {
+
+		// header param X-Dispatch-Org
+		if err := r.SetHeaderParam("X-Dispatch-Org", *o.XDispatchOrg); err != nil {
+			return err
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/pkg/identity-manager/gen/restapi/embedded_spec.go
+++ b/pkg/identity-manager/gen/restapi/embedded_spec.go
@@ -146,7 +146,7 @@ func init() {
       },
       "parameters": [
         {
-          "$ref": "#/parameters/orgIDParam"
+          "$ref": "#/parameters/orgIDParamOptional"
         }
       ]
     },
@@ -254,7 +254,7 @@ func init() {
       },
       "parameters": [
         {
-          "$ref": "#/parameters/orgIDParam"
+          "$ref": "#/parameters/orgIDParamOptional"
         }
       ]
     },
@@ -1055,6 +1055,11 @@ func init() {
       "name": "X-Dispatch-Org",
       "in": "header",
       "required": true
+    },
+    "orgIDParamOptional": {
+      "type": "string",
+      "name": "X-Dispatch-Org",
+      "in": "header"
     }
   },
   "securityDefinitions": {
@@ -1213,8 +1218,7 @@ func init() {
         {
           "type": "string",
           "name": "X-Dispatch-Org",
-          "in": "header",
-          "required": true
+          "in": "header"
         }
       ]
     },
@@ -1324,8 +1328,7 @@ func init() {
         {
           "type": "string",
           "name": "X-Dispatch-Org",
-          "in": "header",
-          "required": true
+          "in": "header"
         }
       ]
     },
@@ -2417,6 +2420,11 @@ func init() {
       "name": "X-Dispatch-Org",
       "in": "header",
       "required": true
+    },
+    "orgIDParamOptional": {
+      "type": "string",
+      "name": "X-Dispatch-Org",
+      "in": "header"
     }
   },
   "securityDefinitions": {

--- a/pkg/identity-manager/gen/restapi/operations/auth_parameters.go
+++ b/pkg/identity-manager/gen/restapi/operations/auth_parameters.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -37,10 +36,9 @@ type AuthParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*
-	  Required: true
 	  In: header
 	*/
-	XDispatchOrg string
+	XDispatchOrg *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -63,21 +61,18 @@ func (o *AuthParams) BindRequest(r *http.Request, route *middleware.MatchedRoute
 }
 
 func (o *AuthParams) bindXDispatchOrg(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("X-Dispatch-Org", "header")
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: true
+	// Required: false
 
-	if err := validate.RequiredString("X-Dispatch-Org", "header", raw); err != nil {
-		return err
+	if raw == "" { // empty values pass all other validations
+		return nil
 	}
 
-	o.XDispatchOrg = raw
+	o.XDispatchOrg = &raw
 
 	return nil
 }

--- a/pkg/identity-manager/gen/restapi/operations/organization/add_organization_parameters.go
+++ b/pkg/identity-manager/gen/restapi/operations/organization/add_organization_parameters.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -41,10 +40,9 @@ type AddOrganizationParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*
-	  Required: true
 	  In: header
 	*/
-	XDispatchOrg string
+	XDispatchOrg *string
 	/*Organization Object
 	  Required: true
 	  In: body
@@ -95,21 +93,18 @@ func (o *AddOrganizationParams) BindRequest(r *http.Request, route *middleware.M
 }
 
 func (o *AddOrganizationParams) bindXDispatchOrg(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("X-Dispatch-Org", "header")
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: true
+	// Required: false
 
-	if err := validate.RequiredString("X-Dispatch-Org", "header", raw); err != nil {
-		return err
+	if raw == "" { // empty values pass all other validations
+		return nil
 	}
 
-	o.XDispatchOrg = raw
+	o.XDispatchOrg = &raw
 
 	return nil
 }

--- a/pkg/identity-manager/gen/restapi/operations/organization/get_organizations_parameters.go
+++ b/pkg/identity-manager/gen/restapi/operations/organization/get_organizations_parameters.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -37,10 +36,9 @@ type GetOrganizationsParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*
-	  Required: true
 	  In: header
 	*/
-	XDispatchOrg string
+	XDispatchOrg *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -63,21 +61,18 @@ func (o *GetOrganizationsParams) BindRequest(r *http.Request, route *middleware.
 }
 
 func (o *GetOrganizationsParams) bindXDispatchOrg(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	if !hasKey {
-		return errors.Required("X-Dispatch-Org", "header")
-	}
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
 	}
 
-	// Required: true
+	// Required: false
 
-	if err := validate.RequiredString("X-Dispatch-Org", "header", raw); err != nil {
-		return err
+	if raw == "" { // empty values pass all other validations
+		return nil
 	}
 
-	o.XDispatchOrg = raw
+	o.XDispatchOrg = &raw
 
 	return nil
 }

--- a/pkg/identity-manager/policy_api_handler_test.go
+++ b/pkg/identity-manager/policy_api_handler_test.go
@@ -42,7 +42,7 @@ func TestAddPolicyHandler(t *testing.T) {
 	params := policyOperations.AddPolicyParams{
 		HTTPRequest:  r,
 		Body:         reqBody,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	api := setupTestAPI(t, false)
 	responder := api.PolicyAddPolicyHandler.Handle(params, "testCookie")
@@ -85,7 +85,7 @@ func TestAddPolicyHandlerDuplicatePolicy(t *testing.T) {
 	params := policyOperations.AddPolicyParams{
 		HTTPRequest:  r,
 		Body:         reqBody,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	// Pre-create policy with same name
 	api := setupTestAPI(t, true)
@@ -100,7 +100,7 @@ func TestGetPoliciesHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/iam/policy", nil)
 	params := policyOperations.GetPoliciesParams{
 		HTTPRequest:  r,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	// Also, load test data
 	api := setupTestAPI(t, true)
@@ -108,7 +108,7 @@ func TestGetPoliciesHandler(t *testing.T) {
 	var respBody []v1.Policy
 	helpers.HandlerRequest(t, responder, &respBody, http.StatusOK)
 
-	assert.Len(t, respBody, 1)
+	assert.Len(t, respBody, 2)
 	assert.NotEmpty(t, respBody[0].ID)
 	assert.NotNil(t, respBody[0].CreatedTime)
 	assert.Equal(t, "test-policy-1", *respBody[0].Name)
@@ -123,7 +123,7 @@ func TestDeletePolicyHandler(t *testing.T) {
 	params := policyOperations.DeletePolicyParams{
 		HTTPRequest:  r,
 		PolicyName:   "test-policy-1",
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	// Also, load test data
 	api := setupTestAPI(t, true)
@@ -165,7 +165,7 @@ func TestGetPolicyHandler(t *testing.T) {
 	params := policyOperations.GetPolicyParams{
 		HTTPRequest:  r,
 		PolicyName:   "test-policy-1",
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	// Also, load test data
 	api := setupTestAPI(t, true)
@@ -208,7 +208,7 @@ func TestUpdatePolicyHandler(t *testing.T) {
 		HTTPRequest:  r,
 		PolicyName:   "test-policy-1",
 		Body:         reqBody,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 
 	// Also, load test data

--- a/pkg/identity-manager/service_account_api_handler_test.go
+++ b/pkg/identity-manager/service_account_api_handler_test.go
@@ -39,7 +39,7 @@ func setupServiceAccountTestAPI(t *testing.T) *operations.IdentityManagerAPI {
 	svcAccount := &ServiceAccount{
 		BaseEntity: entitystore.BaseEntity{
 			Name:           "test-serviceaccount-1",
-			OrganizationID: testOrgID,
+			OrganizationID: testOrgA,
 		},
 		PublicKey: base64.StdEncoding.EncodeToString(pubKey),
 	}
@@ -57,7 +57,7 @@ func TestAddServiceAccountHandler(t *testing.T) {
 	params := serviceaccountOperations.AddServiceAccountParams{
 		HTTPRequest:  r,
 		Body:         reqBody,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	api := setupServiceAccountTestAPI(t)
 	responder := api.ServiceaccountAddServiceAccountHandler.Handle(params, "testCookie")
@@ -74,7 +74,7 @@ func TestGetServiceAccountsHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/iam/serviceaccount", nil)
 	params := serviceaccountOperations.GetServiceAccountsParams{
 		HTTPRequest:  r,
-		XDispatchOrg: testOrgID,
+		XDispatchOrg: testOrgA,
 	}
 	// Also, load test data
 	api := setupServiceAccountTestAPI(t)
@@ -93,7 +93,7 @@ func TestDeleteServiceAccountHandler(t *testing.T) {
 	params := serviceaccountOperations.DeleteServiceAccountParams{
 		HTTPRequest:        r,
 		ServiceAccountName: "test-serviceaccount-1",
-		XDispatchOrg:       testOrgID,
+		XDispatchOrg:       testOrgA,
 	}
 	// Also, load test data
 	api := setupServiceAccountTestAPI(t)
@@ -112,7 +112,7 @@ func TestGetServiceAccountHandler(t *testing.T) {
 	params := serviceaccountOperations.GetServiceAccountParams{
 		HTTPRequest:        r,
 		ServiceAccountName: "test-serviceaccount-1",
-		XDispatchOrg:       testOrgID,
+		XDispatchOrg:       testOrgA,
 	}
 	// Also, load test data
 	api := setupServiceAccountTestAPI(t)
@@ -146,7 +146,7 @@ func TestUpdateServiceAccountHandlerError(t *testing.T) {
 		HTTPRequest:        r,
 		ServiceAccountName: "test-serviceaccount-1",
 		Body:               reqBody,
-		XDispatchOrg:       testOrgID,
+		XDispatchOrg:       testOrgA,
 	}
 
 	// Also, load test data
@@ -165,7 +165,7 @@ func TestUpdateServiceAccountHandlerInvalidKey(t *testing.T) {
 		HTTPRequest:        r,
 		ServiceAccountName: "test-serviceaccount-1",
 		Body:               reqBody,
-		XDispatchOrg:       testOrgID,
+		XDispatchOrg:       testOrgA,
 	}
 
 	// Also, load test data

--- a/pkg/testing/api/api.go
+++ b/pkg/testing/api/api.go
@@ -10,6 +10,7 @@ package api
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -61,6 +62,11 @@ func MakeAPI(t *testing.T, registrar api.HandlerRegistrar, api api.SwaggerAPI) {
 
 // HandlerRequest is a convenience function for testing API handlers
 func HandlerRequest(t *testing.T, responder middleware.Responder, responseObject interface{}, statusCode int) {
+	HandlerRequestWithResponse(t, responder, responseObject, statusCode)
+}
+
+// HandlerRequestWithResponse is a convenience function for testing API handlers that additionally returns the response object
+func HandlerRequestWithResponse(t *testing.T, responder middleware.Responder, responseObject interface{}, statusCode int) *http.Response {
 	w := httptest.NewRecorder()
 
 	responder.WriteResponse(w, runtime.JSONProducer())
@@ -77,4 +83,5 @@ func HandlerRequest(t *testing.T, responder middleware.Responder, responseObject
 			t.Fatalf("Failed to unmarshal response: %v", err)
 		}
 	}
+	return resp
 }

--- a/swagger/identity-manager.yaml
+++ b/swagger/identity-manager.yaml
@@ -17,6 +17,10 @@ produces:
 - application/json
 basePath: /
 parameters:
+  orgIDParamOptional:
+    in: header
+    name: X-Dispatch-Org
+    type: string
   orgIDParam:
     in: header
     name: X-Dispatch-Org
@@ -84,7 +88,7 @@ paths:
             $ref: "./models.json#/definitions/Error"
   /v1/iam/auth:
     parameters:
-      - $ref: '#/parameters/orgIDParam'
+      - $ref: '#/parameters/orgIDParamOptional'
     get:
       summary: handles authorization
       operationId: auth
@@ -291,7 +295,7 @@ paths:
             $ref: './models.json#/definitions/Error'
   /v1/iam/organization:
     parameters:
-      - $ref: '#/parameters/orgIDParam'
+      - $ref: '#/parameters/orgIDParamOptional'
     post:
       tags:
       - organization


### PR DESCRIPTION
* Adds E2E tests for multi-tenancy
  Basically creates two organizations and creates images, functions with the same name under each of them.
* Removed a workaround in CI setup which was no longer needed.
* Fixes an auth issue with service accounts
   Previously, upon successful authorization of an svc account, the `v1/iam/auth` API was setting `XDispatchOrg` in response header to the orgID of that svc account. This meant the svc account could never login to other organizations even if it had the right policies. With this change, we set the `XDispatchOrg` header to the requested orgID (params.XDispatchOrg) upon successful authorization. We also enhanced the casbin policy model to better distinguish between the requested orgID and the associated orgID in policies.
* Make `X-Dispatch-Org` Header optional in a request to v1/iam/auth API. Earlier this was mandatory, but with this change, we will try to infer the associated org from the bearer token and try to enforce the policy. If the header is specified, then the policy check will be done on the requestedOrg. Either way, the response from `v1/iam/auth` will still contain an `X-Dispatch-Org` header that will be proxied to the backend service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/534)
<!-- Reviewable:end -->
