### PR TITLE
Delete resources in error state

### DIFF
--- a/examples/powershell/powercli-list-vms.ps1
+++ b/examples/powershell/powercli-list-vms.ps1
@@ -3,14 +3,14 @@
 ## SPDX-License-Identifier: Apache-2.0
 #######################################################################
 
-Import-Module PowerCLI.ViCore
+# Import-Module PowerCLI.ViCore
 
 function handle($context, $payload) {
     [void](Set-PowerCLIConfiguration -InvalidCertificateAction ignore -Confirm:$false)
 
     $username = $context.secrets.username
     $password = $context.secrets.password
-    $hostname = $payload.host
+    $hostname = $context.secrets.host
 
     $server = connect-viserver -server $hostname -User $username -Password $password
 

--- a/examples/powershell/requirements.psd1
+++ b/examples/powershell/requirements.psd1
@@ -1,3 +1,4 @@
 @{
   PSSlack = 'latest'
+  'VMware.PowerCLI' = 'latest'
 }

--- a/pkg/dispatchcli/cmd/create_eventdrivertype.go
+++ b/pkg/dispatchcli/cmd/create_eventdrivertype.go
@@ -41,7 +41,7 @@ func NewCmdCreateEventDriverType(out io.Writer, errOut io.Writer) *cobra.Command
 		},
 	}
 	cmd.Flags().StringVarP(&cmdFlagApplication, "application", "a", "", "associate with an application")
-	cmd.Flags().BoolVar(&exposeEventDriverType, "expose", true, "expose the driver externally")
+	cmd.Flags().BoolVar(&exposeEventDriverType, "expose", false, "expose the driver externally")
 	return cmd
 }
 

--- a/pkg/entity-store/postgres.go
+++ b/pkg/entity-store/postgres.go
@@ -297,8 +297,7 @@ func (p *postgresEntityStore) Update(ctx context.Context, lastRevision uint64, e
 		return 0, errors.Wrap(err, "error updating entity")
 	}
 	if rowsAffected != 1 {
-		log.Errorf("rowsAffected != 1: intead %v", rowsAffected)
-		return 0, errors.Errorf("error updating entity: no such entity or there's intermidate update")
+		return 0, errors.Errorf("error updating entity %s/%s: no such entity or there is an intermidate update - %v", entity.GetOrganizationID(), entity.GetName(), lastRevision)
 	}
 	entity.setRevision(lastRevision + 1)
 	return int64(entity.GetRevision()), nil

--- a/pkg/event-manager/drivers/http_handlers.go
+++ b/pkg/event-manager/drivers/http_handlers.go
@@ -246,6 +246,7 @@ func (h *Handlers) deleteDriver(params driverapi.DeleteDriverParams, principal i
 			})
 	}
 	d.Status = entitystore.StatusDELETING
+	d.SetDelete(true)
 	if _, err = h.store.Update(ctx, d.Revision, d); err != nil {
 		log.Errorf("store error when deleting the event driver %s: %+v", d.Name, err)
 		return driverapi.NewDeleteDriverDefault(500).WithPayload(&v1.Error{

--- a/pkg/image-manager/controller.go
+++ b/pkg/image-manager/controller.go
@@ -115,6 +115,14 @@ func (h *imageEntityHandler) Add(ctx context.Context, obj entitystore.Entity) (e
 		log.Error(err)
 	}
 
+	i.SetStatus(entitystore.StatusCREATING)
+	_, err = h.Store.Update(ctx, i.GetRevision(), i)
+	if err != nil {
+		span.LogKV("error", err)
+		log.Error(err)
+		return
+	}
+
 	defer func() { h.Store.UpdateWithError(ctx, i, err) }()
 
 	if i.Status == entitystore.StatusMISSING {
@@ -173,7 +181,6 @@ func (h *imageEntityHandler) Sync(ctx context.Context, resyncPeriod time.Duratio
 func (h *imageEntityHandler) Error(ctx context.Context, obj entitystore.Entity) error {
 	span, ctx := trace.Trace(ctx, "")
 	defer span.Finish()
-
 	_, err := h.Store.Update(ctx, obj.GetRevision(), obj)
 	return err
 }

--- a/pkg/service-manager/controller_test.go
+++ b/pkg/service-manager/controller_test.go
@@ -462,12 +462,12 @@ func TestServiceBindingSyncReady(t *testing.T) {
 	assert.Len(t, bindings, 0)
 
 	client.On("ListServiceBindings").Return([]entitystore.Entity{}, nil).Once()
-	// Actual binding missing... delete binding entity (should we recreate?)
+	// Actual binding missing... recreate binding entity
 	bindings, err = handler.Sync(context.Background(), time.Duration(1))
 	assert.NoError(t, err)
 	assert.Len(t, bindings, 1)
-	assert.True(t, bindings[0].GetDelete())
-	assert.Equal(t, entitystore.StatusDELETING, bindings[0].GetStatus())
+	assert.False(t, bindings[0].GetDelete())
+	assert.Equal(t, entitystore.StatusINITIALIZED, bindings[0].GetStatus())
 
 	// Remove the entity, creating an orphan
 	err = es.Delete(context.Background(), readyBinding.OrganizationID, readyBinding.Name, &readyBinding)


### PR DESCRIPTION
- Allow errored event drivers to be deleted
- Do not default event driver types to expose=true
- Put images in to CREATING state when picked up by controller
- Be more resilient about deleting service bindings accidentally
- Fix powercli list vms

Signed-off-by: Berndt Jung <bjung@vmware.com>