### PR TITLE
Helm chart enhancements

### DIFF
--- a/charts/dispatch/charts/api-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/api-manager/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: DOCKER_API_VERSION
               value: "1.24"
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
           emptyDir: {}

--- a/charts/dispatch/charts/application-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/application-manager/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: DOCKER_API_VERSION
               value: "1.24"
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
           emptyDir: {}

--- a/charts/dispatch/charts/echo-server/templates/deployment.yaml
+++ b/charts/dispatch/charts/echo-server/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               path: /
               port: {{ .Values.service.internalPort }}
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dispatch/charts/event-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/event-manager/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
               name: tls
               readOnly: true
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/function-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/function-manager/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - name: DOCKER_HOST
               value: "tcp://localhost:2375"
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
         - name: {{ .Chart.Name }}-docker
           image: docker:dind
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -95,7 +95,7 @@ spec:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.dindResources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/function-manager/values.yaml
+++ b/charts/dispatch/charts/function-manager/values.yaml
@@ -37,6 +37,14 @@ resources: {}
   #requests:
   #  cpu: 100m
   #  memory: 128Mi
+# Resources to allocate for Docker-in-Docker container within the function-manager pod
+dindResources: {}
+# limits:
+  #  cpu: 500m
+  #  memory: 2Gi
+  #requests:
+  #  cpu: 250m
+  #  memory: 512Mi
 faas:
   selected: openfaas
   templates: /images/function-manager/templates

--- a/charts/dispatch/charts/identity-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 3
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
         - name: oauth2-proxy
           image: {{ .Values.oauth2proxy.image }}
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -141,7 +141,7 @@ spec:
           ports:
             - containerPort: {{ .Values.oauth2proxy.service.internalPort }}
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/identity-manager/templates/ingress.noauth.yaml
+++ b/charts/dispatch/charts/identity-manager/templates/ingress.noauth.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
+    kubernetes.io/ingress.class: "{{ .Values.global.ingress.class }}"
     {{ .Values.global.ingress.annotationsPrefix }}/configuration-snippet: |
       error_page 403 = @403.json;
       error_page 401 = @401.json;

--- a/charts/dispatch/charts/image-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/image-manager/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: DOCKER_HOST
               value: "tcp://localhost:2375"
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
         - name: {{ .Chart.Name }}-docker
           image: docker:dind
           imagePullPolicy: {{ default .Values.global.pullPolicy .Values.image.pullPolicy }}
@@ -90,7 +90,7 @@ spec:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.dindResources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/image-manager/values.yaml
+++ b/charts/dispatch/charts/image-manager/values.yaml
@@ -32,11 +32,19 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #   cpu: 500m
-  #   memory: 4Gi
-  # requests:
-  #   cpu: 250m
-  #   memory: 2Gi
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+# Resources to allocate for Docker-in-Docker container within the image-manager pod
+dindResources: {}
+# limits:
+  #  cpu: 500m
+  #  memory: 2Gi
+  #requests:
+  #  cpu: 250m
+  #  memory: 512Mi
 registry: {}
   # insecure: false
   # uri: docker-docker-registry.docker.svc.cluster.local:5000

--- a/charts/dispatch/charts/secret-store/templates/deployment.yaml
+++ b/charts/dispatch/charts/secret-store/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: DOCKER_API_VERSION
               value: "1.23"
           resources:
-{{ toYaml .Values.resources | default .Values.global.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/charts/service-manager/templates/deployment.yaml
+++ b/charts/dispatch/charts/service-manager/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
                   name: {{ template "fullname" . }}
                   key: organization
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ .Values.resources | default .Values.global.resources | toYaml | indent 12 }}
       volumes:
         - name: {{ template "fullname" . }}
 {{- if default .Values.global.data.persist .Values.data.persist }}

--- a/charts/dispatch/templates/_helpers.tpl
+++ b/charts/dispatch/templates/_helpers.tpl
@@ -14,7 +14,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "{{ .Values.global.ingress.class }}"
     {{- range $key, $value := $ingress_annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/dispatch/values.yaml
+++ b/charts/dispatch/values.yaml
@@ -26,6 +26,7 @@ global:
     release: postgres
   ingress:
     enabled: true
+    class: nginx
     # Used to create Ingress record (should used with service.type: ClusterIP).
     # host: dispatch.vmware.com
     # The annotationsPrefix that your ingress controller requires. default - nginx.ingress.kubernetes.io for
@@ -53,7 +54,7 @@ global:
     create: true
     # Ignored, if rbac.create is true
     serviceAccountName: default
-  resources:
+  resources: {}
     # limits:
     #  cpu: 100m
     #  memory: 128Mi

--- a/pkg/dispatchcli/cmd/install_config.go
+++ b/pkg/dispatchcli/cmd/install_config.go
@@ -58,8 +58,7 @@ kafka:
     chart: kafka
     namespace: dispatch
     release: transport
-    repo: https://riff-charts.storage.googleapis.com
-    version: 0.0.1
+    repo: http://storage.googleapis.com/kubernetes-charts-incubator
   brokers:
   - transport-kafka.dispatch:9092
   zookeeperNodes:


### PR DESCRIPTION
* Adds a nginx class option. This can be used to target a different ingress controller in a deployment.

* Adds an option to specify resources just for the dind container in the image/function-manager. The earlier sub-chart level option applied the resource values for all the containers in the pod which wasn't necessary for the image/function-manager containers.

* Fixes an issue where the resources specified for an individual sub-chart didn't take precedence over the global resources.

* Switch to upstream Kafka Helm chart repo.

