### PR TITLE
Remove outdated eventing documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,9 @@
+# Dispatch Maintainers
+* [Berndt Jung, @berndtj](https://github.com/berndtj)
+* [Sabari Murugesan, @neosab](https://github.com/neosab)
+* [Karol Stepniewski, @kars7e](https://github.com/kars7e)
+* [Ivan Mikushin, @imikushin](https://github.com/imikushin)
+* [Russell Jew, @rjew](https://github.com/rjew)
+* [Zimeng Yang, @zimengyang](https://github.com/zimengyang)
+* [Nick Tenczar, @tenczar](https://github.com/tenczar)
+* [Mark Peek, @markpeek](https://github.com/markpeek)

--- a/README.md
+++ b/README.md
@@ -50,3 +50,21 @@ $ dispatch install --file config.yaml
 ```
 
 For a more complete quickstart see the [developer documentation](#documentation)
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull
+requests, and do our best to process them as fast as we can. If you wish to contribute code and you have not signed our
+contributor license agreement (CLA), our bot will update the issue when you open a [Pull
+Request](https://help.github.com/articles/creating-a-pull-request). For any questions about the CLA process, please
+refer to our [FAQ](https://cla.vmware.com/faq).
+
+Before you start to code, we recommend discussing your plans through a  [GitHub
+issue](https://github.com/vmware/dispatch/issues) or discuss it first with the official project
+[maintainers](AUTHORS.md) via the [#Dispatch Slack Channel](https://vmwarecode.slack.com/messages/dispatch/), especially
+for more ambitious contributions. This gives other contributors a chance to point you in the right direction, give you
+feedback on your design, and help you find out if someone else is working on the same thing.
+
+## License
+
+Admiral is available under the [Apache 2 license](LICENSE).

--- a/docs/_guides/built-in-event-drivers.md
+++ b/docs/_guides/built-in-event-drivers.md
@@ -1,8 +1,0 @@
----
-layout: default
----
-
-
-# Built-in event drivers
-
-TODO

--- a/docs/_guides/custom-event-drivers.md
+++ b/docs/_guides/custom-event-drivers.md
@@ -2,22 +2,44 @@
 layout: default
 ---
 
-# Custom event drivers in Dispatch
+# Creating Event Drivers for Dispatch
 
-Dispatch is designed to accept events from different sources. To be able to do that, Dispatch introduces a concept of event driver.
-An Event Driver is an image that knows how to ingest events from a particular source. See more in [Working with events](working-with-events.md).
-For a list of built-in drivers, see [Built-in event drivers](built-in-event-drivers.md).
+Dispatch is designed to accept events from different sources. To be able to do that, Dispatch introduces a concept of
+event driver. An Event Driver is an image that knows how to ingest events from a particular source. For a list of
+built-in drivers as well as usage, see [Working with Events](working-with-events.md).
 
 If you would like to add your own event driver, read on.
 
 ## Writing custom event driver
 
-You can write your own event driver, or use an existing driver image. In both cases, what you need is a Docker image, which
-you will register with Dispatch.
+Creating event drivers is easy.  As stated previously an event driver is simply a container which can injest events
+from a remote location, translate that event into a cloudevent format and write that event over http (or stdout).  The
+event driver is deployed with a side-car container which contains a webserver listening on port 8080, so events are
+simply sent to `http://localhost:8080` at which point the side-car forwards the event onto the event bus.
+
+### Credentials and arguments
+
+Often times an event driver will need credentials or other arguments.  These are simply represented as string flags
+which are passed through from Dispatch.  For insance if your driver requries a password, the driver should take an
+arguement `--password` and the value is passed to the driver through a Dispatch secret which includes a key/value pair
+for `"password"`.  Currently Dispatch only supports long form flags prefixed with double dashes (`--arg` not `-a` or
+`-arg`).
+
+### Injesting Events
+
+Dispatch supports both push and pull for injesting events.  A pull based event driver is pretty straight forward as it
+generally polls some remote source for new events.  Unlike functions, event drivers are long running containers which
+man maintain some state (such as last timestamps).  However, they are not persistent, so if an event driver crashes,
+state will be lost.
+
+Push based event drivers expose an HTTP endpoint for posting event data to from a remote source.  The event driver
+should implment an HTTP server listening on port 80 (configurable ports are currently not supported).  The event driver
+then translates the HTTP payload into an event or events and sends it on just like all other event drivers. See the
+[Driver registration](#driver-registration) section for information about how to expose the driver types.
 
 ### Example: ticker event driver
 
-You can find an example custom event driver written in go in examples/event-drivers/go/ticker-driver. We will
+You can find an example custom event driver written in go in `examples/event-drivers/go/ticker-driver`. We will
 progressively add more examples of event drivers written in other languages.
 
 ## Using custom event driver

--- a/docs/_guides/working-with-events.md
+++ b/docs/_guides/working-with-events.md
@@ -4,39 +4,128 @@ layout: default
 
 # Working with Events in Dispatch
 
-Dispatch is designed to accept events from different sources. To be able to do that, Dispatch introduces a concept of event driver.
-An Event Driver is an image that knows how to ingest events from a particular source. For example, if you would like to run your functions
-in reaction to events coming from VMware vCenter, you would create an event driver of type `vcenter`. There are built-in types,
-you can also register your own type by providing a specially crafted image.
+Dispatch is designed to accept events from different sources. To be able to do that, Dispatch introduces an event driver
+concept. An Event Driver is an image that knows how to ingest events from a particular source. For example, if you would
+like to run your functions in reaction to events coming from VMware vCenter, you would register a driver that knows how
+to communicate to vCenter and translate the vCenter events.  Then you create an event driver instance of that type.
+
+## Available Event Drivers
+
+The following table lists out all of the currently supported pre-build event drivers.  Adding additional event drivers
+is easy, see [Custom Event Drivers](custom-event-drivers.md) for information.  The GitHub link should provide additional
+detail per driver type.
+
+| Driver Type | Image | GitHub |
+| ----------- | ----- | ------ |
+| vcenter | dispatchframework/dispatch-events-vcenter | https://github.com/dispatchframework/dispatch-events-vcenter |
+| azure-eventgrid | dispatchframework/events-eventgrid | https://github.com/dispatchframework/dispatch-events-eventgrid |
+| aws | dispatchframework/dispatch-events-aws | https://github.com/dispatchframework/dispatch-events-aws |
+
 
 ## Implementation
 
 Event drivers are implemented as Kubernetes Pods. When a new event driver is created, a new Kubernetes pod is deployed,
 with configuration matching the one provided in the request. The pod is wrapped in the deployment, so that it will be
-rescheduled/restarted if needed. See [Registering custom event driver](custom-event-drivers.md) for more details.
+rescheduled/restarted if needed. See [Registering an Event Driver Type](#registering-an-event-driver-type) for more details.
 
-## How to use event driver in your environment
+## Event Driver Usage
 
-### Adding event driver
+The examples below show both the YAML representation of the Dispatch resource which can be used with the CLI (`dispatch
+create -f <path to yaml>`) and the pure CLI command.
 
-You can use Dispatch CLI or API to add an event driver (UI support coming soon). In the following example, we're adding
-a new vCenter event driver. 
+### Registering an Event Driver Type
+
+Before creating an event driver instance, event driver types must be registered with Dispatch.  Registering an event
+driver type is simple.  Dispatch needs to know the name of the driver type, where the driver container image is located
+and whether or not to expose an endpoint for the driver.
+
+```yaml
+kind: DriverType
+image: dispatchframework/dispatch-events-vcenter
+expose: false
+name: vcenter
+tags:
+  - key: role
+    value: example
+```
+```
+dispatch create eventdrivertype vcenter dispatchframework/dispatch-events-vcenter
+```
+
+### Adding an Event Driver Instance
+
+Once the event driver type has been registered, event driver instances can be created.  Unlike the event driver types, instances often take arguements.  To discover the arguments
+appropriate to the driver type, see the documentation for the type.  For instance the vcenter
+event driver takes vcenterurl as an argument which it uses to connect to the remote vcenter instance.
+
+Event driver arguments can be passed one of two ways:
+
+1. Directly via config or `--set` (do not use this method for passing sensitive data i.e. secrets)
+
+   ```
+   kind: Driver
+   name: vcenter1.example.com
+   type: vcenter
+   config:
+     - key: vcenterurl
+       value: user:passwd@host:port
+   tags:
+     - key: role
+       value: example
+   ```
+   ```
+   dispatch create eventdriver vcenter1.example.com --name vcenter1.example.com --set    vcenterurl=user:passwd@host:port
+   ```
+
+2. Indirectly using secrets
+
+   Create a secret with the arguments specfied as keys and values
+
+   ```
+   kind: Secret
+   name: vcenter
+   secrets:
+     vcenterurl: user:passwd@host:port
+   tags:
+     - key: role
+       value: example
+   ```
+   ```
+   cat << EOF > vcenter.json
+   {
+     "vcenterurl": "user:passwd@host:port"
+   }
+   EOF
+   dispatch create secret vcenter ./vcenter.json
+   ```
+
+   Then reference that secret when creating the event driver instance.
+
+   ```
+   kind: Driver
+   name: vcenter1.example.com
+   type: vcenter
+   secrets:
+     - vcenter
+   tags:
+     - key: role
+       value: example
+   ```
+   ```
+   dispatch create eventdriver vcenter --name vcenter1.example.com --secret vcenter
+   ```
+
+The above will create a new event driver of type `vcenter` and --name `vcenter1.example.com`. Creating an event-driver
+may take some time - monitor its status by running:
 
 ```
-dispatch create event-driver vcenter --name vcenter1.corp.local
+dispatch get eventdriver vcenter1.example.com
 ```
 
-The above will create a new event driver of type `vcenter` and --name `vcenter1.corp.local`. Creating an event-driver
-takes a while - monitor its status by running:
+When the status changes to `READY`, the event driver is ready to use.
 
-```
-dispatch get event-driver vcenter1.corp.local
-```
-
-When the status changes to `RUNNING`, the event driver is ready to use.
-
-Event driver by itself doesn't do much. it produces events which are ingested by Dispatch, but Dispatch does not know what
-to do with them yet. To tell Dispatch to react to events, you need to create a subscription.
+Event driver by itself doesn't do much. it produces events which are ingested by Dispatch, but Dispatch does not know
+what to do with them yet. To tell Dispatch to react to events, you need to create a subscription.
 
 ## Working with subscriptions
 ### Adding subscription
@@ -58,13 +147,13 @@ The above command will print output similar to the following:
   complete-cicada-410962 | vm.being.created | myFunction    | READY  | Fri Dec 31 17:18:54 PST -0001
 ```
 
-The above subscription will cause dispatch to execute function `myFunction` for every event of type `vm.being.created`. 
+The above subscription will cause dispatch to execute function `myFunction` for every event of type `vm.being.created`.
 
-You can also specify a name for your subscription using `--name` parameter. if you don't, a random, human-readable name will be created.  
+You can also specify a name for your subscription using `--name` parameter. if you don't, a random, human-readable name will be created.
 
 ### Event driver event types
 
-To find out the list of event types produced by built-in event drivers, see [Built-in Event Drivers](built-in-event-drivers.md).
+To find out the list of event types produced by event drivers, see the documentation for the event driver type.
 
 
 ## Emitting events via CLI or API
@@ -79,14 +168,14 @@ In the following example, We emit an event of type `my.event`:
 
 ```
 dispatch emit my.event --data '{ "example": "payload"}'
-```  
+```
 
 Events in Dispatch follow [Cloud Events specification](https://github.com/cloudevents/spec/blob/a12b6b618916c89bfa5595fc76732f07f89219b5/spec.md).
 There are certain attributes in Cloud Events that are mandatory. when emitting them through the CLI, the CLI will pick reasonable defaults.
 You can customize those defaults using CLI attributes:
 
 * `--source` - Event source. Defaults to `dispatch`
-* `--event-id` - Event ID, should be unique within the scope of producer. Defaults to generated UUIDv4. 
+* `--event-id` - Event ID, should be unique within the scope of producer. Defaults to generated UUIDv4.
 
 You can also provide following optional details about the emitted event:
 * `--event-type-version` - Version of the event, specific to the source. Defaults to empty string.
@@ -117,3 +206,6 @@ curl -X "POST" "https://${DISPATCH_URL}/v1/event/" \
   }
 }'
 ```
+
+> NOTE: The above example assume no authentication.  In a production environment, service account credentials must be
+> passed as a JWT bearer token to an Authorization HTTP header.


### PR DESCRIPTION
Remove stale and misleading documentation and add new documentation
which is current.

Also add AUTHORS.md file listing maintainers.

Signed-off-by: Berndt Jung <bjung@vmware.com>