### PR TITLE
Create API paths under org name

### DIFF
--- a/docs/_guides/quickstart.md
+++ b/docs/_guides/quickstart.md
@@ -65,7 +65,7 @@ cat $HOME/.dispatch/config.json
 {
     "host": "<DISPATCH_HOST>",
     "port": <port>,
-    "organization": "",
+    "organization": "dispatch",
     "cookie": "",
     "insecure": true,
     "Json": false
@@ -142,7 +142,7 @@ api-gateway-kongproxy   10.107.109.1   <nodes>       80:31788/TCP,443:32611/TCP 
 We are looking at the port associated with https/443 => 32611. 
 
 ```bash
-$ curl -k "https://$DISPATCH_HOST:32611/hello" -H "Content-Type: application/json" -d '{"name": "Jon", "place": "winterfell"}'
+$ curl -k "https://$DISPATCH_HOST:32611/dispatch/hello" -H "Content-Type: application/json" -d '{"name": "Jon", "place": "winterfell"}'
 {"myField":"Hello, Jon from winterfell"}
 ```
 
@@ -158,7 +158,7 @@ and should just use the port associated with the chosen protocol (443 for https,
 
 For the example endpoint
 ```bash
-curl -k "http://35.203.141.195:443/hello" -H "Content-Type: application/json" -d '{"name": "Jon", "place": "winterfell"}'
+curl -k "http://35.203.141.195:443/dispatch/hello" -H "Content-Type: application/json" -d '{"name": "Jon", "place": "winterfell"}'
 {"myField":"Hello, Jon from winterfell"}
 ```
 

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -42,12 +42,12 @@ load variables
 
     echo "${API_GATEWAY_HTTPS_HOST}"
 
-    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/http -H \"Content-Type: application/json\" -d '{
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/http -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"HTTP\"
         }' | jq -r .myField" "Hello, VMware from HTTP" 6 5
 
-    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/http -k -H \"Content-Type: application/json\" -d '{
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/http -k -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"HTTPS\"
         }' | jq -r .myField" "Hello, VMware from HTTPS" 6 5
@@ -59,12 +59,12 @@ load variables
     assert_success
     run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
 
-    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/https-only -H \"Content-Type: application/json\" -d '{ \
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/https-only -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"HTTPS ONLY\"
         }' | jq -r .message" "Please use HTTPS protocol" 6 5
 
-    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/https-only -k -H \"Content-Type: application/json\" -d '{ \
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/https-only -k -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"HTTPS ONLY\"
         }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
@@ -83,13 +83,13 @@ load variables
     run_with_retry "dispatch get api api-echo --json | jq -r .status" "READY" 6 5
 
     # "blocking: true" is default header
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k -H \"Content-Type: application/json\" -d '{ \
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
         }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
 
     # with "x-serverless-blocking: false", it will not return an result
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-blocking: false' -d '{
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-blocking: false' -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
         }'" "" 6 5
@@ -97,34 +97,34 @@ load variables
     # with "x-dispatch-org: invalid", setting this header should have no effect as it's overwritten by the plugin.
     # if the plugin fails to overwrite this HEADER, it will allow end-users to switch orgs and this test should fail
     # with {"message":"function not found"}.
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-org: invalid' -d '{
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-org: invalid' -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
         }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
 
     # PUT with no content-type and no payload
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
 
     # PUT with json content-type and non-json payload
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k \
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
         -H \"Content-Type: application/json\" -d \"not a json payload\" | jq -r .message" "request body is not json" 6 5
 
     # PUT with x-www-form-urlencoded content-type and x-www-form-urlencoded payload
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k \
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
         -H \"Content-Type: application/x-www-form-urlencoded\" -d \"name=VMware&place=Palo Alto\" | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
 
     # PUT with non-supported content-type and payload
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/hello -k \
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
         -H \"Content-Type: unsupported-content-type\" -d \"some payload\" | jq -r .message" "request body type is not supported: unsupported-content-type" 6 5
 
     # GET with parameters
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto" 6 5
 
     # GET without parameters
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
 
     # Test HTTP Context
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/echo -k | jq -r .context.httpContext.method" "PUT" 6 5
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/echo -k | jq -r .context.httpContext.method" "PUT" 6 5
 }
 
 @test "Test APIs with CORS" {
@@ -134,7 +134,7 @@ load variables
     run_with_retry "dispatch get api api-test-cors --json | jq -r .status" "READY" 10 5
 
     # contains "Access-Control-Allow-Origin: *"
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/cors -k -v -H \"Content-Type: application/json\" -d '{
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/cors -k -v -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
         }' 2>&1 | grep -c \"Access-Control-Allow-Origin: *\"" 1 10 5
@@ -145,14 +145,14 @@ load variables
     assert_success
     run_with_retry "dispatch get api api-test-update --json | jq -r .status" "READY" 6 5
 
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTP_HOST}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
 
     # update path and https
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f api_update.yaml
     assert_success
     run_with_retry "dispatch get api api-test-update --json | jq -r .status" "READY" 6 20
 
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/goodbye -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/goodbye -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
 }
 
 @test "Cleanup" {

--- a/e2e/tests/organizations.bats
+++ b/e2e/tests/organizations.bats
@@ -6,21 +6,15 @@ load helpers
 load variables
 
 
+@test "Create resources in test-org-a" {
 
-@test "Verify multi-tenancy by creating resources in two different orgs" {
-
-    #######
-    # Setup
-    #######
+    ##################
+    # Setup test-org-a
+    ##################
     tmp_dir_a=$(mktemp -d)
-    tmp_dir_b=$(mktemp -d)
     setup_test_org test-org-a ${tmp_dir_a}
-    setup_test_org test-org-b ${tmp_dir_b}
 
     # Unset the CI accounts (if any)
-    svc_acct=${DISPATCH_SERVICE_ACCOUNT}
-    pri_key=${DISPATCH_JWT_PRIVATE_KEY}
-    org=${DISPATCH_ORGANIZATION}
     unset DISPATCH_SERVICE_ACCOUNT
     unset DISPATCH_JWT_PRIVATE_KEY
     unset DISPATCH_ORGANIZATION
@@ -50,10 +44,34 @@ load variables
     echo_to_log
     assert_failure
 
+    run dispatch create api api-test-https-only node-hello-no-schema -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/test-org-a/https-only -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+
     run dispatch logout
     assert_success
 
+    rm -r ${tmp_dir_a}
     unset DISPATCH_CONFIG
+}
+
+@test "Create resources in test-org-b" {
+
+    ##################
+    # Setup test-org-b
+    ##################
+    tmp_dir_b=$(mktemp -d)
+    setup_test_org test-org-b ${tmp_dir_b}
+
+    # Unset the CI accounts (if any)
+    unset DISPATCH_SERVICE_ACCOUNT
+    unset DISPATCH_JWT_PRIVATE_KEY
+    unset DISPATCH_ORGANIZATION
 
     #####################
     # Login to test-org-b
@@ -83,24 +101,26 @@ load variables
 
     run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 15 5
 
+    run dispatch create api api-test-https-only node-hello-no-schema -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/test-org-b/https-only -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+
     run dispatch logout
     assert_success
 
+    rm -r ${tmp_dir_b}
     unset DISPATCH_CONFIG
+}
 
-    #########
-    # Cleanup
-    #########
-    # Reset the CI accounts (if any)
-    export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
-    export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
-    export DISPATCH_ORGANIZATION=${org}
-
+@test cleanup {
     # Cleanup resources
-    rm -r ${tmp_dir_a} ${tmp_dir_b}
     DISPATCH_ORGANIZATION=test-org-a cleanup
     DISPATCH_ORGANIZATION=test-org-b cleanup
     delete_test_org test-org-a
     delete_test_org test-org-b
-
 }

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -7,3 +7,4 @@
 : ${BASE_IMAGE_POWERSHELL:="powershell-base:0.0.10"}
 : ${BASE_IMAGE_JAVA:="java-base:0.0.10"}
 : ${IMAGES_YAML:="images.yaml"}
+: ${DISPATCH_ORGANIZATION:=${DISPATCH_ORGANIZATION:-dispatch}}

--- a/pkg/api-manager/controller.go
+++ b/pkg/api-manager/controller.go
@@ -43,11 +43,11 @@ func (h *apiEntityHandler) Add(ctx context.Context, obj entitystore.Entity) (err
 
 	defer func() { h.store.UpdateWithError(ctx, api, err) }()
 
-	gwAPI, err := h.gw.UpdateAPI(ctx, api.Name, &api.API)
+	gwAPI, err := h.gw.UpdateAPI(ctx, api.API.Name, &api.API)
 	if err != nil {
 		return ewrapper.Wrap(err, "gateway error when adding api")
 	}
-	log.Infof("api %s added by gateway", api.Name)
+	log.Infof("api %s added by gateway", api.API.Name)
 	api.Status = entitystore.StatusREADY
 	api.API.ID = gwAPI.ID
 	api.API.CreatedAt = gwAPI.CreatedAt

--- a/pkg/api-manager/handlers_test.go
+++ b/pkg/api-manager/handlers_test.go
@@ -68,6 +68,40 @@ func TestAPIAddAPI(t *testing.T) {
 	addAPI(t, a, reqBody)
 }
 
+func TestAPIAddAPINoHosts(t *testing.T) {
+
+	a := operations.NewAPIManagerAPI(nil)
+	es := helpers.MakeEntityStore(t)
+	h := NewHandlers(nil, es)
+
+	helpers.MakeAPI(t, h.ConfigureHandlers, a)
+
+	reqBody := &v1.API{
+		Name:           swag.String("testAPI"),
+		Function:       swag.String("testFunction"),
+		Authentication: "public",
+		Enabled:        true,
+		Hosts:          []string{},
+		Uris:           []string{"test", "/hello"},
+		Methods:        []string{"GET", "POST"},
+		Protocols:      []string{"http", "https"},
+		TLS:            "testtls",
+	}
+
+	params := apihandler.AddAPIParams{
+		HTTPRequest:  httptest.NewRequest("POST", "/v1/api", nil),
+		Body:         reqBody,
+		XDispatchOrg: testOrgID,
+	}
+
+	responder := a.EndpointAddAPIHandler.Handle(params, "cookie")
+	var respBody v1.API
+	helpers.HandlerRequest(t, responder, &respBody, 200)
+
+	expected := []string{"/" + testOrgID + "/test", "/" + testOrgID + "/hello"}
+	assert.Equal(t, expected, respBody.Uris)
+}
+
 func TestAPIGetAPIs(t *testing.T) {
 
 	a := operations.NewAPIManagerAPI(nil)
@@ -204,7 +238,7 @@ func TestAPIUpdateAPI(t *testing.T) {
 	}
 	addAPI(t, a, oneAPI)
 
-	oneAPI.Hosts = []string{}
+	oneAPI.Hosts = []string{"test.com"}
 	oneAPI.Uris = []string{"anothertest", "anotherhello"}
 	params := apihandler.UpdateAPIParams{
 		HTTPRequest:  httptest.NewRequest("GET", "/v1/api", nil),

--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -16,11 +16,11 @@ import (
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/vmware/dispatch/pkg/utils"
-
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
 	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
+	"github.com/vmware/dispatch/pkg/utils"
 )
 
 var cmdConfig struct {

--- a/pkg/dispatchcli/cmd/create_api.go
+++ b/pkg/dispatchcli/cmd/create_api.go
@@ -55,7 +55,7 @@ func NewCmdCreateAPI(out io.Writer, errOut io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVarP(&cmdFlagApplication, "application", "a", "", "associate with an application")
 	cmd.Flags().StringArrayVarP(&hosts, "domain", "d", []string{}, "domain names that point to your API (multi-values), default: empty")
-	cmd.Flags().StringArrayVarP(&paths, "path", "p", []string{"/"}, "paths that point to your API (multi-values), default: /")
+	cmd.Flags().StringArrayVarP(&paths, "path", "p", []string{"/"}, "relative paths that point to your API (multi-values), default: /")
 	cmd.Flags().StringArrayVarP(&methods, "method", "m", []string{"GET"}, "methods that point to your API, default: GET")
 	cmd.Flags().BoolVar(&httpsOnly, "https-only", false, "only support https connections, default: false")
 	cmd.Flags().BoolVar(&disable, "disable", false, "disable the api, default: false")

--- a/pkg/event-sidecar/cmd.go
+++ b/pkg/event-sidecar/cmd.go
@@ -19,13 +19,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/vmware/dispatch/pkg/utils"
 
 	"github.com/vmware/dispatch/pkg/event-sidecar/listener"
 	"github.com/vmware/dispatch/pkg/events"
 	"github.com/vmware/dispatch/pkg/events/parser"
 	"github.com/vmware/dispatch/pkg/events/transport"
 	"github.com/vmware/dispatch/pkg/events/validator"
+	"github.com/vmware/dispatch/pkg/utils"
 )
 
 // NO TESTS


### PR DESCRIPTION
Creates the user-specified API paths under the org name. This is because we share an API Gateway and the paths from different org's can overlap. For production uses, user usually specifies a hostname for the API's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/550)
<!-- Reviewable:end -->
