### PR TITLE
Bump version of PhotonOS in our images

### DIFF
--- a/images/dispatch-server/Dockerfile
+++ b/images/dispatch-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:2.0
+FROM vmware/photon2:20180620
 
 ADD bin/dispatch-server-linux /dispatch-server
 RUN chmod +x /dispatch-server

--- a/images/event-sidecar/Dockerfile
+++ b/images/event-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:2.0
+FROM vmware/photon2:20180620
 
 ADD bin/event-sidecar-linux /event-sidecar
 RUN chmod +x /event-sidecar


### PR DESCRIPTION
We're still using an ancient version of PhotonOS. We shouldn't.