### PR TITLE
Add local API gateway to API manager

### DIFF
--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -82,13 +82,13 @@ load variables
     assert_success
     run_with_retry "dispatch get api api-echo --json | jq -r .status" "READY" 6 5
 
-    # "blocking: true" is default header
+    # "x-dispatch-blocking: true" is default header
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
         }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
 
-    # with "x-serverless-blocking: false", it will not return an result
+    # with "x-dispatch-blocking: false", it will not return an result
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-blocking: false' -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"

--- a/e2e/tests/helpers.bash
+++ b/e2e/tests/helpers.bash
@@ -217,14 +217,17 @@ run_with_retry() {
       run bash -c "${1}"
       assert_success
       echo_to_log
-      if [[ ${output} =~ "${2}" ]]; then
-          break
+      if [[ ${output} == ${2} ]]; then
+          return 0
+      fi
+      if [[ ${output} =~ ${2} ]]; then
+          return 0
       fi
       sleep ${4}
   done
   echo ${1}
   echo $output
-  [[ ${output} =~ "${2}" ]]
+  return 1
 }
 
 batch_create_images() {

--- a/pkg/api-manager/gateway/local/gateway.go
+++ b/pkg/api-manager/gateway/local/gateway.go
@@ -1,0 +1,127 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/vmware/dispatch/pkg/api-manager/gateway"
+	"github.com/vmware/dispatch/pkg/client"
+	"github.com/vmware/dispatch/pkg/errors"
+	"github.com/vmware/dispatch/pkg/http"
+	"github.com/vmware/dispatch/pkg/trace"
+)
+
+// Gateway implements API Manager Gateway using local HTTP server.
+type Gateway struct {
+	Server *http.Server
+
+	fnClient client.FunctionsClient
+
+	sync.RWMutex
+	pathLookup   map[string][]*gateway.API
+	hostLookup   map[string][]*gateway.API
+	methodLookup map[string][]*gateway.API
+	apis         map[string]*gateway.API
+}
+
+// NewGateway creates a new local API gateway
+func NewGateway(functionsClient client.FunctionsClient) (*Gateway, error) {
+	c := &Gateway{
+		fnClient:     functionsClient,
+		Server:       http.NewServer(nil),
+		apis:         make(map[string]*gateway.API),
+		pathLookup:   make(map[string][]*gateway.API),
+		hostLookup:   make(map[string][]*gateway.API),
+		methodLookup: make(map[string][]*gateway.API),
+	}
+	return c, nil
+}
+
+// GetAPI gets the API
+func (g *Gateway) GetAPI(ctx context.Context, name string) (*gateway.API, error) {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	g.RLock()
+	defer g.RUnlock()
+	if api, ok := g.apis[name]; ok {
+		apiCopy := *api
+		return &apiCopy, nil
+	}
+	return nil, &errors.ObjectNotFoundError{Err: fmt.Errorf("api %s not found", name)}
+}
+
+// AddAPI adds an API to internal registry
+func (g *Gateway) AddAPI(ctx context.Context, entity *gateway.API) (*gateway.API, error) {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	g.Lock()
+	defer g.Unlock()
+	apiCopy := *entity
+	g.apis[entity.Name] = &apiCopy
+	g.rebuildCache()
+
+	return entity, nil
+}
+
+// UpdateAPI updates the API
+func (g *Gateway) UpdateAPI(ctx context.Context, name string, entity *gateway.API) (*gateway.API, error) {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	g.Lock()
+	defer g.Unlock()
+	_, ok := g.apis[name]
+	if !ok {
+		return nil, &errors.ObjectNotFoundError{Err: fmt.Errorf("api %s not found", name)}
+	}
+	apiCopy := *entity
+	g.apis[name] = &apiCopy
+	g.rebuildCache()
+
+	return entity, nil
+}
+
+// DeleteAPI deletes the API
+func (g *Gateway) DeleteAPI(ctx context.Context, api *gateway.API) error {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	g.Lock()
+	defer g.Unlock()
+	delete(g.apis, api.Name)
+	g.rebuildCache()
+	return nil
+}
+
+// rebuildCache iterates over all configured APIs and populates lookup caches. Could optimized
+// to only add changes.
+func (g *Gateway) rebuildCache() {
+	g.hostLookup = make(map[string][]*gateway.API)
+	g.methodLookup = make(map[string][]*gateway.API)
+	g.pathLookup = make(map[string][]*gateway.API)
+	for i, api := range g.apis {
+		if !api.Enabled {
+			continue
+		}
+		for _, method := range api.Methods {
+			g.methodLookup[method] = append(g.methodLookup[method], g.apis[i])
+		}
+		for _, path := range api.URIs {
+			g.pathLookup[path] = append(g.pathLookup[path], g.apis[i])
+		}
+		for _, host := range api.Hosts {
+			g.hostLookup[host] = append(g.hostLookup[host], g.apis[i])
+		}
+	}
+	log.Debugf("Cache rebuilt: methods: %#v, paths: %#v, hosts: %#v", g.methodLookup, g.pathLookup, g.hostLookup)
+}

--- a/pkg/api-manager/gateway/local/gateway_test.go
+++ b/pkg/api-manager/gateway/local/gateway_test.go
@@ -1,0 +1,132 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/vmware/dispatch/pkg/api-manager/gateway"
+	"github.com/vmware/dispatch/pkg/api/v1"
+	"github.com/vmware/dispatch/pkg/client/mocks"
+)
+
+func TestGatewayGetRequest(t *testing.T) {
+	// empty API matches everything
+	fnClient := &mocks.FunctionsClient{}
+	fnClient.On("RunFunction", mock.Anything, mock.Anything, mock.Anything).Return(
+		&v1.Run{}, nil,
+	)
+	gw, err := NewGateway(fnClient)
+	assert.NoError(t, err)
+
+	api1 := &gateway.API{
+		ID:        uuid.NewV4().String(),
+		CreatedAt: int(time.Now().Unix()),
+		Name:      "api1",
+		Function:  "function1",
+		URIs:      []string{"/hello"},
+		Methods:   []string{"GET"},
+		Enabled:   true,
+	}
+
+	req1 := httptest.NewRequest("GET", "http://localhost:8080/hello", nil)
+
+	rec1 := httptest.NewRecorder()
+	gw.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusNotFound, rec1.Code)
+
+	gw.AddAPI(context.Background(), api1)
+	rec2 := httptest.NewRecorder()
+	gw.ServeHTTP(rec2, req1)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	apiResult, err := gw.GetAPI(context.Background(), api1.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, api1, apiResult)
+
+	gw.DeleteAPI(context.Background(), apiResult)
+	rec3 := httptest.NewRecorder()
+	gw.ServeHTTP(rec3, req1)
+	assert.Equal(t, http.StatusNotFound, rec3.Code)
+
+	_, err = gw.GetAPI(context.Background(), api1.Name)
+	assert.Error(t, err)
+}
+
+func TestGatewayPostRequest(t *testing.T) {
+	// empty API matches everything
+	fnClient := &mocks.FunctionsClient{}
+	fnClient.On("RunFunction", mock.Anything, mock.Anything, mock.Anything).Return(
+		&v1.Run{}, nil,
+	)
+	gw, err := NewGateway(fnClient)
+	assert.NoError(t, err)
+
+	api1 := &gateway.API{
+		ID:        uuid.NewV4().String(),
+		CreatedAt: int(time.Now().Unix()),
+		Name:      "api",
+		Function:  "function1",
+		Hosts:     []string{"example.com"},
+		Methods:   []string{"POST"},
+		Enabled:   true,
+	}
+
+	api2 := &gateway.API{
+		ID:        uuid.NewV4().String(),
+		CreatedAt: int(time.Now().Unix()),
+		Name:      "api",
+		Function:  "function1",
+		Hosts:     []string{"example.com"},
+		Enabled:   true,
+	}
+
+	req1 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer([]byte(`{"key":"value"}`)))
+	req1.Host = "example.com"
+	req1.Header.Add("Content-type", "application/json")
+
+	rec1 := httptest.NewRecorder()
+	gw.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusNotFound, rec1.Code)
+
+	gw.AddAPI(context.Background(), api1)
+	rec2 := httptest.NewRecorder()
+	gw.ServeHTTP(rec2, req1)
+	fmt.Printf(rec2.Body.String())
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	apiResult, err := gw.GetAPI(context.Background(), api1.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, api1, apiResult)
+
+	req2 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer([]byte(`{"key":"value"}`)))
+	req2.Host = "example.com"
+	req2.Header.Add("Content-type", "application/json")
+	gw.UpdateAPI(context.Background(), apiResult.Name, api2)
+	rec3 := httptest.NewRecorder()
+	gw.ServeHTTP(rec3, req2)
+	fmt.Printf(rec3.Body.String())
+	assert.Equal(t, http.StatusOK, rec3.Code)
+
+	apiResult, err = gw.GetAPI(context.Background(), api1.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, api2, apiResult)
+
+	gw.DeleteAPI(context.Background(), api2)
+	rec4 := httptest.NewRecorder()
+	gw.ServeHTTP(rec4, req1)
+	assert.Equal(t, http.StatusNotFound, rec4.Code)
+
+}

--- a/pkg/api-manager/gateway/local/router.go
+++ b/pkg/api-manager/gateway/local/router.go
@@ -1,0 +1,306 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package local
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vmware/dispatch/pkg/api-manager/gateway"
+	"github.com/vmware/dispatch/pkg/api/v1"
+	"github.com/vmware/dispatch/pkg/client"
+)
+
+// Serve sets the handler and starts the API Gateway HTTP server
+func (g *Gateway) Serve() error {
+	g.Server.SetHandler(g)
+	return g.Server.Serve()
+}
+
+// Shutdown gracefully stops the HTTP server.
+func (g *Gateway) Shutdown() error {
+	return g.Server.Shutdown()
+}
+
+// ServeHTTP implements http.Handler interface.
+func (g *Gateway) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	api := g.matchAPI(cleanHost(req.Host), req.URL.Path, req.Method)
+	if api == nil {
+		// No match found
+		writeErrorResp(rw, 404, "no API found with those values")
+		return
+	}
+	if len(api.Protocols) == 1 {
+		expectedProto := strings.ToUpper(api.Protocols[0])
+		// api is set to support single protocol
+		proto := "HTTP"
+		if req.TLS != nil {
+			proto = "HTTPS"
+		}
+		if expectedProto != proto {
+			writeErrorResp(rw, 400, fmt.Sprintf("Please use %s protocol", expectedProto))
+		}
+	}
+
+	if api.CORS {
+		addCORS(rw)
+	}
+
+	if req.Method == http.MethodOptions {
+		writeEmptyResp(rw, 200)
+		return
+	}
+
+	input, err := getInput(req)
+	if err != nil {
+		writeErrorResp(rw, 400, err.Error())
+		return
+	}
+
+	blocking := true
+	if req.Header.Get("x-dispatch-blocking") == "false" {
+		blocking = false
+	}
+
+	run := v1.Run{
+		Blocking:     blocking,
+		FunctionName: api.Function,
+		Input:        input,
+		HTTPContext:  getContext(req, api.Function),
+	}
+	resp, err := g.fnClient.RunFunction(req.Context(), api.OrganizationID, &run)
+	if err != nil {
+		if be, ok := err.(client.Error); ok {
+			writeErrorResp(rw, be.Code(), be.Message())
+		} else {
+			writeErrorResp(rw, 400, err.Error())
+		}
+		return
+	}
+	if blocking == false || resp.Output == nil {
+		writeEmptyResp(rw, 200)
+		return
+	}
+
+	if str, ok := resp.Output.(string); ok && str == "" {
+		writeEmptyResp(rw, 200)
+		return
+	}
+	rw.Header().Add("Content-type", "application/json")
+	enc := json.NewEncoder(rw)
+	enc.Encode(resp.Output)
+}
+
+// matchAPI returns first API that matches host and path and method. It finds only first match.
+// It starts looking by checking path, as it's expected to be most common filter to be set.
+// local gateway is expected to be only used by single-host deployments, thus host filter is checked last.
+func (g *Gateway) matchAPI(host, path, method string) *gateway.API {
+	log.Debugf("Matching API for host:%s, path:%s, method:%s", host, path, method)
+	g.RLock()
+	defer g.RUnlock()
+	if apis, ok := g.pathLookup[path]; ok {
+		for i := range apis {
+			if matchAPIAgainst(apis[i], host, method, "") {
+				return apis[i]
+			}
+		}
+	}
+
+	if apis, ok := g.methodLookup[method]; ok {
+		for i := range apis {
+			if matchAPIAgainst(apis[i], host, "", path) {
+				return apis[i]
+			}
+		}
+	}
+
+	if apis, ok := g.hostLookup[host]; ok {
+		for i := range apis {
+			if matchAPIAgainst(apis[i], "", method, path) {
+				return apis[i]
+			}
+		}
+	}
+
+	return nil
+}
+
+// matchAPIAgainst takes api and checks if it matches against provided host, method and string.
+// if the api has nil slice for particular property, that property will always match regardless of
+// the actual value in the request.
+func matchAPIAgainst(api *gateway.API, host, method, path string) bool {
+	foundHost := matchString(api.Hosts, host)
+	foundPath := matchString(api.URIs, path)
+	var foundMethod bool
+	if method == http.MethodOptions {
+		foundMethod = true
+	} else {
+		foundMethod = matchString(api.Methods, method)
+	}
+
+	return foundHost && foundMethod && foundPath
+}
+
+// matchString checks if needle string is in set slice. if any of these are zero values,
+// it returns true.
+func matchString(set []string, needle string) bool {
+	if len(set) == 0 || needle == "" {
+		// empty set means no filtering
+		return true
+	}
+	for _, elem := range set {
+		if elem == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func addCORS(rw http.ResponseWriter) {
+	rw.Header().Add("Access-Control-Allow-Origin", "*")
+	rw.Header().Add("Access-Control-Allow-Methods", "*")
+	rw.Header().Add("Access-Control-Allow-Headers", "*")
+}
+
+// getInput processes the request and generates an input for the function.
+func getInput(req *http.Request) (interface{}, error) {
+	if req.Method == http.MethodGet {
+		return processValues(req.URL.Query()), nil
+	}
+
+	if req.ContentLength == 0 {
+		return map[string]interface{}{}, nil
+	}
+
+	contentType := req.Header.Get("Content-type")
+
+	if isFormContentType(contentType) {
+		req.ParseMultipartForm(
+			int64(10 << 20), // 10 MB
+		)
+		return processValues(req.Form), nil
+	}
+
+	if isJSONContentType(contentType) {
+		var input interface{}
+		dec := json.NewDecoder(req.Body)
+		err := dec.Decode(&input)
+		if err != nil {
+			return nil, errors.New("request body is not json")
+		}
+		return input, nil
+	}
+
+	if contentType != "" {
+		return nil, fmt.Errorf("request body type is not supported: %s", contentType)
+	}
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func getContext(req *http.Request, funcName string) map[string]interface{} {
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	return map[string]interface{}{
+		"args":            req.URL.RawQuery,
+		"request":         req.URL.String(),
+		"request_uri":     req.RequestURI,
+		"scheme":          scheme,
+		"server_protocol": req.Proto,
+		"upstream_uri":    funcName,
+		"uri":             req.RequestURI,
+		"method":          req.Method,
+	}
+}
+
+// processValues converts url.Values into a simplified map, i.e.
+// when there is a single value for given key, the value is assigned directly.
+// Otherwise, the value slice is assigned.
+func processValues(values url.Values) map[string]interface{} {
+	simpleMap := make(map[string]interface{}, len(values))
+	for key, value := range values {
+		if len(value) == 1 {
+			simpleMap[key] = value[0]
+		} else {
+			simpleMap[key] = value
+		}
+	}
+	return simpleMap
+}
+
+func isFormContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+
+	for _, v := range strings.Split(contentType, ",") {
+		t, _, err := mime.ParseMediaType(v)
+		if err != nil {
+			break
+		}
+		switch t {
+		case "application/x-www-form-urlencoded", "multipart/form-data":
+			return true
+		}
+	}
+	return false
+}
+
+// isJSONContentType checks if provided string is a proper JSON content type
+func isJSONContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+
+	for _, v := range strings.Split(contentType, ",") {
+		t, _, err := mime.ParseMediaType(v)
+		if err != nil {
+			break
+		}
+		if t == "application/json" {
+			return true
+		}
+		if strings.HasPrefix(t, "application/") && strings.HasSuffix(t, "+json") {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanHost returns host without port, if one is set
+func cleanHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	return strings.Split(host, ":")[0]
+}
+
+func writeErrorResp(rw http.ResponseWriter, code int, msg string) {
+	rw.Header().Add("Content-type", "application/json")
+	rw.WriteHeader(code)
+	resp := struct {
+		Message string `json:"message"`
+	}{Message: msg}
+	enc := json.NewEncoder(rw)
+	enc.Encode(&resp)
+}
+
+func writeEmptyResp(rw http.ResponseWriter, code int) {
+	rw.WriteHeader(code)
+	rw.(http.Flusher).Flush()
+}

--- a/pkg/api-manager/gateway/local/router_test.go
+++ b/pkg/api-manager/gateway/local/router_test.go
@@ -1,0 +1,134 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package local
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/dispatch/pkg/api-manager/gateway"
+)
+
+func TestMatchAPIAgainst(t *testing.T) {
+	// empty API matches everything
+	emptyAPI := &gateway.API{}
+
+	hostsAPI := &gateway.API{Hosts: []string{"example.com", "my.host.test"}}
+	methodsAPI := &gateway.API{Methods: []string{"GET", "POST"}}
+	pathsAPI := &gateway.API{URIs: []string{"/hello", "/", "/some/multi/level/path"}}
+	methodPathAPI := &gateway.API{
+		Methods: []string{"GET", "POST"},
+		URIs:    []string{"/hello", "/", "/some/multi/level/path"},
+	}
+
+	testCases := []struct {
+		InAPI  *gateway.API
+		Host   string
+		Method string
+		Path   string
+		Out    bool
+	}{
+		{emptyAPI, "not", "important", "at all", true},
+		{hostsAPI, "missing", "notimportant", "/", false},
+		{hostsAPI, "example.com", "notimportant", "/", true},
+		{methodsAPI, "something", "GET", "/", true},
+		{methodsAPI, "missing", "OPTIONS", "/", true},
+		{methodsAPI, "missing", "DELETE", "/", false},
+		{pathsAPI, "missing", "notimportant", "/", true},
+		{pathsAPI, "missing", "notimportant", "/notexistent", false},
+		{methodPathAPI, "missing", "GET", "/some/multi/level/path", true},
+		{methodPathAPI, "missing", "PUT", "/some/multi/level/path", false},
+	}
+
+	for _, c := range testCases {
+		result := matchAPIAgainst(c.InAPI, c.Host, c.Method, c.Path)
+		assert.Equal(t, result, c.Out)
+	}
+}
+
+func TestGetInput(t *testing.T) {
+	req1 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer([]byte(`{"key":"value"}`)))
+	req1.Host = "example.com"
+	req1.Header.Add("Content-type", "application/json")
+	body, err := getInput(req1)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", body.(map[string]interface{})["key"])
+
+	req2 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer(nil))
+	req2.Host = "example.com"
+	body, err = getInput(req2)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{}, body)
+
+	req3 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer([]byte(`name=VMware&place=Palo Alto`)))
+	req3.Host = "example.com"
+	req3.Header.Add("Content-type", "application/x-www-form-urlencoded")
+	body, err = getInput(req3)
+	assert.NoError(t, err)
+	assert.Equal(t, "Palo Alto", body.(map[string]interface{})["place"])
+
+	req4 := httptest.NewRequest("POST", "http://example.com/hello", bytes.NewBuffer([]byte(`blabla`)))
+	req4.Host = "example.com"
+	req4.Header.Add("Content-type", "text/plain")
+	body, err = getInput(req4)
+	assert.Error(t, err)
+
+}
+
+func TestMatchString(t *testing.T) {
+	testCases := []struct {
+		InSlice  []string
+		InNeedle string
+		Out      bool
+	}{
+		{[]string{"one", "two", "three"}, "one", true},
+		{[]string{}, "not important", true},
+		{[]string{"not", "important"}, "", true},
+		{[]string{"one", "two"}, "missing", false},
+	}
+
+	for _, c := range testCases {
+		result := matchString(c.InSlice, c.InNeedle)
+		assert.Equal(t, result, c.Out)
+	}
+}
+
+func TestIsJSONContentType(t *testing.T) {
+	testCases := []struct {
+		In  string
+		Out bool
+	}{
+		{"", false},
+		{"multipart/form-data; boundary=---------------------------974767299852498929531610575", false},
+		{"text/html; charset=utf-8", false},
+		{"application/json", true},
+		{"application/cloudevents+json", true},
+	}
+
+	for _, c := range testCases {
+		result := isJSONContentType(c.In)
+		assert.Equal(t, result, c.Out)
+	}
+}
+
+func TestCleanHost(t *testing.T) {
+	testCases := []struct {
+		In  string
+		Out string
+	}{
+		{"", ""},
+		{"host", "host"},
+		{"host:12345", "host"},
+		{":1245", ""},
+	}
+
+	for _, c := range testCases {
+		result := cleanHost(c.In)
+		assert.Equal(t, result, c.Out)
+	}
+}

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -11,6 +11,13 @@ import (
 	"github.com/vmware/dispatch/pkg/api/v1"
 )
 
+// Error is an interface implemented by all errors declared here.
+type Error interface {
+	Error() string
+	Message() string
+	Code() int
+}
+
 type baseError struct {
 	code    int
 	message string

--- a/pkg/dispatchserver/apis.go
+++ b/pkg/dispatchserver/apis.go
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package dispatchserver
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/go-openapi/loads"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vmware/dispatch/pkg/api-manager"
+	"github.com/vmware/dispatch/pkg/api-manager/gateway"
+	"github.com/vmware/dispatch/pkg/api-manager/gateway/kong"
+	"github.com/vmware/dispatch/pkg/api-manager/gen/restapi"
+	"github.com/vmware/dispatch/pkg/api-manager/gen/restapi/operations"
+	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
+	"github.com/vmware/dispatch/pkg/entity-store"
+)
+
+// NewCmdAPIs creates a subcommand to run api manager
+func NewCmdAPIs(out io.Writer, config *serverConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apis",
+		Short: i18n.T("Run Dispatch API Manager"),
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runAPIs(config)
+		},
+	}
+	cmd.SetOutput(out)
+	return cmd
+}
+
+func runAPIs(config *serverConfig) {
+	store := entityStore(config)
+
+	gw, err := kong.NewClient(nil)
+	if err != nil {
+		log.Fatalf("Error creating Kong client: %v", err)
+	}
+
+	apisHandler, shutdown := initAPIs(config, store, gw)
+	defer shutdown()
+
+	handler := addMiddleware(apisHandler)
+	server := httpServer(config)
+	server.SetHandler(handler)
+	defer server.Shutdown()
+	if err = server.Serve(); err != nil {
+		log.Error(err)
+	}
+}
+
+func initAPIs(config *serverConfig, store entitystore.EntityStore, gw gateway.Gateway) (http.Handler, func()) {
+	swaggerSpec, err := loads.Analyzed(restapi.FlatSwaggerJSON, "2.0")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	api := operations.NewAPIManagerAPI(swaggerSpec)
+
+	apiController := apimanager.NewController(&apimanager.ControllerConfig{ResyncPeriod: config.ResyncPeriod}, store, gw)
+	apiController.Start()
+
+	handlers := apimanager.NewHandlers(apiController.Watcher(), store)
+
+	handlers.ConfigureHandlers(api)
+
+	return api.Serve(nil), func() {
+		apiController.Shutdown()
+	}
+}

--- a/pkg/dispatchserver/config.go
+++ b/pkg/dispatchserver/config.go
@@ -57,7 +57,7 @@ func configGlobalFlags(flags *pflag.FlagSet) {
 	flags.String("database-username", "dispatch", "Database username")
 	flags.String("database-password", "dispatch", "Database password")
 
-	flags.Duration("resync-period", 10*time.Second, "How often services should sync their state")
+	flags.Duration("resync-period", 20*time.Second, "How often services should sync their state")
 	flags.String("registry-auth", emptyRegistryAuth, "base64-encoded docker registry credentials")
 	flags.String("image-registry", "dispatch", "Image registry host or docker hub org/username")
 	flags.Bool("push-images", false, "Push/pull images to/from image registry")
@@ -73,7 +73,7 @@ func configGlobalFlags(flags *pflag.FlagSet) {
 	flags.Int("tls-port", 8443, "TLS port to listen on")
 	flags.String("tls-certificate", "", "Path to the certificate file")
 	flags.String("tls-certificate-key", "", "Path to the certificate private key")
-	flags.Bool("enable-tls", false, "Enable TLS (HTTPS) listener. tls-certificate and tls-certificate-key must be set")
+	flags.Bool("enable-tls", false, "Enable TLS (HTTPS) listener.")
 
 	flags.String("tracer", "", "OpenTracing-compatible Tracer URL")
 	flags.Bool("debug", false, "Enable debugging logs")

--- a/pkg/dispatchserver/events.go
+++ b/pkg/dispatchserver/events.go
@@ -26,7 +26,7 @@ import (
 // NewCmdEvents creates a subcommand to run event manager
 func NewCmdEvents(out io.Writer, config *serverConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "secrets",
+		Use:   "events",
 		Short: i18n.T("Run Dispatch Event Manager"),
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -64,7 +64,7 @@ func initEvents(config *serverConfig, store entitystore.EntityStore, fnClient cl
 
 	subManager, err := subscriptions.NewManager(eventTransport, fnClient)
 	if err != nil {
-		log.Fatalf("Error creating SubscriptionManager: %v", err)
+		log.Fatalf("Error creating Event Subscription Manager: %v", err)
 	}
 	// event controller
 	eventController := eventmanager.NewEventController(
@@ -72,7 +72,9 @@ func initEvents(config *serverConfig, store entitystore.EntityStore, fnClient cl
 		// TODO: add backend for event drivers in docker
 		nil,
 		store,
-		eventmanager.EventControllerConfig{},
+		eventmanager.EventControllerConfig{
+			ResyncPeriod: config.ResyncPeriod,
+		},
 	)
 
 	eventController.Start()

--- a/pkg/dispatchserver/images.go
+++ b/pkg/dispatchserver/images.go
@@ -23,7 +23,7 @@ import (
 // NewCmdImages creates a subcommand to run image manager
 func NewCmdImages(out io.Writer, config *serverConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "secrets",
+		Use:   "images",
 		Short: i18n.T("Run Dispatch Image Manager"),
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/dispatchserver/local.go
+++ b/pkg/dispatchserver/local.go
@@ -9,15 +9,18 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/opentracing/opentracing-go/log"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/vmware/dispatch/pkg/api-manager/gateway/local"
 	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
 	"github.com/vmware/dispatch/pkg/http"
 )
 
 type localServer struct {
-	DockerHost string `mapstructure:"docker-host" json:"docker-host"`
+	DockerHost     string `mapstructure:"docker-host" json:"docker-host"`
+	GatewayPort    int    `mapstructure:"gateway-port" json:"gateway-port"`
+	GatewayTLSPort int    `mapstructure:"gateway-tls-port" json:"gateway-tls-port"`
 }
 
 // NewCmdLocal creates a subcommand to run Dispatch Local server
@@ -33,7 +36,9 @@ func NewCmdLocal(out io.Writer, config *serverConfig) *cobra.Command {
 	}
 	cmd.SetOutput(out)
 
-	cmd.LocalFlags().String("docker-host", "127.0.0.1", "Docker host/IP. This must be reachable from Dispatch Server.")
+	cmd.LocalFlags().String("docker-host", "127.0.0.1", "Docker host/IP. It must be reachable from Dispatch Server.")
+	cmd.LocalFlags().Int("gateway-port", 8081, "Port for local API Gateway")
+	cmd.LocalFlags().Int("gateway-tls-port", 8444, "TLS port for local API Gateway (only when TLS Enabled in global flags)")
 
 	return cmd
 }
@@ -54,6 +59,25 @@ func runLocal(config *serverConfig) {
 	functionsHandler, functionsShutdown := initFunctions(config, store, docker, images, secrets, services)
 	defer functionsShutdown()
 
+	gw, err := local.NewGateway(functions)
+	if err != nil {
+		log.Fatalf("Error creating API Gateway: %v", err)
+	}
+
+	gw.Server = httpServer(config)
+	gw.Server.Port = config.Local.GatewayPort
+	gw.Server.TLSPort = config.Local.GatewayTLSPort
+	gw.Server.Name = "API Gateway"
+	go func() {
+		err := gw.Serve()
+		if err != nil {
+			log.Errorf("Error running API Gateway: %v", err)
+		}
+	}()
+
+	apisHandler, apisShutdown := initAPIs(config, store, gw)
+	defer apisShutdown()
+
 	eventsHandler, eventsShutdown := initEvents(config, store, functions, secrets)
 	defer eventsShutdown()
 
@@ -62,6 +86,7 @@ func runLocal(config *serverConfig) {
 		ImagesHandler:    imagesHandler,
 		SecretsHandler:   secretsHandler,
 		EventsHandler:    eventsHandler,
+		APIHandler:       apisHandler,
 	}
 	handler := addMiddleware(dispatchHandler)
 	server := httpServer(config)

--- a/pkg/dispatchserver/local_test.go
+++ b/pkg/dispatchserver/local_test.go
@@ -32,7 +32,7 @@ func TestCmdLocalCommand(t *testing.T) {
 			return
 		case <-ticker.C:
 		}
-		if strings.Contains(buf.String(), "Serving HTTP traffic") {
+		if strings.Contains(buf.String(), "serving HTTP traffic") {
 			break
 		}
 	}

--- a/pkg/dispatchserver/main.go
+++ b/pkg/dispatchserver/main.go
@@ -36,6 +36,8 @@ func NewCLI(out io.Writer) *cobra.Command {
 
 	cmd.AddCommand(NewCmdLocal(out, defaultConfig))
 	cmd.AddCommand(NewCmdFunctions(out, defaultConfig))
+	cmd.AddCommand(NewCmdImages(out, defaultConfig))
+	cmd.AddCommand(NewCmdEvents(out, defaultConfig))
 
 	return cmd
 }

--- a/pkg/http/crypto.go
+++ b/pkg/http/crypto.go
@@ -1,0 +1,134 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package http
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	certFilename = "dispatch_self_signed_cert.pem"
+	keyFilename  = "dispatch_private_key.pem"
+)
+
+// GeneratePKI generates private key and a self-signed certificate, stores their encoded representation
+// into files, and returns paths to those files, if successful. If privateKey or certificate are not empty strings,
+// files for them have already been created, regardless of the err value.
+// For development & testing purposes only, not suitable for production usage.
+func GeneratePKI(hosts []string) (privateKey string, certificate string, err error) {
+	if len(hosts) == 0 {
+		return privateKey, certificate, errors.New("at least one host or IP must be provided")
+	}
+
+	workDir, err := os.Getwd()
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "error getting current working directory")
+	}
+	certPath := path.Join(workDir, certFilename)
+	keyPath := path.Join(workDir, keyFilename)
+
+	var certExists, keyExists bool
+	if _, err = os.Stat(certPath); !os.IsNotExist(err) {
+		certExists = true
+	}
+	if _, err = os.Stat(keyPath); !os.IsNotExist(err) {
+		keyExists = true
+	}
+
+	if certExists && keyExists {
+		// files already exist, let's return them and hope they are indeed certificates.
+		return keyPath, certPath, nil
+	}
+	// if one of them exists and the other does not, play safe.
+	if certExists {
+		return keyPath, certPath, fmt.Errorf("certificate %s already exists, please clean up first", certPath)
+	}
+	if keyExists {
+		return keyPath, certPath, fmt.Errorf("key %s already exists, please clean up first", keyPath)
+	}
+
+	startDate := time.Now()
+	endDate := startDate.Add(365 * 24 * time.Hour)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "unable to generate certificate serial number")
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Dispatch"},
+		},
+		NotBefore: startDate,
+		NotAfter:  endDate,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "error creating certificate")
+	}
+
+	certOut, err := os.Create(certFilename)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "error creating %s file", certFilename)
+	}
+
+	certificate = certPath
+
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "error encoding certificate")
+	}
+	certOut.Close()
+
+	keyOut, err := os.OpenFile(keyFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return privateKey, certificate, errors.Wrapf(err, "error creating %s file", keyFilename)
+	}
+
+	privateKey = keyPath
+
+	b, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "error marshalling private key")
+	}
+
+	err = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
+	if err != nil {
+		return privateKey, certificate, errors.Wrap(err, "error encoding private key")
+	}
+	keyOut.Close()
+
+	return privateKey, certificate, nil
+}

--- a/pkg/http/crypto_test.go
+++ b/pkg/http/crypto_test.go
@@ -1,0 +1,35 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package http
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratePKI(t *testing.T) {
+	privateKey, certificate, err := GeneratePKI([]string{"example.com"})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, privateKey)
+	assert.NotEmpty(t, certificate)
+	if privateKey != "" {
+		err = os.Remove(privateKey)
+		assert.NoError(t, err)
+	}
+	if certificate != "" {
+		err = os.Remove(certificate)
+		assert.NoError(t, err)
+	}
+}
+
+func TestGeneratePKIEmpty(t *testing.T) {
+	privateKey, certificate, err := GeneratePKI(nil)
+	assert.Error(t, err)
+	assert.Empty(t, privateKey)
+	assert.Empty(t, certificate)
+}

--- a/pkg/http/handlers.go
+++ b/pkg/http/handlers.go
@@ -30,12 +30,14 @@ func (d *AllInOneRouter) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	components := strings.SplitN(path[1:], "/", 3)
 	if len(components) < 2 {
+		rw.Header().Add("Content-type", "application/json")
 		rw.WriteHeader(http.StatusNotFound)
 		rw.Write(notFoundError())
 		return
 	}
 	// version
 	if components[0] != "v1" {
+		rw.Header().Add("Content-type", "application/json")
 		rw.WriteHeader(http.StatusNotFound)
 		rw.Write(notFoundError())
 		return
@@ -49,10 +51,14 @@ func (d *AllInOneRouter) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		d.ImagesHandler.ServeHTTP(rw, r)
 	case "event", "events":
 		d.EventsHandler.ServeHTTP(rw, r)
-	case "api", "iam", "eventdrivers", "application", "serviceclass", "serviceinstance":
+	case "api":
+		d.APIHandler.ServeHTTP(rw, r)
+	case "iam", "eventdrivers", "application", "serviceclass", "serviceinstance":
+		rw.Header().Add("Content-type", "application/json")
 		rw.WriteHeader(http.StatusNotImplemented)
 		rw.Write(notImplementedError())
 	default:
+		rw.Header().Add("Content-type", "application/json")
 		rw.WriteHeader(http.StatusNotFound)
 		rw.Write(notFoundError())
 	}

--- a/pkg/http/handlers_test.go
+++ b/pkg/http/handlers_test.go
@@ -51,9 +51,9 @@ func TestAllInOneRouter(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			url:           "http://localhost:8080/v1/api",
-			expectedCode:  http.StatusNotImplemented,
-			expectedError: true,
+			url:          "http://localhost:8080/v1/api",
+			expectedCode: http.StatusOK,
+			expectedBody: "apiHandler",
 		},
 		{
 			url:          "http://localhost:8080/v1/image",
@@ -118,6 +118,9 @@ func createRouter() *AllInOneRouter {
 	secretsMock := &mocks.HandlerMock{}
 	secretsMock.On("ServeHTTP", mock.Anything, mock.Anything).Run(testHandler("secretsHandler"))
 	r.SecretsHandler = secretsMock
+	apisMock := &mocks.HandlerMock{}
+	apisMock.On("ServeHTTP", mock.Anything, mock.Anything).Run(testHandler("apiHandler"))
+	r.APIHandler = apisMock
 	return r
 }
 


### PR DESCRIPTION
Part of https://github.com/vmware/dispatch/issues/518

### Added
-  New implementation of API Gateway using golang http server and in-memory cache. 
- A function to generate private key & self-signed certificate. Used when HTTPS is enabled but no certificate or key is set.

### Fixed
- Make API Manager's controller actually use Gateway.AddAPI() when creating new API instead of reusing UpdateAPI().
- Fix e2e run_with_retry which would not work correctly with empty strings on certain bash versions.
- Fix minor issues.

**Note:** Local API gateway does a best effort to match Kong's behavior and currently passes e2e tests:
```
➜  export API_GATEWAY_HTTP_HOST="http://127.0.0.1:8081"
➜  export API_GATEWAY_HTTPS_HOST="https://127.0.0.1:8444"
➜  INSTALL_DISPATCH=0 e2e/scripts/run-e2e.sh e2e/tests/apis.bats
=> running clean first
 ✓ Clean all

1 test, 0 failures
=> e2e/tests/apis.bats
 ✓ Create Images for test
 ✓ Create Functions for test
 ✓ Test APIs with HTTP(S)
 ✓ Test APIs with HTTPS ONLY
 ✓ Test APIs with Kong Plugins
 ✓ Test APIs with CORS
 ✓ Test API Updates
 ✓ Cleanup

8 tests, 0 failures

finished
```

When executed like this:
```
➜  dispatch-server local --enable-tls
INFO[0000] API Gateway: serving HTTP traffic at http://127.0.0.1:8081
WARN[0000] HTTPS requested but key and cert paths are empty. using self-generated PKI
INFO[0000] API Gateway: serving HTTPS traffic at https://127.0.0.1:8444
WARN[0000] Tracer endpoint not provided, OpenTracing is disabled
INFO[0000] Dispatch HTTP server: serving HTTP traffic at http://127.0.0.1:8080
WARN[0000] HTTPS requested but key and cert paths are empty. using self-generated PKI
INFO[0000] Dispatch HTTP server: serving HTTPS traffic at https://127.0.0.1:8443
```  
