### PR TITLE
Clean up leaked images and FaaS deployments

### DIFF
--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -204,10 +204,13 @@ EOF
 }
 
 @test "Update function python" {
+    num_deploy=$(kubectl get deployments --all-namespaces -o json | jq -r '.items | length')
 
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f function_update.yaml
     assert_success
     run_with_retry "dispatch get function python-hello-no-schema -o json | jq -r .status" "READY" 6 5
+
+    run_with_retry "kubectl get deployments --all-namespaces -o json | jq -r '.items | length'" ${num_deploy} 5 5
 
     run_with_retry "dispatch exec python-hello-no-schema --wait -o json | jq -r .output.myField" "Goodbye, Noone from Nowhere" 6 5
 }

--- a/pkg/function-manager/controller_test.go
+++ b/pkg/function-manager/controller_test.go
@@ -132,9 +132,13 @@ func TestFuncEntityHandler_Delete(t *testing.T) {
 	}
 	faas.On("Delete", mock.Anything, function).Return(nil)
 
+	imgBuilder := &fnmocks.ImageBuilder{}
+	imgBuilder.On("RemoveImage", mock.Anything, function).Return(nil)
+
 	h := &funcEntityHandler{
-		Store: helpers.MakeEntityStore(t),
-		FaaS:  faas,
+		Store:        helpers.MakeEntityStore(t),
+		FaaS:         faas,
+		ImageBuilder: imgBuilder,
 	}
 
 	_, err := h.Store.Add(context.Background(), function)

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -589,6 +589,7 @@ func (h *Handlers) updateFunction(params fnstore.UpdateFunctionParams, principal
 		}
 	}
 
+	faasID := e.FaasID
 	err = functionModelOntoEntity(params.Body, sourceURL, e)
 	if err != nil {
 		return fnstore.NewUpdateFunctionBadRequest().WithPayload(&v1.Error{
@@ -596,8 +597,8 @@ func (h *Handlers) updateFunction(params fnstore.UpdateFunctionParams, principal
 			Message: swag.String(err.Error()),
 		})
 	}
-	// generating a new UUID will force the creation of a new function in the underlying FaaS
-	e.FaasID = uuid.NewV4().String()
+
+	e.FaasID = faasID
 	e.Status = entitystore.StatusUPDATING
 
 	_, err = h.Store.Update(ctx, e.Revision, e)

--- a/pkg/functions/builder.go
+++ b/pkg/functions/builder.go
@@ -136,3 +136,14 @@ func tarStream(bs []byte) (io.Reader, error) {
 func imageName(registry, fnID string) string {
 	return registry + "/func-" + fnID + ":latest"
 }
+
+// RemoveImage removes a function image from the docker host
+func (ib *DockerImageBuilder) RemoveImage(ctx context.Context, f *Function) error {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	if err := images.Remove(ctx, ib.docker, f.FunctionImageURL); err != nil {
+		return errors.Wrapf(err, "failed to delete docker image for function %s", f.Name)
+	}
+	return nil
+}

--- a/pkg/functions/docker/driver.go
+++ b/pkg/functions/docker/driver.go
@@ -194,19 +194,6 @@ func (d *Driver) deleteContainers(ctx context.Context, f *functions.Function, de
 		if err != nil {
 			return errors.Wrapf(err, "error when deleting container %s for function %s", c.ID, f.ID)
 		}
-		log.Debugf("Deleting image %s", c.Image)
-		deleted, err := d.docker.ImageRemove(ctx, c.Image, types.ImageRemoveOptions{
-			Force:         true,
-			PruneChildren: true,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "error when deleting function image %s for container %s and function %s", c.Image, c.ID, f.ID)
-		}
-		if log.GetLevel() == log.DebugLevel {
-			for _, image := range deleted {
-				log.Debugf("Deleted image: %+v", image)
-			}
-		}
 	}
 
 	// Clear cache if active is also to be deleted

--- a/pkg/functions/docker/driver_test.go
+++ b/pkg/functions/docker/driver_test.go
@@ -177,9 +177,6 @@ func TestOfDriverDelete(t *testing.T) {
 
 	dockerMock.On("ContainerRemove", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	dockerMock.On("ImageRemove", mock.Anything, mock.Anything, mock.Anything).Return(
-		[]types.ImageDelete{}, nil)
-
 	err := d.Delete(context.Background(), &f)
 	assert.NoError(t, err)
 

--- a/pkg/functions/mocks/image_builder.go
+++ b/pkg/functions/mocks/image_builder.go
@@ -33,3 +33,17 @@ func (_m *ImageBuilder) BuildImage(ctx context.Context, f *functions.Function, c
 
 	return r0, r1
 }
+
+// RemoveImage provides a mock function with given fields: ctx, f
+func (_m *ImageBuilder) RemoveImage(ctx context.Context, f *functions.Function) error {
+	ret := _m.Called(ctx, f)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *functions.Function) error); ok {
+		r0 = rf(ctx, f)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/pkg/functions/types.go
+++ b/pkg/functions/types.go
@@ -78,11 +78,14 @@ type FunctionResources struct {
 
 //go:generate mockery -name ImageBuilder -case underscore -dir . -note "CLOSE THIS FILE AS QUICKLY AS POSSIBLE"
 
-// ImageBuilder builds a docker image for a serverless function.
+// ImageBuilder builds or removes a docker image for a serverless function.
 type ImageBuilder interface {
 	// BuildImage builds a function image and pushes it to the docker registry.
 	// Returns image full name.
 	BuildImage(ctx context.Context, f *Function, code []byte) (string, error)
+
+	// RemoveImage removes a function image from the docker host
+	RemoveImage(ctx context.Context, f *Function) error
 }
 
 // Runner knows how to execute a function

--- a/pkg/image-manager/controller.go
+++ b/pkg/image-manager/controller.go
@@ -125,6 +125,12 @@ func (h *imageEntityHandler) Update(ctx context.Context, obj entitystore.Entity)
 	span, ctx := trace.Trace(ctx, "")
 	defer span.Finish()
 
+	i := obj.(*Image)
+
+	if err := h.Builder.imageDelete(ctx, i); err != nil {
+		log.Errorf("error deleting docker image %s: %+v", i.DockerURL, err)
+	}
+
 	return h.Add(ctx, obj)
 }
 

--- a/pkg/image-manager/handlers.go
+++ b/pkg/image-manager/handlers.go
@@ -303,6 +303,10 @@ func (h *Handlers) updateBaseImageByName(params baseimage.UpdateBaseImageByNameP
 			})
 	}
 
+	if err := h.baseImageBuilder.baseImageDelete(ctx, &e); err != nil {
+		log.Errorf("error deleting docker image %s: %+v", e.DockerURL, err)
+	}
+
 	h.Watcher.OnAction(ctx, updateEntity)
 
 	m := baseImageEntityToModel(updateEntity)
@@ -485,6 +489,7 @@ func (h *Handlers) updateImageByName(params image.UpdateImageByNameParams, princ
 	e.Status = StatusUPDATING
 	e.CreatedTime = current.CreatedTime
 	e.ID = current.ID
+	e.DockerURL = current.DockerURL
 
 	_, err = h.Store.Update(ctx, current.Revision, e)
 	if err != nil {

--- a/pkg/image-manager/image_builder.go
+++ b/pkg/image-manager/image_builder.go
@@ -119,10 +119,7 @@ func (b *BaseImageBuilder) baseImageDelete(ctx context.Context, baseImage *BaseI
 	// Even though we are explicitly removing the image, other base images which point to the same docker URL will
 	// continue to work.  They remain in READY status, and the next "poll" loop should re-pull the image.  If the
 	// image is pulled as part of an image create, the image will be pulled immediately and should continue to work.
-	_, err := b.dockerClient.ImageRemove(ctx, baseImage.DockerURL, dockerTypes.ImageRemoveOptions{
-		Force:         true,
-		PruneChildren: true,
-	})
+	err := images.Remove(ctx, b.dockerClient, baseImage.DockerURL)
 	// If the image status is NOT ready, errors are expected, continue delete
 	if err != nil && baseImage.Status == StatusREADY {
 		return errors.Wrapf(err, "Error deleting image %s/%s", baseImage.OrganizationID, baseImage.Name)
@@ -380,10 +377,7 @@ func (b *ImageBuilder) imageDelete(ctx context.Context, image *Image) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	_, err := b.dockerClient.ImageRemove(ctx, image.DockerURL, dockerTypes.ImageRemoveOptions{
-		Force:         true,
-		PruneChildren: true,
-	})
+	err := images.Remove(ctx, b.dockerClient, image.DockerURL)
 	// If the image status is NOT ready, errors are expected, continue delete
 	if err != nil && image.Status == entitystore.StatusREADY {
 		return errors.Wrapf(err, "Error deleting image %s/%s", image.OrganizationID, image.Name)

--- a/pkg/images/builder.go
+++ b/pkg/images/builder.go
@@ -120,3 +120,19 @@ func Push(ctx context.Context, client docker.ImageAPIClient, name, registryAuth 
 	}
 	return nil
 }
+
+// Remove a docker image
+func Remove(ctx context.Context, client docker.ImageAPIClient, name string) error {
+	span, ctx := trace.Trace(ctx, "")
+	defer span.Finish()
+
+	_, err := client.ImageRemove(ctx, name, types.ImageRemoveOptions{
+		Force:         true,
+		PruneChildren: true,
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete image %s", name)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #564, Fixes #219

* Clean up images from docker host when updating/deleting functions, images, and base-images
* FaaS function deployments are now deleted when a function is updated

There are still some images being leaked when creating a function - the function manager pulls down "dispatch images" when creating a function. Deleting these could cause a race condition if there is also a function being created at the same time which depends on that image.

**TODO**
Delete images from the docker registry when a function/image is deleted