### PR TITLE
Fix Secrets UUID in get/list results

### DIFF
--- a/pkg/secret-store/builder/dispatch_secret_builder.go
+++ b/pkg/secret-store/builder/dispatch_secret_builder.go
@@ -41,7 +41,7 @@ func (builder *DispatchSecretBuilder) Build() dispatchv1.Secret {
 		tags = append(tags, &dispatchv1.Tag{Key: k, Value: v})
 	}
 	return dispatchv1.Secret{
-		ID:   strfmt.UUID(builder.k8sSecret.UID),
+		ID:   strfmt.UUID(builder.entity.ID),
 		Name: &builder.entity.Name,
 		Kind: utils.SecretKind,
 		// Name:    &builder.k8sSecret.Name,


### PR DESCRIPTION
Return the ID of the entity instead of the UUID from k8s secret in the query/list response of secrets API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/544)
<!-- Reviewable:end -->
