### PR TITLE
Move the Meta object inline with API objects

### DIFF
--- a/pkg/api/v1/function.go
+++ b/pkg/api/v1/function.go
@@ -21,7 +21,7 @@ import (
 // swagger:model Function
 type Function struct {
 	// meta
-	Meta Meta `json:"meta"`
+	Meta
 
 	// source
 	Source strfmt.Base64 `json:"source,omitempty"`
@@ -31,12 +31,6 @@ type Function struct {
 
 	// only used in seed.yaml
 	SourcePath string `json:"sourcePath,omitempty"`
-
-	// created time
-	CreatedTime int64 `json:"createdTime,omitempty"`
-
-	// id
-	ID strfmt.UUID `json:"id,omitempty"`
 
 	// image
 	Image string `json:"image,omitempty"`
@@ -50,21 +44,8 @@ type Function struct {
 	// serviceAccount
 	ServiceAccount string `json:"-"`
 
-	// kind
-	// Read Only: true
-	// Pattern: ^[\w\d\-]+$
-	Kind string `json:"kind,omitempty"`
-
 	// handler
 	Handler string `json:"handler,omitempty"`
-
-	// modified time
-	ModifiedTime int64 `json:"modifiedTime,omitempty"`
-
-	// name
-	// Required: true
-	// Pattern: ^[\w\d][\w\d\-]*$
-	Name *string `json:"name,omitempty"`
 
 	// reason
 	Reason []string `json:"reason,omitempty"`
@@ -83,9 +64,6 @@ type Function struct {
 
 	// timeout
 	Timeout int64 `json:"timeout,omitempty"`
-
-	// tags
-	Tags []*Tag `json:"tags,omitempty"`
 }
 
 // Validate validates this function
@@ -184,7 +162,7 @@ func (m *Function) validateName(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := FieldPatternName.Validate("name", *m.Name); err != nil {
+	if err := FieldPatternName.Validate("name", m.Name); err != nil {
 		return err
 	}
 

--- a/pkg/api/v1/meta.go
+++ b/pkg/api/v1/meta.go
@@ -5,14 +5,24 @@
 
 package v1
 
+import strfmt "github.com/go-openapi/strfmt"
+
 // NO TESTS
 
 //Meta holds common metadata for API objects
 type Meta struct {
+	// Kind
+	// Read Only: true
+	// Pattern: ^[\w\d\-]+$
+	Kind string `json:"kind,omitempty"`
+
 	// Name
 	// Required: true
 	// Pattern: ^[\w\d][\w\d\-]*[\w\d]|[\w\d]+$
 	Name string `json:"name"`
+
+	// ID
+	ID strfmt.UUID `json:"id,omitempty"`
 
 	// Project
 	// Pattern: ^[\w\d][\w\d\-]*[\w\d]|[\w\d]+$
@@ -27,6 +37,13 @@ type Meta struct {
 	// CreatedTime
 	// ReadOnly: true
 	CreatedTime int64 `json:"createdTime,omitempty"`
+
+	// ModifiedTime
+	// ReadOnly: true
+	ModifiedTime int64 `json:"modifiedTime,omitempty"`
+
+	// Tags
+	Tags []*Tag `json:"tags,omitempty"`
 
 	// BackingObject
 	// ReadOnly: true

--- a/pkg/client/functions.go
+++ b/pkg/client/functions.go
@@ -335,7 +335,7 @@ func (c *DefaultFunctionsClient) UpdateFunction(ctx context.Context, organizatio
 		Context:      ctx,
 		XDispatchOrg: swag.String(c.getOrgID(organizationID)),
 		Body:         function,
-		FunctionName: *function.Name,
+		FunctionName: function.Name,
 	}
 	response, err := c.client.Store.UpdateFunction(&params)
 	if err != nil {

--- a/pkg/dispatchcli/cmd/create.go
+++ b/pkg/dispatchcli/cmd/create.go
@@ -153,7 +153,7 @@ func importBytes(out io.Writer, b []byte, actionMap map[string]ModelAction, acti
 					return err
 				}
 				if isDir && m.Handler == "" {
-					return fmt.Errorf("error creating function %s: handler is required, source path %s is a directory", *m.Name, sourcePath)
+					return fmt.Errorf("error creating function %s: handler is required, source path %s is a directory", m.Name, sourcePath)
 				}
 				sourceTarGz, err := utils.TarGzBytes(sourcePath)
 				if err != nil {
@@ -166,7 +166,7 @@ func importBytes(out io.Writer, b []byte, actionMap map[string]ModelAction, acti
 				return err
 			}
 			o.Functions = append(o.Functions, m)
-			fmt.Fprintf(out, "%s %s: %s\n", actionName, docKind, *m.Name)
+			fmt.Fprintf(out, "%s %s: %s\n", actionName, docKind, m.Name)
 		case utils.DriverTypeKind:
 			m := &v1.EventDriverType{}
 			err = yaml.Unmarshal(doc, m)

--- a/pkg/dispatchcli/cmd/create_function.go
+++ b/pkg/dispatchcli/cmd/create_function.go
@@ -99,16 +99,15 @@ func createFunction(out, errOut io.Writer, cmd *cobra.Command, args []string, c 
 	function := &v1.Function{
 		Meta: v1.Meta{
 			Name: args[0],
+			Tags: []*v1.Tag{},
 		},
 		// FunctionImageURL: functionImage,
 		Services: fnServices,
 		Image:    depsImage,
-		Name:     &args[0],
 		Source:   codeFileContent,
 		Handler:  handler,
 		Secrets:  fnSecrets,
 		Timeout:  timeout,
-		Tags:     []*v1.Tag{},
 	}
 
 	var schemaIn, schemaOut *spec.Schema

--- a/pkg/functions/backend/knative_test.go
+++ b/pkg/functions/backend/knative_test.go
@@ -32,6 +32,7 @@ const (
 func f1() *v1.Function {
 	return &v1.Function{
 		Meta: v1.Meta{
+			Kind:    utils.FunctionKind,
 			Org:     testOrg,
 			Project: testProject,
 			Name:    fn1,
@@ -39,13 +40,13 @@ func f1() *v1.Function {
 		FunctionImageURL: "dispatchframework/test-fn1",
 		Secrets:          []string{secret1, secret2},
 		Image:            "image1",
-		Kind:             utils.FunctionKind,
 	}
 }
 
 func f2() *v1.Function {
 	return &v1.Function{
 		Meta: v1.Meta{
+			Kind:    utils.FunctionKind,
 			Org:     testOrg,
 			Project: testProject,
 			Name:    fn2,
@@ -54,7 +55,6 @@ func f2() *v1.Function {
 		Timeout:          int64(5 * time.Minute),
 		Secrets:          []string{secret2, secret3},
 		Image:            "image2",
-		Kind:             utils.FunctionKind,
 	}
 }
 

--- a/pkg/functions/backend/knhelpers.go
+++ b/pkg/functions/backend/knhelpers.go
@@ -150,6 +150,6 @@ func ToFunction(service *knserve.Service) *dapi.Function {
 			function.Reason = append(function.Reason, cond.Reason)
 		}
 	}
-	function.Meta.BackingObject = service
+	function.BackingObject = service
 	return &function
 }

--- a/pkg/functions/gen/restapi/embedded_spec.go
+++ b/pkg/functions/gen/restapi/embedded_spec.go
@@ -1278,11 +1278,18 @@ func init() {
         "name"
       ],
       "properties": {
+        "backingObject": {
+          "description": "BackingObject",
+          "type": "object",
+          "x-go-name": "BackingObject",
+          "readOnly": true
+        },
         "createdTime": {
-          "description": "created time",
+          "description": "CreatedTime",
           "type": "integer",
           "format": "int64",
-          "x-go-name": "CreatedTime"
+          "x-go-name": "CreatedTime",
+          "readOnly": true
         },
         "functionImageURL": {
           "description": "functionImageURL",
@@ -1295,7 +1302,7 @@ func init() {
           "x-go-name": "Handler"
         },
         "id": {
-          "description": "id",
+          "description": "ID",
           "type": "string",
           "format": "uuid",
           "x-go-name": "ID"
@@ -1306,26 +1313,38 @@ func init() {
           "x-go-name": "Image"
         },
         "kind": {
-          "description": "kind",
+          "description": "Kind",
           "type": "string",
           "pattern": "^[\\w\\d\\-]+$",
           "x-go-name": "Kind",
           "readOnly": true
         },
-        "meta": {
-          "$ref": "#/definitions/functionMeta"
-        },
         "modifiedTime": {
-          "description": "modified time",
+          "description": "ModifiedTime",
           "type": "integer",
           "format": "int64",
-          "x-go-name": "ModifiedTime"
+          "x-go-name": "ModifiedTime",
+          "readOnly": true
         },
         "name": {
-          "description": "name",
+          "description": "Name",
           "type": "string",
-          "pattern": "^[\\w\\d][\\w\\d\\-]*$",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
           "x-go-name": "Name"
+        },
+        "org": {
+          "description": "Org",
+          "type": "string",
+          "default": "default",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
+          "x-go-name": "Org"
+        },
+        "project": {
+          "description": "Project",
+          "type": "string",
+          "default": "default",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
+          "x-go-name": "Project"
         },
         "reason": {
           "description": "reason",
@@ -1376,7 +1395,7 @@ func init() {
           "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
         },
         "tags": {
-          "description": "tags",
+          "description": "Tags",
           "type": "array",
           "items": {
             "$ref": "#/definitions/functionTagsItems"
@@ -1390,50 +1409,6 @@ func init() {
           "x-go-name": "Timeout"
         }
       },
-      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
-    },
-    "functionMeta": {
-      "description": "Meta holds common metadata for API objects",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "backingObject": {
-          "description": "BackingObject",
-          "type": "object",
-          "x-go-name": "BackingObject",
-          "readOnly": true
-        },
-        "createdTime": {
-          "description": "CreatedTime",
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "CreatedTime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "Name",
-          "type": "string",
-          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
-          "x-go-name": "Name"
-        },
-        "org": {
-          "description": "Org",
-          "type": "string",
-          "default": "default",
-          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
-          "x-go-name": "Org"
-        },
-        "project": {
-          "description": "Project",
-          "type": "string",
-          "default": "default",
-          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
-          "x-go-name": "Project"
-        }
-      },
-      "x-go-gen-location": "models",
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
     },
     "functionSchema": {

--- a/pkg/secret-store/gen/restapi/embedded_spec.go
+++ b/pkg/secret-store/gen/restapi/embedded_spec.go
@@ -789,6 +789,26 @@ func init() {
           "x-go-name": "CreatedTime",
           "readOnly": true
         },
+        "id": {
+          "description": "ID",
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "ID"
+        },
+        "kind": {
+          "description": "Kind",
+          "type": "string",
+          "pattern": "^[\\w\\d\\-]+$",
+          "x-go-name": "Kind",
+          "readOnly": true
+        },
+        "modifiedTime": {
+          "description": "ModifiedTime",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ModifiedTime",
+          "readOnly": true
+        },
         "name": {
           "description": "Name",
           "type": "string",
@@ -808,6 +828,32 @@ func init() {
           "default": "default",
           "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
           "x-go-name": "Project"
+        },
+        "tags": {
+          "description": "Tags",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/secretMetaTagsItems"
+          },
+          "x-go-name": "Tags"
+        }
+      },
+      "x-go-gen-location": "models",
+      "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"
+    },
+    "secretMetaTagsItems": {
+      "description": "Tag tag",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "key",
+          "type": "string",
+          "x-go-name": "Key"
+        },
+        "value": {
+          "description": "value",
+          "type": "string",
+          "x-go-name": "Value"
         }
       },
       "x-go-gen-location": "models",

--- a/swagger/models.json
+++ b/swagger/models.json
@@ -579,11 +579,18 @@
         "name"
       ],
       "properties": {
+        "backingObject": {
+          "description": "BackingObject",
+          "type": "object",
+          "x-go-name": "BackingObject",
+          "readOnly": true
+        },
         "createdTime": {
-          "description": "created time",
+          "description": "CreatedTime",
           "type": "integer",
           "format": "int64",
-          "x-go-name": "CreatedTime"
+          "x-go-name": "CreatedTime",
+          "readOnly": true
         },
         "functionImageURL": {
           "description": "functionImageURL",
@@ -596,7 +603,7 @@
           "x-go-name": "Handler"
         },
         "id": {
-          "description": "id",
+          "description": "ID",
           "type": "string",
           "format": "uuid",
           "x-go-name": "ID"
@@ -607,26 +614,38 @@
           "x-go-name": "Image"
         },
         "kind": {
-          "description": "kind",
+          "description": "Kind",
           "type": "string",
           "pattern": "^[\\w\\d\\-]+$",
           "x-go-name": "Kind",
           "readOnly": true
         },
-        "meta": {
-          "$ref": "#/definitions/Meta"
-        },
         "modifiedTime": {
-          "description": "modified time",
+          "description": "ModifiedTime",
           "type": "integer",
           "format": "int64",
-          "x-go-name": "ModifiedTime"
+          "x-go-name": "ModifiedTime",
+          "readOnly": true
         },
         "name": {
-          "description": "name",
+          "description": "Name",
           "type": "string",
-          "pattern": "^[\\w\\d][\\w\\d\\-]*$",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
           "x-go-name": "Name"
+        },
+        "org": {
+          "description": "Org",
+          "type": "string",
+          "default": "default",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
+          "x-go-name": "Org"
+        },
+        "project": {
+          "description": "Project",
+          "type": "string",
+          "default": "default",
+          "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
+          "x-go-name": "Project"
         },
         "reason": {
           "description": "reason",
@@ -675,7 +694,7 @@
           "$ref": "#/definitions/Status"
         },
         "tags": {
-          "description": "tags",
+          "description": "Tags",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Tag"
@@ -869,6 +888,26 @@
           "x-go-name": "CreatedTime",
           "readOnly": true
         },
+        "id": {
+          "description": "ID",
+          "type": "string",
+          "format": "uuid",
+          "x-go-name": "ID"
+        },
+        "kind": {
+          "description": "Kind",
+          "type": "string",
+          "pattern": "^[\\w\\d\\-]+$",
+          "x-go-name": "Kind",
+          "readOnly": true
+        },
+        "modifiedTime": {
+          "description": "ModifiedTime",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ModifiedTime",
+          "readOnly": true
+        },
         "name": {
           "description": "Name",
           "type": "string",
@@ -888,6 +927,14 @@
           "default": "default",
           "pattern": "^[\\w\\d][\\w\\d\\-]*[\\w\\d]|[\\w\\d]+$",
           "x-go-name": "Project"
+        },
+        "tags": {
+          "description": "Tags",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          },
+          "x-go-name": "Tags"
         }
       },
       "x-go-package": "github.com/vmware/dispatch/pkg/api/v1"


### PR DESCRIPTION
Use meta more like a base type (should the meta name remain?)

Signed-off-by: Berndt Jung <bjung@vmware.com>