### PR TITLE
Update K8S Version to 1.9.6-gke.2 in E2E CI

### DIFF
--- a/ci/e2e/gke-cluster-create.yml
+++ b/ci/e2e/gke-cluster-create.yml
@@ -10,7 +10,7 @@ image_resource:
 params:
   GKE_KEY:
   GKE_PROJECT_ID:
-  K8S_VERSION: 1.9.6-gke.1
+  K8S_VERSION: 1.9.6-gke.2
   GKE_ZONE: us-west1-c
   CLUSTER_NAME_SUFFIX: job
 


### PR DESCRIPTION
Currently our CI jobs are failing to create a K8S cluster since the previous version `1.9.6-gke.1` is unsupported for Master Nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/601)
<!-- Reviewable:end -->
