### PR TITLE
Fix Dispatch installation api-gateway output

### DIFF
--- a/pkg/dispatchcli/cmd/install.go
+++ b/pkg/dispatchcli/cmd/install.go
@@ -474,6 +474,8 @@ func writeConfig(out, errOut io.Writer, configDir string, config *installConfig)
 	c.Port = config.DispatchConfig.Port
 	c.Insecure = config.DispatchConfig.TLS.Insecure
 	c.Namespace = config.DispatchConfig.Chart.Namespace
+	c.APIHTTPPort = dispatchConfig.APIHTTPPort
+	c.APIHTTPSPort = dispatchConfig.APIHTTPSPort
 
 	if config.DispatchConfig.SkipAuth {
 		// In SkipAuth mode, a dummy org is required to be passed as HEADER to avoid swagger runtime returning an


### PR DESCRIPTION
Quick fix where the http and https ports are now correctly outputted when installing the dispatch api-gateway as `NodePort`.

Previously when installing the api-gateway with `NodePort` the installation output would display the http and https ports as 0:
```
Installing charts/dispatch helm chart
Successfully installed charts/dispatch chart - dispatch
dispatch api-gateway is running at http port: 0 and https port: 0
```