### PR TITLE
Add CI base images pipeline

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -8,6 +8,7 @@ Dispatch Concourse server can be accessed via [ci.dispatchframework.io](https://
 Dispatch CI consists (as of today) of two pipelines:
 * `dispatch-pr` - executed for every Pull Request. runs basic syntax checks, unit tests and coverage.
 * `e2e` - executed for open PRs with `run-e2e` label.
+* `base-images` - executed for open PRs on every language base images
 
 New pipelines will be added as needed.
 
@@ -17,7 +18,22 @@ E2E pipeline runs 3 jobs:
 
 * `build-images` - compiles binaries, builds docker images and pushes them to a docker registry with tag based on date and commit id.
 * `deploy-dispatch` - Deploys dispatch o one of pre-created k8s clusters. Access to these clusters is managed using [Pool resource](https://github.com/concourse/pool-resource).
-* `run-tests` - Executes all tests defined in `e2e/tests`. Tests are written using [Bats](https://github.com/sstephenson/bats). 
+* `run-tests` - Executes all tests defined in `e2e/tests`. Tests are written using [Bats](https://github.com/sstephenson/bats).
+
+### Base Images pipeline
+
+`base-images` has several jobs:
+* `create-gke-cluster` and `delete-gke-cluster`: create and delete gke cluster. Both jobs are triggered manually.
+* `install-dispatch`: deploys dispatch running instance, triggered by every Dispatch release and will update the existing dispatch intance automatically.
+* `uninstall-dispatch`: uninstalls dispatch, triggered manually.
+
+For each specific language, will have following jobs:
+* `build-<LANGUAGE>-base-image`: builds base image based on language pr.
+* `test-<LANGUAGE>-base-image`: runs tests on the base image from above pr. And report status back to github pull request.
+
+To add tests for a base image:
+* `dispatch/ci/base-images/tests/<LANGUAGE>/task.yml`: concourse ci job yml runs tests. Customize this file to add more language-specific tests preparation.
+* `dispatch/ci/base-images/tests/<LANGUAGE>/tests.bats`: bats file contains all tests functions. Tests inside this file will be executed by default.
 
 
 ## Introduction to Concourse
@@ -43,7 +59,7 @@ dispatch-pr  no      yes
 ```
 $ fly -t dispatch jobs -p dispatch-pr
 name            paused  status     next
-dispatch-basic  no      succeeded  n/a 
+dispatch-basic  no      succeeded  n/a
 ```
 
 Pipelines in Concourse revolve around three main concepts: *tasks*, *jobs* and *resources* (read more about them [here](http://concourse.ci/concepts.html)).

--- a/ci/README.md
+++ b/ci/README.md
@@ -5,7 +5,7 @@ Dispatch Concourse server can be accessed via [ci.dispatchframework.io](https://
 
 ## Current pipelines
 
-Dispatch CI consists (as of today) of two pipelines:
+Dispatch CI consists (as of today) of the following pipelines:
 * `dispatch-pr` - executed for every Pull Request. runs basic syntax checks, unit tests and coverage.
 * `e2e` - executed for open PRs with `run-e2e` label.
 * `base-images` - executed for open PRs on every language base images
@@ -24,7 +24,7 @@ E2E pipeline runs 3 jobs:
 
 `base-images` has several jobs:
 * `create-gke-cluster` and `delete-gke-cluster`: create and delete gke cluster. Both jobs are triggered manually.
-* `install-dispatch`: deploys dispatch running instance, triggered by every Dispatch release and will update the existing dispatch intance automatically.
+* `install-dispatch`: deploys dispatch running instance, triggered by every Dispatch release and will update the existing dispatch instance automatically.
 * `uninstall-dispatch`: uninstalls dispatch, triggered manually.
 
 For each specific language, will have following jobs:

--- a/ci/base-images/base-image-tag.yml
+++ b/ci/base-images/base-image-tag.yml
@@ -1,0 +1,30 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-golang-ci
+    tag: "1.10"
+
+inputs:
+- name: base-image
+
+outputs:
+- name: build-context
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    cp -r base-image/* build-context/
+
+    pushd base-image
+      export IMAGE_TAG="$(date +'%y%m%d%H%M%S')-$(git rev-parse --short HEAD)"
+    popd
+
+    echo ${IMAGE_TAG} > build-context/tag
+    echo "tag=${IMAGE_TAG}" > build-context/keyval.properties

--- a/ci/base-images/config-dispatch-env.sh
+++ b/ci/base-images/config-dispatch-env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cp dispatch-release/dispatch-linux /usr/local/bin/dispatch
+chmod +x /usr/local/bin/dispatch
+
+export INSTALL_DISPATCH=0
+export CI=true
+export TERM=linux
+export DISPATCH_ORGANIZATION=ci-org
+export DISPATCH_SERVICE_ACCOUNT="ci-org/ci-user"
+export DISPATCH_JWT_PRIVATE_KEY=$(pwd)/ci-keys/ci-user.key
+
+mkdir -p ~/.dispatch
+
+export LOADBALANCER_IP=$(kubectl get svc/ingress-nginx-ingress-controller -n kube-system -o json | jq -r '.status.loadBalancer.ingress[0].ip')
+export API_GATEWAY_IP=$(kubectl get svc/api-gateway-kongproxy -n kong -o json | jq -r '.status.loadBalancer.ingress[0].ip')
+cp dispatch/ci/base-images/configs/dispatch-config.json ~/.dispatch/config.json
+sed -i "s/LOADBALANCER_IP/$LOADBALANCER_IP/g" ~/.dispatch/config.json
+sed -i "s/CURRENT_CONTEXT/$(echo $LOADBALANCER_IP | tr '.' '-')/g" ~/.dispatch/config.json
+
+export API_GATEWAY_HTTPS_HOST="https://${API_GATEWAY_IP}:443"
+export API_GATEWAY_HTTP_HOST="http://${API_GATEWAY_IP}:80"

--- a/ci/base-images/config-gke-env.sh
+++ b/ci/base-images/config-gke-env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# config gke environment: account, project and zone
+set -e +x -u
+
+: ${GKE_ZONE:="us-west1-c"}
+
+echo "Setting up GKE key"
+echo ${GKE_KEY} | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+echo "Activating GKE account"
+gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json >/dev/null 2>&1
+echo "Setting GKE project"
+gcloud config set project ${GKE_PROJECT_ID} >/dev/null 2>&1
+echo "Setting default GKE compute zone"
+gcloud config set compute/zone ${GKE_ZONE} >/dev/null 2>&1
+
+set -x

--- a/ci/base-images/config-k8s-env.sh
+++ b/ci/base-images/config-k8s-env.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# config k8s cluster environment: get cluster credentials
+set -e +x -u
+
+export cluster_name=$(cat k8s-cluster/keyval.properties | grep "cluster_name" | cut -d'=' -f2)
+gcloud container clusters get-credentials ${cluster_name}
+
+helm init -c
+helm repo remove local
+
+set -x

--- a/ci/base-images/configs/dispatch-config.json
+++ b/ci/base-images/configs/dispatch-config.json
@@ -1,0 +1,14 @@
+{
+  "current": "CURRENT_CONTEXT",
+  "contexts": {
+    "CURRENT_CONTEXT": {
+      "host": "LOADBALANCER_IP",
+      "port": 443,
+      "organization": "",
+      "cookie": "",
+      "insecure": true,
+      "json": false,
+      "namespace": "dispatch"
+    }
+  }
+}

--- a/ci/base-images/configs/dispatch-install.yml
+++ b/ci/base-images/configs/dispatch-install.yml
@@ -1,0 +1,14 @@
+ingress:
+  serviceType: LoadBalancer
+apiGateway:
+  serviceType: LoadBalancer
+  host: 10.0.0.1
+dispatch:
+  host: 10.0.0.1
+  port: 443
+  faas: FAAS
+  eventTransport: EVENT_TRANSPORT
+  image:
+    host: DOCKER_REGISTRY_HOST
+    tag: IMAGE_TAG
+  skipAuth: false

--- a/ci/base-images/gke-cluster-create.yml
+++ b/ci/base-images/gke-cluster-create.yml
@@ -1,0 +1,39 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  K8S_VERSION: 1.9.6-gke.1
+  GKE_ZONE: us-west1-c
+  CLUSTER_NAME_SUFFIX: job
+
+inputs:
+- name: dispatch
+
+outputs:
+- name: k8s-cluster
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+
+    export cluster_name=dispatch-ci-${CLUSTER_NAME_SUFFIX}-$(date +%s)-${RANDOM}
+    echo "cluster_name=${cluster_name}" > k8s-cluster/name
+
+    gcloud container clusters create -m n1-standard-2 --cluster-version ${K8S_VERSION} ${cluster_name}
+    gcloud container clusters get-credentials ${cluster_name}
+    kubectl create clusterrolebinding tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+
+    helm init --wait

--- a/ci/base-images/gke-cluster-delete.yml
+++ b/ci/base-images/gke-cluster-delete.yml
@@ -1,0 +1,62 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  MAX_ATTEMPTS: 18
+  TIMEOUT: 10
+
+inputs:
+- name: dispatch
+- name: k8s-cluster
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    set +x
+
+    # Delete load balancers
+    while read -r line && [[ -n ${line} ]]; do
+        namespace=$(echo $line | awk '{print $1;}')
+        svc_name=$(echo $line | awk '{print $2;}')
+        attempts=0
+
+        kubectl delete -n ${namespace} svc ${svc_name}
+
+        # Wait until LB is deleted asynchronously before deleting cluster (Workaround for https://github.com/kubernetes/kubernetes/issues/51701)
+        until (kubectl get -n ${namespace} events | grep ${svc_name} | grep -q DeletedLoadBalancer); do
+            sleep ${TIMEOUT}
+            attempts=$((attempts+1))
+
+            # Prevent possible infinite loop
+            if [[ ${attempts} -ge ${MAX_ATTEMPTS} ]]; then
+                break
+            fi
+        done
+    done <<< $(kubectl get svc --all-namespaces | grep LoadBalancer)
+
+    # Persistant storage info
+    export PERSISTANT_STORAGE=$(kubectl -n dispatch get pv -o json | jq -r '.items[0].spec.gcePersistentDisk.pdName // empty')
+
+    # Delete cluster
+    gcloud container clusters delete --quiet ${cluster_name}
+    # Delete persistent storage
+    if [[ -n ${PERSISTANT_STORAGE} ]]; then
+      gcloud compute disks delete --quiet ${PERSISTANT_STORAGE}
+    fi
+
+    set -x

--- a/ci/base-images/install-dispatch.yml
+++ b/ci/base-images/install-dispatch.yml
@@ -17,7 +17,6 @@ params:
 inputs:
 - name: dispatch
 - name: dispatch-release
-- name: version
 - name: k8s-cluster
 
 
@@ -37,7 +36,7 @@ run:
     cp dispatch-release/dispatch-linux /usr/local/bin/dispatch
     chmod +x /usr/local/bin/dispatch
 
-    export IMAGE_TAG="v$(cat version/version)"
+    export IMAGE_TAG="v$(cat dispatch-release/version)"
 
     set +x
     cp dispatch/ci/base-images/configs/dispatch-install.yml install.yml

--- a/ci/base-images/install-dispatch.yml
+++ b/ci/base-images/install-dispatch.yml
@@ -1,0 +1,92 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  DOCKER_REGISTRY_HOST:
+  FAAS: openfaas
+  EVENT_TRANSPORT: kafka
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: version
+- name: k8s-cluster
+
+
+outputs:
+- name: ci-keys
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    cp dispatch-release/dispatch-linux /usr/local/bin/dispatch
+    chmod +x /usr/local/bin/dispatch
+
+    export IMAGE_TAG="v$(cat version/version)"
+
+    set +x
+    cp dispatch/ci/base-images/configs/dispatch-install.yml install.yml
+    set -x
+
+    # setup install config file
+    sed -i "s/IMAGE_TAG/${IMAGE_TAG}/g" install.yml
+    sed -i "s#DOCKER_REGISTRY_HOST#${DOCKER_REGISTRY_HOST}#g" install.yml
+    sed -i "s/FAAS/${FAAS}/g" install.yml
+    sed -i "s/EVENT_TRANSPORT/${EVENT_TRANSPORT}/g" install.yml
+
+    cp -r dispatch/charts ./charts
+
+    dispatch install --file install.yml --charts-dir ./charts
+
+    # setup Dispatch config
+    mkdir -p ~/.dispatch
+
+    export LOADBALANCER_IP=$(kubectl get svc/ingress-nginx-ingress-controller -n kube-system -o json | jq -r '.status.loadBalancer.ingress[0].ip')
+    cp dispatch/ci/base-images/configs/dispatch-config.json ~/.dispatch/config.json
+    sed -i "s/LOADBALANCER_IP/$LOADBALANCER_IP/g" ~/.dispatch/config.json
+    sed -i "s/CURRENT_CONTEXT/$(echo $LOADBALANCER_IP | tr '.' '-')/g" ~/.dispatch/config.json
+
+    # Bootstrap Dispatch with default org, service-accounts
+    dispatch manage bootstrap --bootstrap-org ci-org
+
+    if (dispatch iam get serviceaccount | grep -q ci-user)
+    then
+      # delete servcie account first
+      dispatch iam delete serviceaccount ci-user
+    fi
+
+    if (dispatch iam get policy | grep -q ci-user-admin-policy)
+    then
+      # delete svc acct policy
+      dispatch iam delete policy ci-user-admin-policy
+    fi
+
+    # generate svc-acct keys
+    openssl genrsa -out ci-keys/ci-user.key 4096
+    openssl rsa -in ci-keys/ci-user.key -pubout -outform PEM -out ci-keys/ci-user.key.pub
+
+    # Create ci-user service account
+    dispatch iam create serviceaccount \
+      ci-user \
+      --public-key ci-keys/ci-user.key.pub
+
+    # Create super-admin policy for the service account
+    dispatch iam create policy \
+      ci-user-admin-policy \
+      --subject ci-user --action "*" --resource "*" \
+      --global

--- a/ci/base-images/tests/clojure/task.yml
+++ b/ci/base-images/tests/clojure/task.yml
@@ -1,0 +1,44 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  REPOSITORY:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: ci-keys
+- name: k8s-cluster
+- name: tag
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    # TODO: add tests
+    export image_name=dispatch-clojure-base-image
+    export tag=$(cat tag/keyval.properties | grep "tag" | cut -d'=' -f2)
+
+    export image_url=${REPOSITORY}/${image_name}:${tag}
+
+    echo ${image_url}
+
+    chmod +x ./dispatch/ci/base-images/tests/run-tests.sh
+    ./dispatch/ci/base-images/tests/run-tests.sh ./dispatch/ci/base-images/tests/clojure/tests.bats
+

--- a/ci/base-images/tests/clojure/tests.bats
+++ b/ci/base-images/tests/clojure/tests.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${DISPATCH_ROOT}/e2e/tests/helpers.bash
+
+@test "Version" {
+    run dispatch version
+    echo_to_log
+}

--- a/ci/base-images/tests/java/task.yml
+++ b/ci/base-images/tests/java/task.yml
@@ -1,0 +1,43 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  REPOSITORY:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: ci-keys
+- name: k8s-cluster
+- name: tag
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    # TODO: add tests
+    export image_name=dispatch-java-base-image
+    export tag=$(cat tag/keyval.properties | grep "tag" | cut -d'=' -f2)
+
+    export image_url=${REPOSITORY}/${image_name}:${tag}
+
+    echo ${image_url}
+
+    chmod +x ./dispatch/ci/base-images/tests/run-tests.sh
+    ./dispatch/ci/base-images/tests/run-tests.sh ./dispatch/ci/base-images/tests/java/tests.bats

--- a/ci/base-images/tests/java/tests.bats
+++ b/ci/base-images/tests/java/tests.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${DISPATCH_ROOT}/e2e/tests/helpers.bash
+
+@test "Version" {
+    run dispatch version
+    echo_to_log
+}
+
+@test "Create java base image" {
+
+    run dispatch create base-image java-base-image ${image_url} --language java
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get base-image java-base-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create java image" {
+    run dispatch create image java-image java-base-image
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get image java-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create java function no schema" {
+    run dispatch create function --image=java java-hello-no-schema ${DISPATCH_ROOT}/examples/java/hello-with-deps --handler=io.dispatchframework.examples.Hello
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function java-hello-no-schema --json | jq -r .status" "READY" 20 5
+}
+
+@test "Execute java function no schema" {
+    run_with_retry "dispatch exec java-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Cleanup" {
+    delete_entities function
+    cleanup
+}

--- a/ci/base-images/tests/nodejs/task.yml
+++ b/ci/base-images/tests/nodejs/task.yml
@@ -1,0 +1,43 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  REPOSITORY:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: ci-keys
+- name: k8s-cluster
+- name: tag
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    # TODO: add tests
+    export image_name=dispatch-nodejs-base-image
+    export tag=$(cat tag/keyval.properties | grep "tag" | cut -d'=' -f2)
+
+    export image_url=${REPOSITORY}/${image_name}:${tag}
+
+    echo ${image_url}
+
+    chmod +x ./dispatch/ci/base-images/tests/run-tests.sh
+    ./dispatch/ci/base-images/tests/run-tests.sh ./dispatch/ci/base-images/tests/nodejs/tests.bats

--- a/ci/base-images/tests/nodejs/tests.bats
+++ b/ci/base-images/tests/nodejs/tests.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${DISPATCH_ROOT}/e2e/tests/helpers.bash
+
+@test "Create nodejs base image" {
+
+    run dispatch create base-image nodejs-base-image ${image_url} --language nodejs
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get base-image nodejs-base-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create nodejs image" {
+    run dispatch create image nodejs-image nodejs-base-image
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get image nodejs-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create nodejs function no schema" {
+    run dispatch create function --image=nodejs-image nodejs-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function nodejs-hello-no-schema --json | jq -r .status" "READY" 10 5
+}
+
+@test "Execute node function no schema" {
+    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 10 5
+}
+
+@test "Delete node function no schema" {
+    run dispatch delete function node-hello-no-schema
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get runs node-hello-no-schema --json | jq '. | length'" 0 5 5
+}
+
+@test "Create node function with schema" {
+    run dispatch create function --image=nodejs node-hello-with-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js --schema-in ${DISPATCH_ROOT}/examples/nodejs/hello.schema.in.json --schema-out ${DISPATCH_ROOT}/examples/nodejs/hello.schema.out.json
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-with-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Execute node function with schema" {
+    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Execute node function with input schema error" {
+    run_with_retry "dispatch exec node-hello-with-schema --wait --json | jq -r .error.type" "InputError" 5 5
+}
+
+@test "Cleanup" {
+    delete_entities function
+    cleanup
+}

--- a/ci/base-images/tests/powershell/task.yml
+++ b/ci/base-images/tests/powershell/task.yml
@@ -1,0 +1,43 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  REPOSITORY:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: ci-keys
+- name: k8s-cluster
+- name: tag
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    # TODO: add tests
+    export image_name=dispatch-powershell-base-image
+    export tag=$(cat tag/keyval.properties | grep "tag" | cut -d'=' -f2)
+
+    export image_url=${REPOSITORY}/${image_name}:${tag}
+
+    echo ${image_url}
+
+    chmod +x ./dispatch/ci/base-images/tests/run-tests.sh
+    ./dispatch/ci/base-images/tests/run-tests.sh ./dispatch/ci/base-images/tests/powershell/tests.bats

--- a/ci/base-images/tests/powershell/tests.bats
+++ b/ci/base-images/tests/powershell/tests.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${DISPATCH_ROOT}/e2e/tests/helpers.bash
+
+@test "Version" {
+    run dispatch version
+    echo_to_log
+}

--- a/ci/base-images/tests/python3/task.yml
+++ b/ci/base-images/tests/python3/task.yml
@@ -1,0 +1,43 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+  REPOSITORY:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: ci-keys
+- name: k8s-cluster
+- name: tag
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    # TODO: add tests
+    export image_name=dispatch-python3-base-image
+    export tag=$(cat tag/keyval.properties | grep "tag" | cut -d'=' -f2)
+
+    export image_url=${REPOSITORY}/${image_name}:${tag}
+
+    echo ${image_url}
+
+    chmod +x ./dispatch/ci/base-images/tests/run-tests.sh
+    ./dispatch/ci/base-images/tests/run-tests.sh ./dispatch/ci/base-images/tests/python3/tests.bats

--- a/ci/base-images/tests/python3/tests.bats
+++ b/ci/base-images/tests/python3/tests.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${DISPATCH_ROOT}/e2e/tests/helpers.bash
+
+@test "Version" {
+    run dispatch version
+    echo_to_log
+}
+
+@test "Create python3 base image" {
+
+    run dispatch create base-image python3-base-image ${image_url} --language python3
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get base-image python3-base-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create python3 image" {
+    run dispatch create image python3-image python3-base-image
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get image python3-image --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create python function no schema" {
+    run dispatch create function --image=python3-image python-hello-no-schema ${DISPATCH_ROOT}/examples/python3 --handler=hello.handle
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function python-hello-no-schema --json | jq -r .status" "READY" 10 5
+}
+
+@test "Execute python function no schema" {
+    run_with_retry "dispatch exec python-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Cleanup" {
+    delete_entities function
+    cleanup
+}

--- a/ci/base-images/tests/run-tests.sh
+++ b/ci/base-images/tests/run-tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Usage: ./run-tests.sh [tests bat file]
+
+set -e
+
+mkdir $(pwd)/test-logs
+export BATS_LOG=$(pwd)/test-logs/bats.log
+
+export DISPATCH_ROOT=$(pwd)/dispatch
+
+function run_bats() {
+    echo "==> running tests:"
+    bats $1
+    if [[ $? -ne 0 ]]; then
+        EXIT_STATUS=1
+    fi
+    echo "tests finished <=="
+}
+
+
+EXIT_STATUS=0
+run_bats "$1"
+
+# TODO: delete
+cat ${BATS_LOG}
+
+exit ${EXIT_STATUS}

--- a/ci/base-images/uninstall-dispatch.yml
+++ b/ci/base-images/uninstall-dispatch.yml
@@ -1,0 +1,36 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-k8s-ci
+    tag: v0.0.12
+
+params:
+  GKE_KEY:
+  GKE_PROJECT_ID:
+
+inputs:
+- name: dispatch
+- name: dispatch-release
+- name: k8s-cluster
+
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+
+    source dispatch/ci/base-images/config-gke-env.sh
+    source dispatch/ci/base-images/config-k8s-env.sh
+
+    source dispatch/ci/base-images/config-dispatch-env.sh
+
+    cp dispatch/ci/base-images/configs/dispatch-install.yml install.yaml
+
+    dispatch uninstall -f install.yaml
+
+    echo "Dispatch uninstalled"

--- a/ci/pipelines/base-images.yml
+++ b/ci/pipelines/base-images.yml
@@ -1,0 +1,542 @@
+---
+resource_types:
+
+- name: keyval
+  type: docker-image
+  source:
+    repository: swce/keyval-resource
+
+- name: pull-request
+  type: docker-image
+  source:
+    repository: jtarchie/pr
+
+
+resources:
+
+# dispatch repo
+- name: dispatch-master
+  type: git
+  source:
+    uri: https://github.com/vmware/dispatch.git
+    branch: master
+
+# latest release contains binaries
+- name: dispatch-release
+  type: github-release
+  source:
+    owner: vmware
+    repository: dispatch
+    access_token: ((github-access-token))
+
+# pool resource for locking environment during test
+- name: k8s-env-pool
+  type: pool
+  source:
+    uri: git@github.com:dispatchframework/ci-base-images-lock.git
+    branch: master
+    pool: k8s-cluster
+    private_key: ((dfbot-private-key))
+
+# store k8s cluster name
+- name: k8s-cluster
+  type: keyval
+
+# store python3 base images tag
+- name: python3-base-image-env
+  type: keyval
+
+  # store nodejs base images tag
+- name: nodejs-base-image-env
+  type: keyval
+
+# store java base images tag
+- name: java-base-image-env
+  type: keyval
+
+# store clojure base images tag
+- name: clojure-base-image-env
+  type: keyval
+
+# store powershell base images tag
+- name: powershell-base-image-env
+  type: keyval
+
+# ci-user private keys
+- name: ci-keys
+  type: s3
+  source:
+    bucket: ((s3-keys-bucket-name))
+    private: true
+    versioned_file: ci-keys/ci-user.key
+    region_name: ((s3-keys-bucket-region-name))
+    access_key_id: ((s3-keys-bucket-access-key))
+    secret_access_key: ((s3-keys-bucket-secret-key))
+
+- name: version
+  type: semver
+  source:
+    initial_version: 0.1.3
+    bucket: ((s3-ci-bucket-name))
+    key: current-version
+    region_name: ((s3-ci-bucket-region-name))
+    access_key_id: ((s3-ci-bucket-access-key))
+    secret_access_key: ((s3-ci-bucket-secret-key))
+
+
+# python3 base image pr
+- name: python3-base-image-pr
+  type: pull-request
+  source:
+    repo: dispatchframework/python3-base-image
+    uri: git@github.com:dispatchframework/python3-base-image.git
+    access_token: ((github-access-token))
+    private_key: ((github-private-key))
+    every: true
+
+- name: python3-base-image
+  type: docker-image
+  source:
+    username: ((ci-registry-username.gcr))
+    password: ((ci-registry-password.gcr))
+    repository: ((ci-registry-org.gcr))/dispatch-python3-base-image
+
+
+# nodejs base image pr
+- name: nodejs-base-image-pr
+  type: pull-request
+  source:
+    repo: dispatchframework/nodejs-base-image
+    uri: git@github.com:dispatchframework/nodejs-base-image
+    access_token: ((github-access-token))
+    private_key: ((github-private-key))
+    every: true
+
+- name: nodejs-base-image
+  type: docker-image
+  source:
+    username: ((ci-registry-username.gcr))
+    password: ((ci-registry-password.gcr))
+    repository: ((ci-registry-org.gcr))/dispatch-nodejs-base-image
+
+
+# java base image pr
+- name: java-base-image-pr
+  type: pull-request
+  source:
+    repo: dispatchframework/java-base-image
+    uri: git@github.com:dispatchframework/java-base-image
+    access_token: ((github-access-token))
+    private_key: ((github-private-key))
+    every: true
+
+- name: java-base-image
+  type: docker-image
+  source:
+    username: ((ci-registry-username.gcr))
+    password: ((ci-registry-password.gcr))
+    repository: ((ci-registry-org.gcr))/dispatch-java-base-image
+
+
+# clojure base image pr
+- name: clojure-base-image-pr
+  type: pull-request
+  source:
+    repo: dispatchframework/clojure-base-image
+    uri: git@github.com:dispatchframework/clojure-base-image
+    access_token: ((github-access-token))
+    private_key: ((github-private-key))
+    every: true
+
+- name: clojure-base-image
+  type: docker-image
+  source:
+    username: ((ci-registry-username.gcr))
+    password: ((ci-registry-password.gcr))
+    repository: ((ci-registry-org.gcr))/dispatch-clojure-base-image
+
+
+# powershell base image pr
+- name: powershell-base-image-pr
+  type: pull-request
+  source:
+    repo: dispatchframework/powershell-base-image
+    uri: git@github.com:dispatchframework/powershell-base-image
+    access_token: ((github-access-token))
+    private_key: ((github-private-key))
+    every: true
+
+- name: powershell-base-image
+  type: docker-image
+  source:
+    username: ((ci-registry-username.gcr))
+    password: ((ci-registry-password.gcr))
+    repository: ((ci-registry-org.gcr))/dispatch-powershell-base-image
+
+
+jobs:
+
+- name: create-gke-cluster
+  public: true
+  plan:
+  - get: dispatch
+    resource: dispatch-master
+  - task: create-gke-cluster
+    file: dispatch/ci/base-images/gke-cluster-create.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      CLUSTER_NAME_SUFFIX: job-base-image
+  - put: k8s-cluster
+    params:
+      file: k8s-cluster/name
+
+- name: delete-gke-cluster
+  public: true
+  plan:
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - task: delete-gke-cluster
+    file: dispatch/ci/base-images/gke-cluster-delete.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+
+
+- name: deploy-dispatch
+  public: true
+  plan:
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+      trigger: true
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+    - get: version
+  - task: deploy-dispatch
+    file: dispatch/ci/base-images/install-dispatch.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      DOCKER_REGISTRY_HOST: ((docker-hub-org))
+      FAAS: openfaas
+      EVENT_TRANSPORT: rabbitmq
+    input_mapping:
+      version: version
+  - put: ci-keys
+    params:
+      file: ci-keys/ci-user.key
+
+
+- name: uninstall-dispatch
+  public: true
+  plan:
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - task: uninstall-dispatch
+    file: dispatch/ci/base-images/uninstall-dispatch.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+
+
+- name: build-python3-base-image
+  public: true
+  plan:
+  - aggregate:
+    - get: base-image
+      resource: python3-base-image-pr
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+  - task: base-image-tag
+    file: dispatch/ci/base-images/base-image-tag.yml
+  - put: python3-base-image
+    params:
+      build: build-context
+      dockerfile: build-context/Dockerfile
+      tag: build-context/tag
+  - put: python3-base-image-env
+    params:
+      file: build-context/keyval.properties
+
+
+- name: test-python3-base-image
+  public: true
+  plan:
+  - put: k8s-env-pool
+    params: {acquire: true}
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: python3-base-image-env
+      passed: [build-python3-base-image]
+      trigger: true
+    - get: ci-keys
+      passed: [deploy-dispatch]
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - put: python3-base-image-pr
+    params: {path: python3-base-image, context: tests, status: pending}
+  - task: test-python3
+    file: dispatch/ci/base-images/tests/python3/task.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      REPOSITORY: ((ci-registry-org.gcr))
+    input_mapping:
+      tag: python3-base-image-env
+  on_success:
+    put: python3-base-image-pr
+    params: {path: python3-base-image, context: tests, status: success}
+  on_failure:
+    put: python3-base-image-pr
+    params: {path: python3-base-image, context: tests, status: failure}
+  ensure: *test_ensure
+
+
+- name: build-nodejs-base-image
+  public: true
+  plan:
+  - aggregate:
+    - get: base-image
+      resource: nodejs-base-image-pr
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+  - task: base-image-tag
+    file: dispatch/ci/base-images/base-image-tag.yml
+  - put: nodejs-base-image
+    params:
+      build: build-context
+      dockerfile: build-context/Dockerfile
+      tag: build-context/tag
+  - put: nodejs-base-image-env
+    params:
+      file: build-context/keyval.properties
+
+
+- name: test-nodejs-base-image
+  public: true
+  plan:
+  - put: k8s-env-pool
+    params: {acquire: true}
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: nodejs-base-image-env
+      passed: [build-nodejs-base-image]
+      trigger: true
+    - get: ci-keys
+      passed: [deploy-dispatch]
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - put: nodejs-base-image-pr
+    params: {path: nodejs-base-image, context: tests, status: pending}
+  - task: test-nodejs
+    file: dispatch/ci/base-images/tests/nodejs/task.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      REPOSITORY: ((ci-registry-org.gcr))
+    input_mapping:
+      tag: nodejs-base-image-env
+  on_success:
+    put: nodejs-base-image-pr
+    params: {path: nodejs-base-image, context: tests, status: success}
+  on_failure:
+    put: nodejs-base-image-pr
+    params: {path: nodejs-base-image, context: tests, status: failure}
+  ensure: *test_ensure
+
+
+- name: build-java-base-image
+  public: true
+  plan:
+  - aggregate:
+    - get: base-image
+      resource: java-base-image-pr
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+  - task: base-image-tag
+    file: dispatch/ci/base-images/base-image-tag.yml
+  - put: java-base-image
+    params:
+      build: build-context
+      dockerfile: build-context/Dockerfile
+      tag: build-context/tag
+  - put: java-base-image-env
+    params:
+      file: build-context/keyval.properties
+
+
+- name: test-java-base-image
+  public: true
+  plan:
+  - put: k8s-env-pool
+    params: {acquire: true}
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: java-base-image-env
+      passed: [build-java-base-image]
+      trigger: true
+    - get: ci-keys
+      passed: [deploy-dispatch]
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - put: java-base-image-pr
+    params: {path: java-base-image, context: tests, status: pending}
+  - task: test-java
+    file: dispatch/ci/base-images/tests/java/task.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      REPOSITORY: ((ci-registry-org.gcr))
+    input_mapping:
+      tag: java-base-image-env
+  on_success:
+    put: java-base-image-pr
+    params: {path: java-base-image, context: tests, status: success}
+  on_failure:
+    put: java-base-image-pr
+    params: {path: java-base-image, context: tests, status: failure}
+  ensure: *test_ensure
+
+
+- name: build-clojure-base-image
+  public: true
+  plan:
+  - aggregate:
+    - get: base-image
+      resource: clojure-base-image-pr
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+  - task: base-image-tag
+    file: dispatch/ci/base-images/base-image-tag.yml
+  - put: clojure-base-image
+    params:
+      build: build-context
+      dockerfile: build-context/Dockerfile
+      tag: build-context/tag
+  - put: clojure-base-image-env
+    params:
+      file: build-context/keyval.properties
+
+
+- name: test-clojure-base-image
+  public: true
+  plan:
+  - put: k8s-env-pool
+    params: {acquire: true}
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: clojure-base-image-env
+      passed: [build-clojure-base-image]
+      trigger: true
+    - get: ci-keys
+      passed: [deploy-dispatch]
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - put: clojure-base-image-pr
+    params: {path: clojure-base-image, context: tests, status: pending}
+  - task: test-clojure
+    file: dispatch/ci/base-images/tests/clojure/task.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      REPOSITORY: ((ci-registry-org.gcr))
+    input_mapping:
+      tag: clojure-base-image-env
+  on_success:
+    put: clojure-base-image-pr
+    params: {path: clojure-base-image, context: tests, status: success}
+  on_failure:
+    put: clojure-base-image-pr
+    params: {path: clojure-base-image, context: tests, status: failure}
+  ensure: *test_ensure
+
+
+- name: build-powershell-base-image
+  public: true
+  plan:
+  - aggregate:
+    - get: base-image
+      resource: powershell-base-image-pr
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+  - task: base-image-tag
+    file: dispatch/ci/base-images/base-image-tag.yml
+  - put: powershell-base-image
+    params:
+      build: build-context
+      dockerfile: build-context/Dockerfile
+      tag: build-context/tag
+  - put: powershell-base-image-env
+    params:
+      file: build-context/keyval.properties
+
+
+- name: test-powershell-base-image
+  public: true
+  plan:
+  - put: k8s-env-pool
+    params: {acquire: true}
+  - aggregate:
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: dispatch-release
+    - get: powershell-base-image-env
+      passed: [build-powershell-base-image]
+      trigger: true
+    - get: ci-keys
+      passed: [deploy-dispatch]
+    - get: k8s-cluster
+      passed: [create-gke-cluster]
+  - put: powershell-base-image-pr
+    params: {path: powershell-base-image, context: tests, status: pending}
+  - task: test-powershell
+    file: dispatch/ci/base-images/tests/powershell/task.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      REPOSITORY: ((ci-registry-org.gcr))
+    input_mapping:
+      tag: powershell-base-image-env
+  on_success:
+    put: powershell-base-image-pr
+    params: {path: powershell-base-image, context: tests, status: success}
+  on_failure:
+    put: powershell-base-image-pr
+    params: {path: powershell-base-image, context: tests, status: failure}
+  ensure: *test_ensure
+
+
+templates:
+  test_ensure: &test_ensure
+    do:
+    - put: k8s-env-pool
+      params: {release: k8s-env-pool}

--- a/ci/pipelines/base-images.yml
+++ b/ci/pipelines/base-images.yml
@@ -73,16 +73,6 @@ resources:
     access_key_id: ((s3-keys-bucket-access-key))
     secret_access_key: ((s3-keys-bucket-secret-key))
 
-- name: version
-  type: semver
-  source:
-    initial_version: 0.1.3
-    bucket: ((s3-ci-bucket-name))
-    key: current-version
-    region_name: ((s3-ci-bucket-region-name))
-    access_key_id: ((s3-ci-bucket-access-key))
-    secret_access_key: ((s3-ci-bucket-secret-key))
-
 
 # python3 base image pr
 - name: python3-base-image-pr
@@ -217,7 +207,6 @@ jobs:
       trigger: true
     - get: k8s-cluster
       passed: [create-gke-cluster]
-    - get: version
   - task: deploy-dispatch
     file: dispatch/ci/base-images/install-dispatch.yml
     params:
@@ -226,8 +215,6 @@ jobs:
       DOCKER_REGISTRY_HOST: ((docker-hub-org))
       FAAS: openfaas
       EVENT_TRANSPORT: rabbitmq
-    input_mapping:
-      version: version
   - put: ci-keys
     params:
       file: ci-keys/ci-user.key


### PR DESCRIPTION
* Adding a new pipeline in CI, which is for testing language base images under dispatchframework repo. 
* Update CI README

In this pipeline, some key jobs are:
* `create/delete gke cluster` jobs are triggered manually
* `deploy/update dispatch` job is triggered by Dispatch release
* `build base image` job is trigger by base image repo pr, and then `test base image` job will be triggered using new image. So each language base image will have separate build & test jobs.

A testing pipeline has been setup in ci.dispatchframework.io.

**TODO**:
* `reuse scripts` - some scripts and task files are partially shared across pipelines, which might be able to simplify and extract separated script. It will need some refactor
* `tests` - add tests for each language base image.
* UI layout is somehow messy. Haven't found a way to  change it.