### PR TITLE
Include dispatch-server in the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file. For more in
 ## [Unreleased] - [[Git compare](https://github.com/vmware/dispatch/compare/v0.1.20...HEAD)]
 
 ### Added
+- [[Issue #518](https://github.com/vmware/dispatch/issues/518)] **Single-binary, local version of Dispatch Server:**
+This release includes a single-binary dispatch-server. You can run this server locally on your desktop without a need
+to provision Kubernetes - the only requirement is Docker. This should cover use cases like local development, proofs of concept,
+or a small deployment for personal needs. To use it, simply download the `dispatch-server` binary for your platform,
+and run `dispatch-server local`.
+    
+    *Note:* The local version supports all commands/resources except:
+    - event drivers
+    - services 
+
 
 ### Fixed
 

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -257,6 +257,7 @@ jobs:
         tag: build-context/tag
         globs:
         - dispatch-cli/dispatch-*
+        - dispatch-binaries/dispatch-server-*
 
 templates:
   on_failure: &test_on_failure

--- a/ci/release/binaries.yml
+++ b/ci/release/binaries.yml
@@ -16,6 +16,7 @@ outputs:
 - name: dispatch-cli
 - name: dispatch-binaries
 
+
 run:
   path: /bin/bash
   args:
@@ -28,7 +29,9 @@ run:
 
     cd $GOPATH/src/github.com/vmware/dispatch
     make linux
+    make darwin
     make cli-darwin
-
+    mv bin/dispatch-server-* $GOPATH/dispatch-binaries/
     mv bin/dispatch-* $GOPATH/dispatch-cli/
     mv bin/* $GOPATH/dispatch-binaries/
+

--- a/ci/release/release-images.yml
+++ b/ci/release/release-images.yml
@@ -29,11 +29,6 @@ run:
         if [[ -e "../dispatch-binaries/${image}-linux" ]]; then
           cp -r ../dispatch-binaries/${image}-linux $image/bin/
         fi
-        # kind of a gross hack to pull in the templates for the function-manager
-        if [[ -d "$image/templates" ]]; then
-          mkdir -p $image/images/$image/templates/
-          cp -r $image/templates/* $image/images/$image/templates/
-        fi
       done
     popd
 


### PR DESCRIPTION
* Add dispatch-server binaries to the Github release
* Add an update to the CHANGELOG
* remove a hack in release script not needed since the introduction of base images