### PR TITLE
Ability to set cpu and memory limits/requests on a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ function invocation reaches the function server after the deadline has expired t
 the function will be invoked until the function returns or the deadline is hit, whichever comes first. This support requires
 the use of the most recent function base images, 0.0.11 for nodejs-base and python3-base and 0.0.12 for java-base and
 powershell-base. Executing `dispatch create seed-images` will automatically populate these images.
+- [[Issue #301]](https://github.com/vmware/dispatch/issues/301) **Set cpu and memory requests/limits on a function** CPU and memory requests/limits can now be set for a single function. When creating a function, the following flags can be used to set the requests/limits: `--cpu-limit`, `--cpu-req`, `--mem-limit`, `--mem-req`. [PR #581](https://github.com/vmware/dispatch/pull/581)
 
 ### Fixed
 

--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -215,6 +215,25 @@ EOF
     run_with_retry "dispatch exec python-hello-no-schema --wait -o json | jq -r .output.myField" "Goodbye, Noone from Nowhere" 6 5
 }
 
+@test "Create function with resource requirements" {
+    run dispatch create function --image=python3 func-resources ${DISPATCH_ROOT}/examples/python3 --handler=http_func.handle --cpu-req 500m --cpu-limit 2 --mem-req 128Mi --mem-limit 256Mi
+    echo_to_log
+    assert_success
+
+    # Wait for deploy to be up
+    sleep 10
+
+    faas_id=$(dispatch get function func-resources --json | jq -r .faasId)
+    image=$(dispatch get function func-resources --json | jq -r .functionImageURL)
+    ns=$(kubectl get deploy --all-namespaces | grep ${faas_id} | awk '{print $1;}')
+    deploy=$(kubectl get deploy --all-namespaces | grep ${faas_id} | awk '{print $2;}')
+
+    run_with_retry "kubectl get deploy -n ${ns} ${deploy} -o json | jq -r --arg image ${image} '.spec.template.spec.containers | .[] | select(.image==\"$image\") | .resources.requests.cpu'" "500m" 5 5
+    run_with_retry "kubectl get deploy -n ${ns} ${deploy} -o json | jq -r --arg image ${image} '.spec.template.spec.containers | .[] | select(.image==\"$image\") | .resources.limits.cpu'" "2" 5 5
+    run_with_retry "kubectl get deploy -n ${ns} ${deploy} -o json | jq -r --arg image ${image} '.spec.template.spec.containers | .[] | select(.image==\"$image\") | .resources.requests.memory'" "128Mi" 5 5
+    run_with_retry "kubectl get deploy -n ${ns} ${deploy} -o json | jq -r --arg image ${image} '.spec.template.spec.containers | .[] | select(.image==\"$image\") | .resources.limits.memory'" "256Mi" 5 5
+}
+
 @test "Delete functions" {
     delete_entities function
 }

--- a/pkg/api/v1/function.go
+++ b/pkg/api/v1/function.go
@@ -30,6 +30,12 @@ type Function struct {
 	// only used in seed.yaml
 	SourcePath string `json:"sourcePath,omitempty"`
 
+	// resource limits
+	ResourceLimits *FunctionResources `json:"resourceLimits,omitempty"`
+
+	// resource requests
+	ResourceRequests *FunctionResources `json:"resourceRequests,omitempty"`
+
 	// created time
 	CreatedTime int64 `json:"createdTime,omitempty"`
 
@@ -89,6 +95,16 @@ type Function struct {
 func (m *Function) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateResourceLimits(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateResourceRequests(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateFaasID(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -142,6 +158,44 @@ func (m *Function) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Function) validateResourceLimits(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ResourceLimits) { // not required
+		return nil
+	}
+
+	if m.ResourceLimits != nil {
+
+		if err := m.ResourceLimits.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("resourceLimits")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Function) validateResourceRequests(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ResourceRequests) { // not required
+		return nil
+	}
+
+	if m.ResourceRequests != nil {
+
+		if err := m.ResourceRequests.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("resourceRequests")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1/function_resources.go
+++ b/pkg/api/v1/function_resources.go
@@ -1,0 +1,54 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package v1
+
+import (
+	strfmt "github.com/go-openapi/strfmt"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/swag"
+)
+
+// NO TESTS
+
+// FunctionResources function resources
+// swagger:model FunctionResources
+type FunctionResources struct {
+
+	// cpu
+	CPU string `json:"cpu,omitempty"`
+
+	// memory
+	Memory string `json:"memory,omitempty"`
+}
+
+// Validate validates this function resources
+func (m *FunctionResources) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *FunctionResources) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *FunctionResources) UnmarshalBinary(b []byte) error {
+	var res FunctionResources
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}

--- a/pkg/dispatchcli/cmd/create_function.go
+++ b/pkg/dispatchcli/cmd/create_function.go
@@ -34,6 +34,10 @@ var (
 	fnSecrets             []string
 	fnServices            []string
 	timeout               int64
+	cpuLimit              = ""
+	cpuRequest            = ""
+	memoryLimit           = ""
+	memoryRequest         = ""
 )
 
 // NewCmdCreateFunction creates command responsible for dispatch function creation.
@@ -58,6 +62,10 @@ func NewCmdCreateFunction(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd.Flags().StringArrayVar(&fnSecrets, "secret", []string{}, "Function secrets, can be specified multiple times or a comma-delimited string")
 	cmd.Flags().StringArrayVar(&fnServices, "service", []string{}, "Service instances this function uses, can be specified multiple times or a comma-delimited string")
 	cmd.Flags().Int64Var(&timeout, "timeout", 0, "A timeout to limit function execution time (in milliseconds). Default: 0 (no timeout)")
+	cmd.Flags().StringVar(&cpuLimit, "cpu-limit", "", "CPU limit for the function expressed in units of cores")
+	cmd.Flags().StringVar(&cpuRequest, "cpu-req", "", "CPU request for the function expressed in units of cores")
+	cmd.Flags().StringVar(&memoryLimit, "mem-limit", "", "Memory limit for the function expressed in bytes")
+	cmd.Flags().StringVar(&memoryRequest, "mem-req", "", "Memory request for the function expressed in bytes")
 	cmd.MarkFlagRequired("image")
 	return cmd
 }
@@ -98,7 +106,15 @@ func createFunction(out, errOut io.Writer, cmd *cobra.Command, args []string, c 
 		Secrets:  fnSecrets,
 		Services: fnServices,
 		Timeout:  timeout,
-		Tags:     []*v1.Tag{},
+		ResourceLimits: &v1.FunctionResources{
+			CPU:    cpuLimit,
+			Memory: memoryLimit,
+		},
+		ResourceRequests: &v1.FunctionResources{
+			CPU:    cpuRequest,
+			Memory: memoryRequest,
+		},
+		Tags: []*v1.Tag{},
 	}
 	if cmdFlagApplication != "" {
 		function.Tags = append(function.Tags, &v1.Tag{

--- a/pkg/dispatchserver/functions.go
+++ b/pkg/dispatchserver/functions.go
@@ -71,9 +71,11 @@ func faasDriver(config functionsConfig, zk string) functions.FaaSDriver {
 		})
 	case "kubeless":
 		faas, err = kubeless.New(&kubeless.Config{
-			K8sConfig:       config.K8sConfig,
-			FuncNamespace:   config.KubelessNamespace,
-			ImagePullSecret: config.ImagePullSecret,
+			K8sConfig:           config.K8sConfig,
+			FuncNamespace:       config.KubelessNamespace,
+			ImagePullSecret:     config.ImagePullSecret,
+			FuncDefaultRequests: config.FuncDefaultRequests,
+			FuncDefaultLimits:   config.FuncDefaultLimits,
 		})
 	case "noop":
 		faas, err = noop.New(&noop.Config{})

--- a/pkg/function-manager/gen/restapi/embedded_spec.go
+++ b/pkg/function-manager/gen/restapi/embedded_spec.go
@@ -1329,6 +1329,12 @@ func init() {
           },
           "x-go-name": "Reason"
         },
+        "resourceLimits": {
+          "$ref": "#/definitions/functionResourceLimits"
+        },
+        "resourceRequests": {
+          "$ref": "#/definitions/functionResourceRequests"
+        },
         "schema": {
           "$ref": "#/definitions/functionSchema"
         },
@@ -1384,6 +1390,42 @@ func init() {
           "x-go-name": "Timeout"
         }
       },
+      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
+    },
+    "functionResourceLimits": {
+      "description": "FunctionResources function resources",
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "description": "cpu",
+          "type": "string",
+          "x-go-name": "CPU"
+        },
+        "memory": {
+          "description": "memory",
+          "type": "string",
+          "x-go-name": "Memory"
+        }
+      },
+      "x-go-gen-location": "models",
+      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
+    },
+    "functionResourceRequests": {
+      "description": "FunctionResources function resources",
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "description": "cpu",
+          "type": "string",
+          "x-go-name": "CPU"
+        },
+        "memory": {
+          "description": "memory",
+          "type": "string",
+          "x-go-name": "Memory"
+        }
+      },
+      "x-go-gen-location": "models",
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     },
     "functionSchema": {

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -81,8 +81,16 @@ func functionEntityToModel(f *functions.Function) *v1.Function {
 		Secrets:  f.Secrets,
 		Services: f.Services,
 		Timeout:  f.Timeout,
-		Tags:     tags,
-		Status:   v1.Status(f.Status),
+		ResourceLimits: &v1.FunctionResources{
+			CPU:    f.ResourceLimits.CPU,
+			Memory: f.ResourceLimits.Memory,
+		},
+		ResourceRequests: &v1.FunctionResources{
+			CPU:    f.ResourceRequests.CPU,
+			Memory: f.ResourceRequests.Memory,
+		},
+		Tags:   tags,
+		Status: v1.Status(f.Status),
 	}
 }
 
@@ -119,6 +127,16 @@ func functionModelOntoEntity(m *v1.Function, sourceURL string, e *functions.Func
 	if err != nil {
 		return err
 	}
+	var resourceLimits functions.FunctionResources
+	if m.ResourceLimits != nil {
+		resourceLimits.CPU = m.ResourceLimits.CPU
+		resourceLimits.Memory = m.ResourceLimits.Memory
+	}
+	var resourceRequests functions.FunctionResources
+	if m.ResourceRequests != nil {
+		resourceRequests.CPU = m.ResourceRequests.CPU
+		resourceRequests.Memory = m.ResourceRequests.Memory
+	}
 	e.SourceURL = sourceURL
 	e.Handler = m.Handler
 	e.ImageName = *m.Image
@@ -128,6 +146,8 @@ func functionModelOntoEntity(m *v1.Function, sourceURL string, e *functions.Func
 	for _, t := range m.Tags {
 		e.Tags[t.Key] = t.Value
 	}
+	e.ResourceRequests = resourceRequests
+	e.ResourceLimits = resourceLimits
 	e.Reason = m.Reason
 	e.Schema = schema
 	e.Secrets = m.Secrets

--- a/pkg/functions/entities.go
+++ b/pkg/functions/entities.go
@@ -20,16 +20,18 @@ import (
 // Function struct represents function entity that is stored in entity store
 type Function struct {
 	entitystore.BaseEntity
-	FaasID           string   `json:"faasId"`
-	SourceURL        string   `json:"sourceURL"`
-	Handler          string   `json:"handler"`
-	ImageName        string   `json:"image"`
-	ImageURL         string   `json:"imageURL"`
-	FunctionImageURL string   `json:"functionImageURL"`
-	Schema           *Schema  `json:"schema,omitempty"`
-	Secrets          []string `json:"secrets,omitempty"`
-	Services         []string `json:"services,omitempty"`
-	Timeout          int64    `json:"timeout,omitempty"`
+	FaasID           string            `json:"faasId"`
+	SourceURL        string            `json:"sourceURL"`
+	Handler          string            `json:"handler"`
+	ImageName        string            `json:"image"`
+	ImageURL         string            `json:"imageURL"`
+	FunctionImageURL string            `json:"functionImageURL"`
+	Schema           *Schema           `json:"schema,omitempty"`
+	Secrets          []string          `json:"secrets,omitempty"`
+	Services         []string          `json:"services,omitempty"`
+	Timeout          int64             `json:"timeout,omitempty"`
+	ResourceLimits   FunctionResources `json:"resourceLimits,omitempty"`
+	ResourceRequests FunctionResources `json:"resourceRequests,omitempty"`
 }
 
 // Schema struct stores input and output validation schemas

--- a/swagger/models.json
+++ b/swagger/models.json
@@ -641,6 +641,12 @@
           },
           "x-go-name": "Reason"
         },
+        "resourceLimits": {
+          "$ref": "#/definitions/FunctionResources"
+        },
+        "resourceRequests": {
+          "$ref": "#/definitions/FunctionResources"
+        },
         "schema": {
           "$ref": "#/definitions/Schema"
         },
@@ -692,6 +698,23 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "Timeout"
+        }
+      },
+      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
+    },
+    "FunctionResources": {
+      "description": "FunctionResources function resources",
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "description": "cpu",
+          "type": "string",
+          "x-go-name": "CPU"
+        },
+        "memory": {
+          "description": "memory",
+          "type": "string",
+          "x-go-name": "Memory"
         }
       },
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"


### PR DESCRIPTION
Fixes #301

* Add configurable cpu and memory limits/requests for a function
* Add cpu and memory limits/requests to riff and kubeless
* Add FunctionResources model
* Add unit tests and e2e test