### PR TITLE
[CLI] Add set,delete,current for manage context

### DIFF
--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -202,6 +202,7 @@ func NewCLI(in io.Reader, out, errOut io.Writer) *cobra.Command {
 	cmds.AddCommand(NewCmdIam(out, errOut))
 	cmds.AddCommand(NewCmdManage(out, errOut))
 	cmds.AddCommand(NewCmdLog(out, errOut))
+	cmds.AddCommand(NewCmdContext(out, errOut))
 	return cmds
 }
 

--- a/pkg/dispatchcli/cmd/context.go
+++ b/pkg/dispatchcli/cmd/context.go
@@ -13,51 +13,49 @@ import (
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/viper"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
 )
 
 var (
-	manageContextLong    = i18n.T(`Manage configuration context.`)
-	manageContextExample = i18n.T(`
+	contextLong    = i18n.T(`Manage configuration context.`)
+	contextExample = i18n.T(`
 # list all contexts:
-$ dispatch manage context`)
+$ dispatch context`)
 
 	currentContextLong = i18n.T(`Show current configuration context.`)
 
 	setContextLong    = i18n.T(`Set configuration context.`)
 	setContextExample = i18n.T(`
 # set current context to localhost:
-$ dispatch manage context set localhost
+$ dispatch context set localhost
 Set context to localhost`)
 
 	deleteContextLong    = i18n.T(`Delete configuration context.`)
 	deleteContextExample = i18n.T(`
 # delete context localhost:
-$ dispatch manage context delete localhost
+$ dispatch context delete localhost
 Deleted context localhost`)
 )
 
-// NewCmdManageContext handles configuration context operations
-func NewCmdManageContext(out io.Writer, errOut io.Writer) *cobra.Command {
+// NewCmdContext handles configuration context operations
+func NewCmdContext(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "context",
-		Short:   i18n.T("Manage context"),
-		Long:    manageContextLong,
-		Example: manageContextExample,
-		Aliases: []string{"app"},
+		Short:   i18n.T("Manage context configuration"),
+		Long:    contextLong,
+		Example: contextExample,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return formatContextOutput(out)
 		},
 	}
 
-	cmd.AddCommand(NewCmdManageContextCurrent(out, errOut))
-	cmd.AddCommand(NewCmdManageContextSet(out, errOut))
-	cmd.AddCommand(NewCmdManageContextDelete(out, errOut))
+	cmd.AddCommand(NewCmdContextCurrent(out, errOut))
+	cmd.AddCommand(NewCmdContextSet(out, errOut))
+	cmd.AddCommand(NewCmdContextDelete(out, errOut))
 
 	return cmd
 }
@@ -150,8 +148,8 @@ func formatContextName(name string) string {
 	return strings.ToLower(strings.Replace(name, ".", "-", -1))
 }
 
-// NewCmdManageContextCurrent show current context
-func NewCmdManageContextCurrent(out io.Writer, errOut io.Writer) *cobra.Command {
+// NewCmdContextCurrent show current context
+func NewCmdContextCurrent(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "current",
 		Short: i18n.T("Show current context"),
@@ -164,8 +162,8 @@ func NewCmdManageContextCurrent(out io.Writer, errOut io.Writer) *cobra.Command 
 	return cmd
 }
 
-// NewCmdManageContextSet handles set context operations
-func NewCmdManageContextSet(out io.Writer, errOut io.Writer) *cobra.Command {
+// NewCmdContextSet handles set context operations
+func NewCmdContextSet(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set CONTEXT",
 		Short:   i18n.T("Set context"),
@@ -180,8 +178,8 @@ func NewCmdManageContextSet(out io.Writer, errOut io.Writer) *cobra.Command {
 	return cmd
 }
 
-// NewCmdManageContextDelete handles delete context operations
-func NewCmdManageContextDelete(out io.Writer, errOut io.Writer) *cobra.Command {
+// NewCmdContextDelete handles delete context operations
+func NewCmdContextDelete(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete CONTEXT",
 		Short:   i18n.T("Delete context"),

--- a/pkg/dispatchcli/cmd/manage.go
+++ b/pkg/dispatchcli/cmd/manage.go
@@ -27,6 +27,5 @@ func NewCmdManage(out, errOut io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdManageBootstrap(out, errOut))
-	cmd.AddCommand(NewCmdManageContext(out, errOut))
 	return cmd
 }

--- a/pkg/dispatchcli/cmd/manage_context.go
+++ b/pkg/dispatchcli/cmd/manage_context.go
@@ -21,48 +21,81 @@ import (
 )
 
 var (
-	manageContextLong = i18n.T(`Manage configuration context.`)
+	manageContextLong    = i18n.T(`Manage configuration context.`)
+	manageContextExample = i18n.T(`
+# list all contexts:
+$ dispatch manage context`)
 
-	// TODO: add examples
-	manageContextExample = i18n.T(``)
-	currentContext       = i18n.T(``)
+	currentContextLong = i18n.T(`Show current configuration context.`)
+
+	setContextLong    = i18n.T(`Set configuration context.`)
+	setContextExample = i18n.T(`
+# set current context to localhost:
+$ dispatch manage context set localhost
+Set context to localhost`)
+
+	deleteContextLong    = i18n.T(`Delete configuration context.`)
+	deleteContextExample = i18n.T(`
+# delete context localhost:
+$ dispatch manage context delete localhost
+Deleted context localhost`)
 )
 
 // NewCmdManageContext handles configuration context operations
 func NewCmdManageContext(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "context [--set CONTEXT]",
+		Use:     "context",
 		Short:   i18n.T("Manage context"),
 		Long:    manageContextLong,
 		Example: manageContextExample,
-		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"app"},
-		Run: func(cmd *cobra.Command, args []string) {
-			err := manageContext(out, errOut, cmd, args)
-			CheckErr(err)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return formatContextOutput(out)
 		},
 	}
 
-	cmd.Flags().StringVarP(&currentContext, "set", "s", "", "Set current context")
+	cmd.AddCommand(NewCmdManageContextCurrent(out, errOut))
+	cmd.AddCommand(NewCmdManageContextSet(out, errOut))
+	cmd.AddCommand(NewCmdManageContextDelete(out, errOut))
+
 	return cmd
 }
 
-func manageContext(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
-	if currentContext != "" {
-		if _, ok := cmdConfig.Contexts[currentContext]; !ok {
-			return errors.Errorf("No such context %s", currentContext)
-		}
-		cmdConfig.Current = currentContext
-		b, _ := json.MarshalIndent(cmdConfig, "", "    ")
-		path := viper.ConfigFileUsed()
-		err := ioutil.WriteFile(path, b, 0644)
-		if err != nil {
-			return errors.Errorf("Failed to write config file %s", path)
-		}
-		fmt.Fprintf(out, "Set context to %s\n", currentContext)
-		return nil
+func setContext(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
+	currentContext := args[0]
+	if _, ok := cmdConfig.Contexts[currentContext]; !ok {
+		return errors.Errorf("No such context %s", currentContext)
 	}
-	return formatContextOutput(out)
+	cmdConfig.Current = currentContext
+	b, _ := json.MarshalIndent(cmdConfig, "", "    ")
+	path := viper.ConfigFileUsed()
+	err := ioutil.WriteFile(path, b, 0644)
+	if err != nil {
+		return errors.Errorf("Failed to write config file %s", path)
+	}
+	fmt.Fprintf(out, "Set context to %s\n", currentContext)
+	return nil
+}
+
+func deleteContext(out, errOut io.Writer, cmd *cobra.Command, args []string) error {
+	ctxName := args[0]
+	if _, ok := cmdConfig.Contexts[ctxName]; !ok {
+		return errors.Errorf("No such context %s", ctxName)
+	}
+
+	if cmdConfig.Current == ctxName {
+		return errors.Errorf("Error: trying to delete active context %s, please switch to other context and try again.", ctxName)
+	}
+
+	delete(cmdConfig.Contexts, ctxName)
+	b, _ := json.MarshalIndent(cmdConfig, "", "    ")
+	path := viper.ConfigFileUsed()
+	err := ioutil.WriteFile(path, b, 0644)
+	if err != nil {
+		return errors.Errorf("Failed to write config file %s", path)
+	}
+	fmt.Fprintf(out, "Deleted context %s\n", ctxName)
+	return nil
 }
 
 func formatContextOutput(out io.Writer) error {
@@ -90,6 +123,75 @@ func formatContextOutput(out io.Writer) error {
 	return nil
 }
 
+func formatCurrentContextOutput(out io.Writer) error {
+	if w, err := formatOutput(out, false, cmdConfig); w {
+		return err
+	}
+
+	headers := []string{"Context", "Config"}
+	table := tablewriter.NewWriter(out)
+	table.SetHeader(headers)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetCenterSeparator("")
+	table.SetAutoWrapText(false)
+	context := cmdConfig.Current
+	config := cmdConfig.Contexts[context]
+	// Remove the cookie from output
+	config.Cookie = ""
+	configContent, _ := json.MarshalIndent(config, "", "  ")
+	context = fmt.Sprintf("* %s", context)
+	row := []string{context, string(configContent)}
+	table.Append(row)
+	table.Render()
+	return nil
+}
+
 func formatContextName(name string) string {
 	return strings.ToLower(strings.Replace(name, ".", "-", -1))
+}
+
+// NewCmdManageContextCurrent show current context
+func NewCmdManageContextCurrent(out io.Writer, errOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "current",
+		Short: i18n.T("Show current context"),
+		Long:  currentContextLong,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return formatCurrentContextOutput(out)
+		},
+	}
+	return cmd
+}
+
+// NewCmdManageContextSet handles set context operations
+func NewCmdManageContextSet(out io.Writer, errOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "set CONTEXT",
+		Short:   i18n.T("Set context"),
+		Long:    setContextLong,
+		Example: setContextExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := setContext(out, errOut, cmd, args)
+			CheckErr(err)
+		},
+	}
+	return cmd
+}
+
+// NewCmdManageContextDelete handles delete context operations
+func NewCmdManageContextDelete(out io.Writer, errOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete CONTEXT",
+		Short:   i18n.T("Delete context"),
+		Long:    deleteContextLong,
+		Example: deleteContextExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := deleteContext(out, errOut, cmd, args)
+			CheckErr(err)
+		},
+	}
+	return cmd
 }


### PR DESCRIPTION
Mange dispatch contexts by `dispatch context`

* Add set,delete and current for managing context
```bash
$ dispatch context current
$ dispatch context set <CONTEXT>
$ dispatch context delete <CONTEXT>
```
* Listing all contexts remains as `dispatch context`
