### PR TITLE
Add e2e tests to release pipeline to test upgrade to new release

### DIFF
--- a/ci/e2e/deploy-dispatch.yml
+++ b/ci/e2e/deploy-dispatch.yml
@@ -13,6 +13,8 @@ params:
   DOCKER_REGISTRY_HOST:
   FAAS: openfaas
   EVENT_TRANSPORT: kafka
+  BOOTSTRAP: 1
+  CI_KEYS_TEST: 0
 
 # dispatch must be dispatch git repo.
 # dispatch-cli must contain "dispatch" binary
@@ -74,21 +76,42 @@ run:
         sed -i "s/INGRESS_PORT/$INGRESS_PORT/g" ~/.dispatch/config.json
     fi
 
-    # Bootstrap Dispatch with default org, service-accounts
-    dispatch manage bootstrap --bootstrap-org ci-org
+    if [[ $BOOTSTRAP == 1 ]]; then
+        # Bootstrap Dispatch with default org, service-accounts
+        dispatch manage bootstrap --bootstrap-org ci-org
 
-    # Generate required keys for ci-user
-    openssl genrsa -out ci-keys/ci-user.key 4096
-    openssl rsa -in ci-keys/ci-user.key -pubout -outform PEM -out ci-keys/ci-user.key.pub
+        # Generate required keys for ci-user
+        openssl genrsa -out ci-keys/ci-user.key 4096
+        openssl rsa -in ci-keys/ci-user.key -pubout -outform PEM -out ci-keys/ci-user.key.pub
 
-    # Create ci-user service account for e2e tests
-    dispatch iam create serviceaccount \
-      ci-user \
-      --public-key ci-keys/ci-user.key.pub
+        # Create ci-user service account for e2e tests
+        dispatch iam create serviceaccount \
+        ci-user \
+        --public-key ci-keys/ci-user.key.pub
 
 
-    # Create super-admin policy for the service account
-    dispatch iam create policy \
-      ci-user-admin-policy \
-      --subject ci-user --action "*" --resource "*" \
-      --global
+        # Create super-admin policy for the service account
+        dispatch iam create policy \
+        ci-user-admin-policy \
+        --subject ci-user --action "*" --resource "*" \
+        --global
+    fi
+
+    if [[ $CI_KEYS_TEST == 1 ]]; then
+        # Generate required keys for ci-test-user
+        openssl genrsa -out ci-keys/ci-test-user.key 4096
+        openssl rsa -in ci-keys/ci-test-user.key -pubout -outform PEM -out ci-keys/ci-test-user.key.pub
+
+        # Create ci-test-user service account for e2e tests
+        dispatch iam create serviceaccount \
+        ci-test-user \
+        --public-key ci-keys/ci-test-user.key.pub
+
+        # Create test policy for the service account
+        dispatch iam create policy \
+        ci-test-user-policy \
+        --subject ci-test-user --action "*" --resource "*"
+    fi
+
+    # Print out dispatch version
+    dispatch version

--- a/ci/e2e/run-tests.yml
+++ b/ci/e2e/run-tests.yml
@@ -12,6 +12,9 @@ params:
   GKE_PROJECT_ID:
   FAAS: openfaas
   EVENT_TRANSPORT: kafka
+  TEST_DIR: e2e/tests
+  CLEAN_BEFORE: 1
+  CLEAN_AFTER: 0
 
 # dispatch must be dispatch git repo.
 # dispatch-cli must contain "dispatch" binary
@@ -38,6 +41,8 @@ run:
     export DISPATCH_ORGANIZATION=ci-org
     export DISPATCH_SERVICE_ACCOUNT="ci-org/ci-user"
     export DISPATCH_JWT_PRIVATE_KEY=$(pwd)/ci-keys/ci-user.key
+    export DISPATCH_TEST_SERVICE_ACCOUNT="ci-test-user"
+    export DISPATCH_TEST_JWT_PRIVATE_KEY=$(pwd)/ci-keys/ci-test-user.key
 
     cp dispatch-cli/dispatch /usr/local/bin/dispatch
     mkdir -p ~/.dispatch
@@ -65,5 +70,5 @@ run:
     fi
     export BATS_LOG="$(pwd)/tests-logs/bats.log"
     pushd dispatch
-    ./e2e/scripts/run-e2e.sh e2e/tests
+    ./e2e/scripts/run-e2e.sh ${TEST_DIR}
 

--- a/ci/pipelines/e2e.yml
+++ b/ci/pipelines/e2e.yml
@@ -136,6 +136,8 @@ jobs:
       DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
       FAAS: openfaas
       EVENT_TRANSPORT: rabbitmq
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 0
   - task: e2e-tests
     file: dispatch/ci/e2e/run-tests.yml
     input_mapping:
@@ -144,6 +146,9 @@ jobs:
       GKE_KEY: ((gke-key))
       GKE_PROJECT_ID: ((gke-project-id))
       FAAS: openfaas
+      TEST_DIR: e2e/tests
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
   - task: uninstall-dispatch
     file: dispatch/ci/e2e/uninstall-dispatch.yml
     input_mapping:
@@ -197,6 +202,8 @@ jobs:
       DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
       FAAS: riff
       EVENT_TRANSPORT: kafka
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 0
   - task: e2e-tests
     file: dispatch/ci/e2e/run-tests.yml
     input_mapping:
@@ -205,6 +212,9 @@ jobs:
       GKE_KEY: ((gke-key))
       GKE_PROJECT_ID: ((gke-project-id))
       FAAS: riff
+      TEST_DIR: e2e/tests
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
   - task: uninstall-dispatch
     file: dispatch/ci/e2e/uninstall-dispatch.yml
     input_mapping:
@@ -253,6 +263,8 @@ jobs:
       DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
       FAAS: riff
       EVENT_TRANSPORT: kafka
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 0
   - task: build-benchmark
     file: benchmark/ci/make-benchmark.yml
   - task: run-benchmark

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -103,10 +103,13 @@ jobs:
 - name: build-e2e-images
   public: true
   plan:
-  - get: version
-    trigger: true
-  - get: dispatch
-    resource: dispatch-master
+  - aggregate:
+    - get: version
+      trigger: true
+    - get: dispatch
+      resource: dispatch-master
+    - get: dispatch-release
+      resource: gh-release
   - task: build-binaries
     file: dispatch/ci/e2e/binaries.yml
   - task: prepare-images
@@ -156,6 +159,8 @@ jobs:
       DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
       FAAS: openfaas
       EVENT_TRANSPORT: rabbitmq
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 0
   - task: e2e-tests
     file: dispatch/ci/e2e/run-tests.yml
     input_mapping:
@@ -164,6 +169,9 @@ jobs:
       GKE_KEY: ((gke-key))
       GKE_PROJECT_ID: ((gke-project-id))
       FAAS: openfaas
+      TEST_DIR: e2e/tests
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
   - task: uninstall-dispatch
     file: dispatch/ci/e2e/uninstall-dispatch.yml
     input_mapping:
@@ -207,6 +215,8 @@ jobs:
       DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
       FAAS: riff
       EVENT_TRANSPORT: kafka
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 0
   - task: e2e-tests
     file: dispatch/ci/e2e/run-tests.yml
     input_mapping:
@@ -215,6 +225,191 @@ jobs:
       GKE_KEY: ((gke-key))
       GKE_PROJECT_ID: ((gke-project-id))
       FAAS: riff
+      TEST_DIR: e2e/tests
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
+  - task: uninstall-dispatch
+    file: dispatch/ci/e2e/uninstall-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: keyval
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+  on_failure:
+    do:
+    - do: *test_on_failure
+  ensure: *test_ensure
+
+- name: tests-openfaas-upgrade
+  public: true
+  plan:
+  - aggregate:
+    - get: version
+      trigger: true
+      passed: [build-e2e-images]
+    - get: dispatch-release
+      resource: gh-release
+      passed: [build-e2e-images]
+    - get: dispatch
+      resource: dispatch-master
+      passed: [build-e2e-images]
+    - get: keyval
+      passed: [build-e2e-images]
+  - task: release-cli
+    file: dispatch/ci/release/release-cli.yml
+  - task: create-gke-cluster
+    file: dispatch/ci/e2e/gke-cluster-create.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+  - task: deploy-dispatch
+    file: dispatch/ci/e2e/deploy-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: build-context
+    output_mapping:
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      DOCKER_REGISTRY_HOST: ((docker-hub-org))
+      FAAS: openfaas
+      EVENT_TRANSPORT: rabbitmq
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 1
+  - task: setup-tests
+    file: dispatch/ci/e2e/run-tests.yml
+    input_mapping:
+      cluster: k8s-cluster
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      FAAS: openfaas
+      TEST_DIR: e2e/upgrade/setup/setup.bats
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
+  - task: build-cli
+    file: dispatch/ci/e2e/build-cli.yml
+  - task: upgrade-dispatch
+    file: dispatch/ci/e2e/deploy-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: keyval
+    output_mapping:
+      ci-keys: ci-keys-upgrade
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
+      FAAS: openfaas
+      EVENT_TRANSPORT: rabbitmq
+      BOOTSTRAP: 0
+      CI_KEYS_TEST: 0
+  - task: exec-tests
+    file: dispatch/ci/e2e/run-tests.yml
+    input_mapping:
+      cluster: k8s-cluster
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      FAAS: openfaas
+      TEST_DIR: e2e/upgrade/exec
+      CLEAN_BEFORE: 0
+      CLEAN_AFTER: 1
+  - task: uninstall-dispatch
+    file: dispatch/ci/e2e/uninstall-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: keyval
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+  on_failure:
+    do:
+    - do: *test_on_failure
+  ensure: *test_ensure
+
+- name: tests-riff-upgrade
+  public: true
+  plan:
+  - aggregate:
+    - get: version
+      trigger: true
+      passed: [build-e2e-images]
+    - get: dispatch-release
+      resource: gh-release
+      passed: [build-e2e-images]
+    - get: dispatch
+      resource: dispatch-master
+      passed: [build-e2e-images]
+    - get: keyval
+      passed: [build-e2e-images]
+  - task: release-cli
+    file: dispatch/ci/release/release-cli.yml
+  - task: create-gke-cluster
+    file: dispatch/ci/e2e/gke-cluster-create.yml
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+  - task: deploy-dispatch
+    file: dispatch/ci/e2e/deploy-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: build-context
+    output_mapping:
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      DOCKER_REGISTRY_HOST: ((docker-hub-org))
+      FAAS: riff
+      EVENT_TRANSPORT: kafka
+      BOOTSTRAP: 1
+      CI_KEYS_TEST: 1
+  - task: setup-tests
+    file: dispatch/ci/e2e/run-tests.yml
+    input_mapping:
+      cluster: k8s-cluster
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      FAAS: riff
+      TEST_DIR: e2e/upgrade/setup/setup.bats
+      CLEAN_BEFORE: 1
+      CLEAN_AFTER: 0
+  - task: build-cli
+    file: dispatch/ci/e2e/build-cli.yml
+  - task: upgrade-dispatch
+    file: dispatch/ci/e2e/deploy-dispatch.yml
+    input_mapping:
+      cluster: k8s-cluster
+      properties: keyval
+    output_mapping:
+      ci-keys: ci-keys-upgrade
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      DOCKER_REGISTRY_HOST: ((ci-registry-org.gcr))
+      FAAS: riff
+      EVENT_TRANSPORT: kafka
+      BOOTSTRAP: 0
+      CI_KEYS_TEST: 0
+  - task: exec-tests
+    file: dispatch/ci/e2e/run-tests.yml
+    input_mapping:
+      cluster: k8s-cluster
+      ci-keys: ci-keys-deploy
+    params:
+      GKE_KEY: ((gke-key))
+      GKE_PROJECT_ID: ((gke-project-id))
+      FAAS: riff
+      TEST_DIR: e2e/upgrade/exec
+      CLEAN_BEFORE: 0
+      CLEAN_AFTER: 1
   - task: uninstall-dispatch
     file: dispatch/ci/e2e/uninstall-dispatch.yml
     input_mapping:

--- a/ci/release/release-cli.yml
+++ b/ci/release/release-cli.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: vmware/dispatch-golang-ci
+    tag: "1.10"
+
+inputs:
+- name: dispatch-release
+
+outputs:
+- name: dispatch-cli
+- name: build-context
+
+run:
+  path: /bin/bash
+  args:
+  - -c
+  - |
+    set -e -x -u
+    
+    mv dispatch-release/dispatch-linux dispatch-cli/dispatch
+    chmod +x dispatch-cli/dispatch
+    echo "tag=$(cat dispatch-release/tag)" > build-context/keyval.properties

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -33,11 +33,13 @@ function run_bats() {
         bring_dispatch_up
     fi
 
-    echo "=> running clean first"
     # BATS returns non-zero to indicate the tests have failed, we shouldn't
     # necessarily bail in this case, so that's the reason for the e toggle.
     set +e
-    bats "e2e/tests/clean.bats"
+    if [[ $CLEAN_BEFORE == 1 ]]; then
+        echo "=> running clean first"
+        bats "e2e/tests/clean.bats"
+    fi
 
     for bats_file in $(find "$1" -name \*.bats | grep -v clean); do
         echo "=> $bats_file"
@@ -47,6 +49,11 @@ function run_bats() {
         fi
         echo
     done
+
+    if [[ $CLEAN_AFTER == 1 ]]; then
+        echo "=> running clean after"
+        bats "e2e/tests/clean.bats"
+    fi
     set -e
 
     if [[ $INSTALL_DISPATCH == 1 ]]; then
@@ -98,6 +105,7 @@ fi
 export BASE_TEST_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export DISPATCH_ROOT="$BASE_TEST_DIR/../.."
 export DISPATCH_BIN_NAME=dispatch
+export E2E_TEST_ROOT="$DISPATCH_ROOT/e2e/tests"
 # By default the CLI config is the generated .dispatch.json in the DISPATCH_ROOT.
 # If running e2e against a cluster brought up separately, you can point to a
 # different location (i.e. $HOME/.dispatch.json)

--- a/e2e/upgrade/exec/apis.bats
+++ b/e2e/upgrade/exec/apis.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create duplicate API" {
+    run dispatch create api api-test-http func-nodejs -m POST -p /http --auth public
+    echo_to_log
+    assert_failure
+}
+
+@test "Test APIs with HTTP(S)" {
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/http -H \"Content-Type: application/json\" -d '{
+            \"name\": \"VMware\",
+            \"place\": \"HTTP\"
+        }' | jq -r .myField" "Hello, VMware from HTTP" 6 5
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/http -k -H \"Content-Type: application/json\" -d '{
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS" 6 5
+}
+
+@test "Test APIs with HTTPS ONLY" {
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/https-only -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .message" "Please use HTTPS protocol" 6 5
+
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/https-only -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+}
+
+@test "Test APIs with Kong Plugins" {
+    # "x-dispatch-blocking: true" is default header
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
+
+    # with "x-dispatch-blocking: false", it will not return an result
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-blocking: false' -d '{
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }'" "" 6 5
+
+    # with "x-dispatch-org: invalid", setting this header should have no effect as it's overwritten by the plugin.
+    # if the plugin fails to overwrite this HEADER, it will allow end-users to switch orgs and this test should fail
+    # with {"message":"function not found"}.
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-org: invalid' -d '{
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
+
+    # PUT with no content-type and no payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+
+    # PUT with json content-type and non-json payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
+        -H \"Content-Type: application/json\" -d \"not a json payload\" | jq -r .message" "request body is not json" 6 5
+
+    # PUT with x-www-form-urlencoded content-type and x-www-form-urlencoded payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
+        -H \"Content-Type: application/x-www-form-urlencoded\" -d \"name=VMware&place=Palo Alto\" | jq -r .myField" "Hello, VMware from Palo Alto" 6 5
+
+    # PUT with non-supported content-type and payload
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
+        -H \"Content-Type: unsupported-content-type\" -d \"some payload\" | jq -r .message" "request body type is not supported: unsupported-content-type" 6 5
+
+    # GET with parameters
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto" 6 5
+
+    # GET without parameters
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+
+    # Test HTTP Context
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/echo -k | jq -r .context.httpContext.method" "PUT" 6 5
+}
+
+@test "Test APIs with CORS" {
+    # contains "Access-Control-Allow-Origin: *"
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/cors -k -v -H \"Content-Type: application/json\" -d '{
+            \"name\": \"VMware\",
+            \"place\": \"Palo Alto\"
+        }' 2>&1 | grep -c \"Access-Control-Allow-Origin: *\"" 1 10 5
+}
+
+@test "Test API Updates" {
+    # update path and https
+    run dispatch update --work-dir ${E2E_TEST_ROOT} -f api_update.yaml
+    assert_success
+    run_with_retry "dispatch get api api-test-update --json | jq -r .status" "READY" 6 20
+
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/goodbye -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+}

--- a/e2e/upgrade/exec/events.bats
+++ b/e2e/upgrade/exec/events.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Emit an event for subscription" {
+    func_name=node-echo-back-sub
+    sub_name=testsub
+    event_name=test.event
+    
+    run dispatch emit ${event_name} --data='{"name": "Jon", "place": "Winterfell"}' --content-type="application/json"
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get runs ${func_name} --json | jq -r '.[0].functionName'" "${func_name}" 4 5
+    run_with_retry "dispatch get runs ${func_name} --json | jq -r '.[0].status'" "READY" 12 5
+    result=$(dispatch get runs ${func_name} --json | jq -r '.[0].output.context.event."eventType"')
+    assert_equal "${event_name}" $result
+}
+
+@test "Create subscription with event driver" {
+    func_name=node-echo-back-driver
+    sub_name=driversub
+    driver_name=testdriver
+
+    run dispatch create subscription --event-type ticker.tick --name ${sub_name} ${func_name}
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get subscription ${sub_name} --json | jq -r .status" "READY" 4 5
+
+    run_with_retry "dispatch get runs ${func_name} --json | jq -r '.[0].status'" "READY" 4 5
+}
+
+@test "Update event driver" {
+    driver_name=testdriver
+
+	update_tmp=$(mktemp)
+	cat <<- EOF > ${update_tmp}
+	config:
+	- key: seconds
+	  value: '5'
+	kind: Driver
+	name: ${driver_name}
+	secrets:
+	tags:
+	type: ticker
+	EOF
+    assert_success
+
+    run dispatch update -f ${update_tmp}
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get eventdriver ${driver_name} --json | jq -r .status" "READY" 4 5
+    result=$(dispatch get eventdriver ${driver_name} --json | jq -r .config[0].value)
+    assert_equal 5 $result
+
+    rm ${update_tmp}
+}

--- a/e2e/upgrade/exec/functions.bats
+++ b/e2e/upgrade/exec/functions.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Execute node function no schema" {
+    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 10 5
+}
+
+@test "Execute node function with schema" {
+    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait --json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 5
+}
+
+@test "Execute node function with input schema error" {
+    run_with_retry "dispatch exec node-hello-with-schema --wait --json | jq -r .error.type" "InputError" 5 5
+}
+
+@test "Execute powershell with runtime deps" {
+    run_with_retry "dispatch exec powershell-slack --wait --json | jq -r .output.result" "true" 5 5
+}
+
+@test "Execute python function with logging" {
+    run_with_retry "dispatch exec logger --wait --json | jq -r \".logs.stderr | .[0]\"" "this goes to stderr" 5 5
+    run_with_retry "dispatch exec logger --wait --json | jq -r \".logs.stdout | .[0]\"" "this goes to stdout" 5 5
+}
+
+@test "Update function python" {
+
+    run dispatch update --work-dir ${E2E_TEST_ROOT} -f function_update.yaml
+    assert_success
+    run_with_retry "dispatch get function python-hello-no-schema --json | jq -r .status" "READY" 6 5
+
+    run_with_retry "dispatch exec python-hello-no-schema --wait --json | jq -r .output.myField" "Goodbye, Noone from Nowhere" 6 5
+}
+
+@test "Delete python function no schema" {
+    run dispatch delete function python-hello-no-schema
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get runs python-hello-no-schema --json | jq '. | length'" 0 5 5
+}

--- a/e2e/upgrade/exec/images.bats
+++ b/e2e/upgrade/exec/images.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Image creation" {
+    run dispatch create image new-nodejs nodejs-base
+    assert_success
+    run_with_retry "dispatch get image new-nodejs --json | jq -r .status" "READY" 8 5
+}
+
+@test "Update images" {
+    run dispatch update --work-dir ${E2E_TEST_ROOT} -f images_update.yaml
+    assert_success
+
+    run_with_retry "dispatch get image python3 --json | jq -r .status" "READY" 6 30
+    run_with_retry "dispatch get base-image nodejs-base --json | jq -r .status" "READY" 6 30
+
+    run_with_retry "dispatch get base-image nodejs-base --json | jq -r .language" "python3" 1 0
+    assert_success
+
+    run_with_retry "dispatch get image python3 --json | jq -r .tags[0].key" "update" 1 0
+    assert_success
+
+    run bash -c "dispatch update --work-dir ${E2E_TEST_ROOT} -f image_not_found_update.yaml"
+    assert_failure
+}

--- a/e2e/upgrade/exec/login.bats
+++ b/e2e/upgrade/exec/login.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Login to test service account" {
+
+    # Unset the CI accounts (if any)
+    svc_acct=${DISPATCH_SERVICE_ACCOUNT}
+    pri_key=${DISPATCH_JWT_PRIVATE_KEY}
+    unset DISPATCH_SERVICE_ACCOUNT
+    unset DISPATCH_JWT_PRIVATE_KEY
+
+    # Set a custom config file to test login
+    tmp_dir=$(mktemp -d)
+    export DISPATCH_CONFIG=${tmp_dir}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+
+    # Login to test service account with invalid private key
+    head -c 4096 < /dev/urandom > ${tmp_dir}/test-invalid.key
+    run dispatch login --service-account ${DISPATCH_TEST_SERVICE_ACCOUNT} --jwt-private-key ${tmp_dir}/test-invalid.key
+    echo_to_log
+    assert_failure
+
+    # Login to test service account with correct private key
+    run dispatch login --service-account ${DISPATCH_TEST_SERVICE_ACCOUNT} --jwt-private-key ${DISPATCH_TEST_JWT_PRIVATE_KEY}
+    echo_to_log
+    assert_success
+
+    run dispatch get functions
+    echo_to_log
+    assert_success
+
+    run dispatch logout
+    assert_success
+
+    unset DISPATCH_CONFIG
+
+    # Cleanup
+    rm -r ${tmp_dir}
+
+    # Reset the CI accounts (if any) and custom config file
+    export DISPATCH_SERVICE_ACCOUNT=${svc_acct}
+    export DISPATCH_JWT_PRIVATE_KEY=${pri_key}
+
+    run dispatch iam delete serviceaccount ${DISPATCH_TEST_SERVICE_ACCOUNT}
+    echo_to_log
+    assert_success
+
+    run dispatch iam delete policy ${DISPATCH_TEST_SERVICE_ACCOUNT}-policy
+    echo_to_log
+    assert_success
+}

--- a/e2e/upgrade/exec/organizations.bats
+++ b/e2e/upgrade/exec/organizations.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create resources in test-org-b" {
+
+    ##################
+    # Setup test-org-b
+    ##################
+    tmp_dir_b=$(mktemp -d)
+    setup_test_org test-org-b ${tmp_dir_b}
+
+    # Unset the CI accounts (if any)
+    unset DISPATCH_SERVICE_ACCOUNT
+    unset DISPATCH_JWT_PRIVATE_KEY
+    unset DISPATCH_ORGANIZATION
+
+    #####################
+    # Login to test-org-b
+    #####################
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir_b}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account test-org-b-user --jwt-private-key ${tmp_dir_b}/private.key --organization test-org-b
+    echo_to_log
+    assert_success
+
+    # Ensure no images exist in test-org-b
+    run bash -c "dispatch get base-image --json | jq '. | length'"
+    assert_equal 0 $output
+
+    # Ensure no functions exist in test-org-b
+    run bash -c "dispatch get functions --json | jq '. | length'"
+    assert_equal 0 $output
+
+    # Create images in test-org-b
+    batch_create_images
+
+    # Create function with same name in test-org-b
+    run dispatch create function --image=nodejs node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 15 5
+
+    run dispatch create api api-test-https-only node-hello-no-schema -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/test-org-b/https-only -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+
+    # Should not be able to view resources in test-org-a
+    run dispatch get functions --organization test-org-a
+    echo_to_log
+    assert_failure
+
+    run dispatch logout
+    assert_success
+
+    rm -r ${tmp_dir_b}
+    unset DISPATCH_CONFIG
+}
+
+@test cleanup {
+    # Cleanup resources
+    DISPATCH_ORGANIZATION=test-org-a cleanup
+    DISPATCH_ORGANIZATION=test-org-b cleanup
+    delete_test_org test-org-a
+    delete_test_org test-org-b
+}

--- a/e2e/upgrade/exec/secrets.bats
+++ b/e2e/upgrade/exec/secrets.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Execute function with a default secret" {
+    run_with_retry "dispatch exec i-have-a-default-secret --wait --json | jq -r .output.message" "The password is OpenSesame" 5 5
+}
+
+@test "Execute function without a default secret" {
+    run_with_retry "dispatch exec i-have-a-secret --wait --json | jq -r .output.message" "I know nothing" 5 5
+    run_with_retry "dispatch exec i-have-a-secret --secret open-sesame --wait --json | jq -r .output.message" "The password is OpenSesame" 5 5
+}
+
+@test "Update secret" {
+    run dispatch update --work-dir ${E2E_TEST_ROOT} -f secret_update.yaml
+    assert_success
+
+    run_with_retry "dispatch get secret open-sesame --json | jq -r .secrets.password" "OpenSesameStreet" 5 5
+}

--- a/e2e/upgrade/exec/services.bats
+++ b/e2e/upgrade/exec/services.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Execute a function which echos the service context" {
+
+    run dispatch exec node-echo-service --wait
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch exec node-echo-service --wait --input '{\"in-1\": \"baz\"}' | jq -r '.output.context.serviceBindings.\"ups-with-schema\".\"special-key-1\"'" "special-value-1" 12 10
+    echo_to_log
+    assert_success
+}
+
+@test "Delete service instance" {
+
+    run dispatch delete serviceinstance ups-with-schema
+    echo_to_log
+    assert_success
+    # See issue https://github.com/vmware/dispatch/issues/542
+    sleep 60
+}
+
+@test "[Re]Create service instance" {
+
+    run dispatch create serviceinstance ups-with-schema user-provided-service-with-schemas default --params '{"param-1": "foo", "param-2": "bar"}'
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get serviceinstances ups-with-schema --json | jq -r .status" "READY" 6 10
+    run_with_retry "dispatch get serviceinstances ups-with-schema --json | jq -r .binding.status" "READY" 6 10
+}
+
+@test "[Re]Delete service instance" {
+
+    run dispatch delete serviceinstance ups-with-schema
+    echo_to_log
+    assert_success
+}
+
+@test "Tear down catalog" {
+
+    run helm delete --purge ups-broker
+    echo_to_log
+    assert_success
+
+    run helm delete --purge catalog
+    echo_to_log
+    assert_success
+
+    run kubectl delete namespace ${DISPATCH_NAMESPACE}-services
+    echo_to_log
+    assert_success
+}

--- a/e2e/upgrade/setup/apis.bats
+++ b/e2e/upgrade/setup/apis.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create functions for APIs" {
+    run dispatch create function --image=nodejs func-nodejs ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function func-nodejs --json | jq -r .status" "READY" 10 5
+
+    run dispatch create function --image=nodejs node-echo-back ${DISPATCH_ROOT}/examples/nodejs --handler=./debug.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-echo-back --json | jq -r .status" "READY" 10 5
+}
+
+@test "Create APIs with HTTP(S)" {
+    run dispatch create api api-test-http func-nodejs -m POST -p /http --auth public
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get api api-test-http --json | jq -r .status" "READY" 10 5
+}
+
+@test "Create APIs with HTTPS ONLY" {
+    run dispatch create api api-test-https-only func-nodejs -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+}
+
+@test "Create APIs with Kong Plugins" {
+    run dispatch create api api-test func-nodejs -m GET -m DELETE -m POST -m PUT -p /hello --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test --json | jq -r .status" "READY" 6 5
+
+    run dispatch create api api-echo node-echo-back -m GET -m DELETE -m POST -m PUT -p /echo --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-echo --json | jq -r .status" "READY" 6 5
+}
+
+@test "Create APIs with CORS" {
+    run dispatch create api api-test-cors func-nodejs -m POST -m PUT -p /cors --auth public --cors
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-cors --json | jq -r .status" "READY" 10 5
+}
+
+@test "Create API Updates" {
+    run dispatch create api api-test-update func-nodejs -m GET -p /hello --auth public
+    assert_success
+    run_with_retry "dispatch get api api-test-update --json | jq -r .status" "READY" 6 5
+
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+}
+

--- a/e2e/upgrade/setup/events.bats
+++ b/e2e/upgrade/setup/events.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create subscription" {
+    func_name=node-echo-back-sub
+    sub_name=testsub
+    event_name=test.event
+
+    run dispatch create function --image=nodejs ${func_name} ${DISPATCH_ROOT}/examples/nodejs --handler=./debug.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function ${func_name} --json | jq -r .status" "READY" 8 5
+
+    # https://github.com/vmware/dispatch/issues/364
+    sleep 5
+
+    run dispatch create subscription --name ${sub_name} --event-type ${event_name} ${func_name}
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get subscription ${sub_name} --json | jq -r .status" "READY" 4 5
+}
+
+@test "Create event driver" {
+    func_name=node-echo-back-driver
+    driver_name=testdriver
+
+    run dispatch create function --image=nodejs ${func_name} ${DISPATCH_ROOT}/examples/nodejs --handler=./debug.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function ${func_name} --json | jq -r .status" "READY" 8 5
+
+    run dispatch create eventdrivertype ticker kars7e/timer:latest
+    echo_to_log
+    assert_success
+
+    run dispatch get eventdrivertype ticker
+    echo_to_log
+    assert_success
+
+    run dispatch create eventdriver ticker --name ${driver_name} --set seconds=2
+    run_with_retry "dispatch get eventdriver ${driver_name} --json | jq -r '.status'" "READY" 4 5
+}

--- a/e2e/upgrade/setup/functions.bats
+++ b/e2e/upgrade/setup/functions.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create node function no schema" {
+
+    run dispatch create function --image=nodejs node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 8 5
+}
+
+@test "Create node function with schema" {
+    run dispatch create function --image=nodejs node-hello-with-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js --schema-in ${DISPATCH_ROOT}/examples/nodejs/hello.schema.in.json --schema-out ${DISPATCH_ROOT}/examples/nodejs/hello.schema.out.json
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-with-schema --json | jq -r .status" "READY" 6 5
+}
+
+@test "Create powershell function with runtime deps" {
+    run dispatch create image powershell-with-slack powershell-base --runtime-deps ${DISPATCH_ROOT}/examples/powershell/requirements.psd1
+    assert_success
+    run_with_retry "dispatch get image powershell-with-slack --json | jq -r .status" "READY" 10 5
+
+    run dispatch create function --image=powershell-with-slack powershell-slack ${DISPATCH_ROOT}/examples/powershell --handler=test-slack.ps1::handle
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function powershell-slack --json | jq -r .status" "READY" 20 5
+}
+
+@test "Create python function with logging" {
+    src_dir=$(mktemp -d)
+    cat << EOF > ${src_dir}/logging_test.py
+import sys
+
+def handle(ctx, payload):
+    print("this goes to stdout")
+    print("this goes to stderr", file=sys.stderr)
+EOF
+
+    run dispatch create function --image=python3 logger ${src_dir} --handler=logging_test.handle
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function logger --json | jq -r .status" "READY" 10 5
+}
+
+@test "Create python function no schema" {
+    run dispatch create function --image=python3 python-hello-no-schema ${DISPATCH_ROOT}/examples/python3 --handler=hello.handle
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function python-hello-no-schema --json | jq -r .status" "READY" 10 5
+}

--- a/e2e/upgrade/setup/images.bats
+++ b/e2e/upgrade/setup/images.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Batch load images" {
+    batch_create_images
+}

--- a/e2e/upgrade/setup/organizations.bats
+++ b/e2e/upgrade/setup/organizations.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create resources in test-org-a" {
+
+    ##################
+    # Setup test-org-a
+    ##################
+    tmp_dir_a=$(mktemp -d)
+    setup_test_org test-org-a ${tmp_dir_a}
+
+    # Unset the CI accounts (if any)
+    unset DISPATCH_SERVICE_ACCOUNT
+    unset DISPATCH_JWT_PRIVATE_KEY
+    unset DISPATCH_ORGANIZATION
+
+    #####################
+    # Login to test-org-a
+    #####################
+    # Set a custom config file to test login
+    export DISPATCH_CONFIG=${tmp_dir_a}/config.json
+    cp ~/.dispatch/config.json ${DISPATCH_CONFIG}
+    run dispatch login --service-account test-org-a-user --jwt-private-key ${tmp_dir_a}/private.key --organization test-org-a
+    echo_to_log
+    assert_success
+
+    # Create images in test-org-a
+    batch_create_images
+
+    # Create function in test-org-a
+    run dispatch create function --image=nodejs node-hello-no-schema ${DISPATCH_ROOT}/examples/nodejs --handler=./hello.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-hello-no-schema --json | jq -r .status" "READY" 15 5
+
+    # Should not be able to view resources in test-org-b
+    run dispatch get functions --organization test-org-b
+    echo_to_log
+    assert_failure
+
+    run dispatch create api api-test-https-only node-hello-no-schema -m POST --https-only -p /https-only --auth public
+    echo_to_log
+    assert_success
+    run_with_retry "dispatch get api api-test-https-only --json | jq -r .status" "READY" 6 5
+    run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/test-org-a/https-only -k -H \"Content-Type: application/json\" -d '{ \
+            \"name\": \"VMware\",
+            \"place\": \"HTTPS ONLY\"
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 5
+
+    run dispatch logout
+    assert_success
+
+    rm -r ${tmp_dir_a}
+    unset DISPATCH_CONFIG
+}

--- a/e2e/upgrade/setup/secrets.bats
+++ b/e2e/upgrade/setup/secrets.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Create secret" {
+    run dispatch create secret open-sesame ${DISPATCH_ROOT}/examples/nodejs/secret.json
+    echo_to_log
+    assert_success
+}
+
+@test "Create function with a default secret" {
+    run dispatch create function --image=nodejs i-have-a-default-secret ${DISPATCH_ROOT}/examples/nodejs --handler=./i-have-a-secret.js --secret open-sesame
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-default-secret --json | jq -r .status" "READY" 15 5
+}
+
+@test "Create function without a default secret" {
+    run dispatch create function --image=nodejs i-have-a-secret ${DISPATCH_ROOT}/examples/nodejs --handler=./i-have-a-secret.js
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function i-have-a-secret --json | jq -r .status" "READY" 8 5
+}

--- a/e2e/upgrade/setup/services.bats
+++ b/e2e/upgrade/setup/services.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load ${E2E_TEST_ROOT}/helpers.bash
+load ${E2E_TEST_ROOT}/variables.bash
+
+@test "Setup service catalog" {
+
+    run helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
+    echo_to_log
+    assert_success
+
+    run helm upgrade -i catalog svc-cat/catalog --namespace ${DISPATCH_NAMESPACE}-services --wait
+    echo_to_log
+    assert_success
+
+    run helm upgrade -i ups-broker svc-cat/ups-broker --namespace ${DISPATCH_NAMESPACE}-services --wait
+    echo_to_log
+    assert_success
+}
+
+
+@test "Register ups broker" {
+
+
+cat << EOF > ups-broker.yaml
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceBroker
+metadata:
+    name: ups-broker
+spec:
+    url: http://ups-broker-ups-broker.${DISPATCH_NAMESPACE}-services.svc.cluster.local
+EOF
+
+    # Seems the service isn't quite ready when it says it is
+    retry_simple "kubectl create -f ups-broker.yaml" 30 6
+    echo_to_log
+    assert_success
+
+    run_with_retry "kubectl get clusterserviceclasses -o json | jq '.items | length'" 3 12 10
+}
+
+@test "List service classes" {
+
+    # Give the service catalog a chance to sync with the broker
+    run_with_retry "dispatch get serviceclasses user-provided-service-with-schemas --json | jq -r .status" "READY" 6 10
+}
+
+@test "Create service instance" {
+
+    run dispatch create serviceinstance ups-with-schema user-provided-service-with-schemas default --params '{"param-1": "foo", "param-2": "bar"}'
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get serviceinstances ups-with-schema --json | jq -r .status" "READY" 12 10
+    run_with_retry "dispatch get serviceinstances ups-with-schema --json | jq -r .binding.status" "READY" 12 10
+    run dispatch get serviceinstances ups-with-schema --json
+    echo_to_log
+    assert_success
+
+    run dispatch get secrets --json
+    echo_to_log
+    assert_success
+}
+
+@test "Create a function which echos the service context" {
+
+    run dispatch create function --image=nodejs node-echo-service ${DISPATCH_ROOT}/examples/nodejs --handler=./echo.js --service ups-with-schema
+    echo_to_log
+    assert_success
+
+    run_with_retry "dispatch get function node-echo-service --json | jq -r .status" "READY" 8 5
+}

--- a/e2e/upgrade/setup/setup.bats
+++ b/e2e/upgrade/setup/setup.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+# Workaround for running resource setup bats files from another bats file
+
+set -o pipefail
+
+# Set this ourselves in case bats call fails
+EXIT_STATUS=0
+
+setup_entity() {
+    bats_file="e2e/upgrade/setup/${1}.bats"
+    echo "=> ${bats_file}" >&2
+    bats "${DISPATCH_ROOT}/${bats_file}" >&2
+    if [[ $? -ne 0 ]]; then
+        EXIT_STATUS=1
+    fi
+    echo >&2
+}
+
+# Load resources in specified order
+set +e
+setup_entity images
+setup_entity functions
+setup_entity apis
+setup_entity events
+setup_entity organizations
+setup_entity secrets
+setup_entity services
+set -e
+
+exit ${EXIT_STATUS}


### PR DESCRIPTION
Fixes #419 

* Adds new upgrade e2e tests to the release pipeline
* This is currently non-blocking but can easily be added in the future to block the release if the upgrade e2e tests fail
* Upgrade e2e tests are separated into two phases:
    * `Setup` - Run in the old dispatch release, creates the resources needed to test in the new dispatch release
        * `Setup.bats` loads the resources in a specific order since the tests are not independent of each other
    * `Exec` - Run in the new dispatch release, acts on the resources created in the `Setup` phase to ensure that all the old resources can still be acted on correctly (i.e. functions can still be executed, resources can still be deleted, etc.)
        * Tests in the `Exec` phase do not affect another test's resources so they can be run in any order