### PR TITLE
CLI: Improve config file handling and misc fixes

### DIFF
--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -488,7 +488,7 @@ func writeConfig(out, errOut io.Writer, configDir string, config *installConfig)
 		fmt.Fprintf(out, "dispatch api-gateway is running at http port: %d and https port: %d\n",
 			c.APIHTTPPort, c.APIHTTPSPort)
 	}
-	cmdConfig.Current = strings.ToLower(strings.Replace(c.Host, ".", "-", -1))
+	cmdConfig.Current = formatContextName(c.Host)
 	cmdConfig.Contexts[cmdConfig.Current] = c
 	b, err := json.MarshalIndent(cmdConfig, "", "    ")
 	if err != nil {

--- a/pkg/dispatchcli/cmd/login.go
+++ b/pkg/dispatchcli/cmd/login.go
@@ -7,10 +7,8 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -130,16 +128,7 @@ func oidcLogin(in io.Reader, out, errOut io.Writer, cmd *cobra.Command, args []s
 	}
 
 	dispatchConfig.Cookie = cookie
-	cmdConfig.Contexts[cmdConfig.Current] = &dispatchConfig
-	vsConfigJSON, err := json.MarshalIndent(cmdConfig, "", "    ")
-	if err != nil {
-		return errors.Wrap(err, "error marshalling json")
-	}
-
-	err = ioutil.WriteFile(viper.ConfigFileUsed(), vsConfigJSON, 0644)
-	if err != nil {
-		return errors.Wrapf(err, "error writing configuration to file: %s", viper.ConfigFileUsed())
-	}
+	writeConfigFile()
 	fmt.Printf("You have successfully logged in, cookie saved to %s\n", viper.ConfigFileUsed())
 	return nil
 }
@@ -151,17 +140,7 @@ func serviceAccountLogin(in io.Reader, out, errOut io.Writer, cmd *cobra.Command
 	if err != nil {
 		return errors.Wrap(err, "error logging in")
 	}
-	// write dispatchConfig to file
-	cmdConfig.Contexts[cmdConfig.Current] = &dispatchConfig
-	vsConfigJSON, err := json.MarshalIndent(cmdConfig, "", "    ")
-	if err != nil {
-		return errors.Wrap(err, "error marshalling json")
-	}
-
-	err = ioutil.WriteFile(viper.ConfigFileUsed(), vsConfigJSON, 0644)
-	if err != nil {
-		return errors.Wrapf(err, "error writing configuration to file: %s", viper.ConfigFileUsed())
-	}
+	writeConfigFile()
 	fmt.Fprintln(out, "You have successfully logged in")
 	return nil
 }

--- a/pkg/dispatchcli/cmd/logout.go
+++ b/pkg/dispatchcli/cmd/logout.go
@@ -6,14 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
 )
@@ -44,16 +40,7 @@ func logout(in io.Reader, out, errOut io.Writer, cmd *cobra.Command, args []stri
 	dispatchConfig.Cookie = ""
 	dispatchConfig.ServiceAccount = ""
 	dispatchConfig.JWTPrivateKey = ""
-	cmdConfig.Contexts[cmdConfig.Current] = &dispatchConfig
-	vsConfigJSON, err := json.MarshalIndent(cmdConfig, "", "    ")
-	if err != nil {
-		return errors.Wrap(err, "error marshalling json")
-	}
-
-	err = ioutil.WriteFile(viper.ConfigFileUsed(), vsConfigJSON, 0644)
-	if err != nil {
-		return errors.Wrapf(err, "error writing configuration to file: %s", viper.ConfigFileUsed())
-	}
+	writeConfigFile()
 	fmt.Printf("You have successfully logged out\n")
 	return nil
 }

--- a/pkg/dispatchcli/cmd/manage_context.go
+++ b/pkg/dispatchcli/cmd/manage_context.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/viper"
@@ -88,4 +89,8 @@ func formatContextOutput(out io.Writer) error {
 	}
 	table.Render()
 	return nil
+}
+
+func formatContextName(name string) string {
+	return strings.ToLower(strings.Replace(name, ".", "-", -1))
 }

--- a/pkg/dispatchcli/cmd/uninstall.go
+++ b/pkg/dispatchcli/cmd/uninstall.go
@@ -212,11 +212,11 @@ func runUninstall(out, errOut io.Writer, cmd *cobra.Command, args []string) erro
 	configDir, err := homedir.Expand(configDest)
 
 	if _, ok := uninstallService("certs"); ok || !uninstallDryRun {
-		err = uninstallSSLCert(out, errOut, configDir, config.DispatchConfig.Chart.Namespace, config.DispatchConfig.Host, config.DispatchConfig.TLS.SecretName)
+		err = uninstallSSLCert(out, errOut, configDir, serviceNamespaces["dispatch"], config.DispatchConfig.Host, config.DispatchConfig.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}
-		err = uninstallSSLCert(out, errOut, configDir, config.APIGateway.Chart.Namespace, config.APIGateway.Host, config.APIGateway.TLS.SecretName)
+		err = uninstallSSLCert(out, errOut, configDir, serviceNamespaces["api-gateway"], config.APIGateway.Host, config.APIGateway.TLS.SecretName)
 		if err != nil {
 			return errors.Wrapf(err, "Error uninstalling ssl cert %s", uninstallConfigFile)
 		}


### PR DESCRIPTION
* Verifies that the config file specified in `--config` or `DISPATCH_CONFIG` env exists.
* When the current context was missing in config file or the config file didn't exist
  - the flags weren't bound correctly
  - login/logout commands didn't write the config file correctly
* A validation for org is not needed in the CLI since org is not mandatory (e.g when using
  tokens)
* Fixes an issue in `dispatch uninstall` cmd when using the single-namespace option