### PR TITLE
Adding a new zookeeper-less controller used when no zookeeper configured

### DIFF
--- a/pkg/api-manager/controller.go
+++ b/pkg/api-manager/controller.go
@@ -18,14 +18,11 @@ import (
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/errors"
 	"github.com/vmware/dispatch/pkg/trace"
-	"github.com/vmware/dispatch/pkg/zookeeper"
 )
 
 // ControllerConfig defines configuration for controller
 type ControllerConfig struct {
-	ResyncPeriod      time.Duration
-	ZookeeperLocation string
-	Driver            zookeeper.Driver
+	ResyncPeriod time.Duration
 }
 
 type apiEntityHandler struct {
@@ -140,10 +137,8 @@ func (h *apiEntityHandler) Error(ctx context.Context, obj entitystore.Entity) er
 // NewController creates a new controller
 func NewController(config *ControllerConfig, store entitystore.EntityStore, gw gateway.Gateway) controller.Controller {
 	c := controller.NewController(controller.Options{
-		ServiceName:       "APIs",
-		ResyncPeriod:      config.ResyncPeriod,
-		ZookeeperLocation: config.ZookeeperLocation,
-		Driver:            config.Driver,
+		ServiceName:  "APIs",
+		ResyncPeriod: config.ResyncPeriod,
 	})
 
 	c.AddEntityHandler(&apiEntityHandler{store: store, gw: gw})

--- a/pkg/api-manager/controller_test.go
+++ b/pkg/api-manager/controller_test.go
@@ -18,31 +18,18 @@ import (
 	"github.com/vmware/dispatch/pkg/controller"
 	entitystore "github.com/vmware/dispatch/pkg/entity-store"
 	helpers "github.com/vmware/dispatch/pkg/testing/api"
-	zkmock "github.com/vmware/dispatch/pkg/zookeeper/mocks"
 )
 
 const (
-	testOrgID             = "dispatch"
-	testResyncPeriod      = 500 * time.Millisecond
-	testSleepDuration     = 2 * testResyncPeriod
-	testZookeeperLocation = "zookeeper.zookeeper.svc.cluster.local"
+	testOrgID         = "dispatch"
+	testResyncPeriod  = 500 * time.Millisecond
+	testSleepDuration = 2 * testResyncPeriod
 )
-
-func getTestDriver() *zkmock.Driver {
-	driver := &zkmock.Driver{}
-	driver.On("CreateNode", mock.Anything, mock.Anything).Return(nil)
-	driver.On("GetConnection").Return(nil)
-	driver.On("LockEntity", mock.Anything).Return("lock", true)
-	driver.On("ReleaseEntity", "lock").Return(nil)
-	driver.On("Close").Return(nil)
-	return driver
-}
 
 func getTestController(t *testing.T, es entitystore.EntityStore, gw gateway.Gateway) (controller.Controller, controller.Watcher) {
 
 	config := &ControllerConfig{
 		ResyncPeriod: testResyncPeriod,
-		Driver:       getTestDriver(),
 	}
 	ctrl := NewController(config, es, gw)
 	return ctrl, ctrl.Watcher()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/trace"
-	"github.com/vmware/dispatch/pkg/zookeeper"
 )
 
 // EntityHandler define an interface for entity operations of a generic controller
@@ -39,10 +37,8 @@ const defaultWorkers = 1
 type Options struct {
 	ServiceName string
 
-	ResyncPeriod      time.Duration
-	Workers           int
-	Driver            zookeeper.Driver
-	ZookeeperLocation string
+	ResyncPeriod time.Duration
+	Workers      int
 }
 
 // WatchEvent captures entity together with the associated context
@@ -85,7 +81,6 @@ type DefaultController struct {
 	done    chan bool
 	watcher chan WatchEvent
 	options Options
-	driver  zookeeper.Driver
 
 	entityHandlers map[reflect.Type]EntityHandler
 }
@@ -95,22 +90,11 @@ func NewController(options Options) Controller {
 	if options.Workers == 0 {
 		options.Workers = defaultWorkers
 	}
-	if options.ZookeeperLocation == "" {
-		options.ZookeeperLocation = "127.0.0.1"
-	}
-	if options.Driver == nil {
-		driver, err := zookeeper.NewDriver(options.ZookeeperLocation)
-		if err != nil {
-			log.Fatalf("Unable to get zookeeper driver for controller")
-		}
-		options.Driver = driver
-		log.Infof("Connected to zookeeper at address %v", options.ZookeeperLocation)
-	}
+
 	return &DefaultController{
 		done:    make(chan bool),
 		watcher: make(chan WatchEvent),
 		options: options,
-		driver:  options.Driver,
 
 		entityHandlers: map[reflect.Type]EntityHandler{},
 	}
@@ -145,19 +129,6 @@ func (dc *DefaultController) processItem(ctx context.Context, e entitystore.Enti
 	defer span.Finish()
 
 	log.Debugf("Processing Item: %v (%v) with status %v", e.GetName(), e.GetID(), e.GetStatus())
-
-	if err := dc.driver.CreateNode(fmt.Sprintf("/entities/%v", e.GetID()), []byte{}); err != nil {
-		log.Fatalf("Unable to create znode for %v (%v): %v", e.GetName(), e.GetID(), err)
-	} else {
-		log.Infof("Created znode /entities/%v", e.GetID())
-	}
-
-	lock, canModify := dc.driver.LockEntity(e.GetID())
-	if !canModify {
-		return errors.Errorf("Failed to acquire lock for %v. Someone else is processing this entity", e.GetID())
-	}
-	log.Infof("Acquired lock for %v", e.GetID())
-	defer dc.driver.ReleaseEntity(lock)
 
 	var err error
 	h, ok := dc.entityHandlers[reflect.TypeOf(e)]
@@ -233,9 +204,7 @@ func DefaultSync(ctx context.Context, store entitystore.EntityStore, entityType 
 func (dc *DefaultController) sync() error {
 	span, ctx := trace.Trace(context.Background(), "controller sync")
 	defer span.Finish()
-	if err := dc.driver.CreateNode("/entities", []byte{}); err != nil {
-		log.Fatalf("Unable to create overarching znode %v", err)
-	}
+
 	sem := semaphore.NewWeighted(int64(dc.options.Workers))
 	for _, handler := range dc.entityHandlers {
 		entities, err := handler.Sync(ctx, dc.options.ResyncPeriod)
@@ -267,11 +236,6 @@ func (dc *DefaultController) run(stopChan <-chan bool) {
 
 	defer close(dc.watcher)
 
-	defer dc.driver.Close()
-
-	if err := dc.driver.CreateNode("/entities", []byte{}); err != nil {
-		log.Fatalf("Unable to create overarching znode %v", err)
-	}
 	// Start a worker pool.  The pool scales up to dc.options.Workers.
 	go func() {
 		sem := semaphore.NewWeighted(int64(dc.options.Workers))

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -12,18 +12,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/vmware/dispatch/pkg/entity-store"
 	helpers "github.com/vmware/dispatch/pkg/testing/api"
-	zkmock "github.com/vmware/dispatch/pkg/zookeeper/mocks"
 )
 
 const (
-	testOrgID             = "testAPIManagerOrg"
-	testResyncPeriod      = 2 * time.Second
-	testSleepDuration     = 2 * testResyncPeriod
-	testZookeeperLocation = "zookeeper.zookeeper.svc.cluster.local"
+	testOrgID         = "testAPIManagerOrg"
+	testResyncPeriod  = 2 * time.Second
+	testSleepDuration = 2 * testResyncPeriod
 )
 
 type testEntity struct {
@@ -66,16 +63,6 @@ func (h *testEntityHandler) Error(ctx context.Context, obj entitystore.Entity) e
 	return nil
 }
 
-func getTestDriver() *zkmock.Driver {
-	driver := &zkmock.Driver{}
-	driver.On("CreateNode", mock.Anything, mock.Anything).Return(nil)
-	driver.On("GetConnection").Return(nil)
-	driver.On("LockEntity", mock.Anything).Return("lock", true)
-	driver.On("ReleaseEntity", "lock").Return(nil)
-	driver.On("Close").Return(nil)
-	return driver
-}
-
 func TestController(t *testing.T) {
 	ctx := context.Background()
 	store := helpers.MakeEntityStore(t)
@@ -83,11 +70,8 @@ func TestController(t *testing.T) {
 	deleteCounter := make(chan string, 100)
 	addCounter := make(chan string, 100)
 
-	zkDriver := getTestDriver()
-
 	controller := NewController(Options{
 		ResyncPeriod: testResyncPeriod,
-		Driver:       zkDriver,
 	})
 	controller.AddEntityHandler(&testEntityHandler{t: t, store: store, addCounter: addCounter, deleteCounter: deleteCounter})
 	watcher := controller.Watcher()

--- a/pkg/dispatchserver/apis.go
+++ b/pkg/dispatchserver/apis.go
@@ -75,8 +75,7 @@ func initAPIs(config *serverConfig, store entitystore.EntityStore, gw gateway.Ga
 	api := operations.NewAPIManagerAPI(swaggerSpec)
 
 	apiController := apimanager.NewController(&apimanager.ControllerConfig{
-		ResyncPeriod:      config.ResyncPeriod,
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
 	}, store, gw)
 	apiController.Start()
 

--- a/pkg/dispatchserver/config.go
+++ b/pkg/dispatchserver/config.go
@@ -98,6 +98,6 @@ func configGlobalFlags(flags *pflag.FlagSet) {
 	flags.Bool("enable-tls", false, "Enable TLS (HTTPS) listener.")
 
 	flags.String("tracer", "", "OpenTracing-compatible Tracer URL")
-	flags.String("zookeeper-location", "", "URL pointing to the location of a zookeeper service")
+	flags.String("zookeeper-location", "", "URL pointing to the location of a zookeeper service (for Riff only)")
 	flags.Bool("debug", false, "Enable debugging logs")
 }

--- a/pkg/dispatchserver/events.go
+++ b/pkg/dispatchserver/events.go
@@ -142,8 +142,7 @@ func initEvents(config *serverConfig, deps eventsDependencies) (http.Handler, fu
 		deps.driversBackend,
 		deps.store,
 		eventmanager.EventControllerConfig{
-			ResyncPeriod:      config.ResyncPeriod,
-			ZookeeperLocation: config.ZookeeperLocation,
+			ResyncPeriod: config.ResyncPeriod,
 		},
 	)
 

--- a/pkg/dispatchserver/functions.go
+++ b/pkg/dispatchserver/functions.go
@@ -167,8 +167,7 @@ func initFunctions(config *serverConfig, deps functionsDependencies) (http.Handl
 	api := operations.NewFunctionManagerAPI(swaggerSpec)
 
 	c := &functionmanager.ControllerConfig{
-		ResyncPeriod:      config.ResyncPeriod,
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
 	}
 
 	r := runner.New(&runner.Config{

--- a/pkg/dispatchserver/identity.go
+++ b/pkg/dispatchserver/identity.go
@@ -74,7 +74,7 @@ func initIdentity(config *serverConfig, store entitystore.EntityStore) (http.Han
 	enforcer := identitymanager.SetupEnforcer(store)
 
 	// Create the identity controller
-	controller := identitymanager.NewIdentityController(store, enforcer, config.ResyncPeriod, config.ZookeeperLocation)
+	controller := identitymanager.NewIdentityController(store, enforcer, config.ResyncPeriod)
 	controller.Start()
 
 	handlers := identitymanager.NewHandlers(controller.Watcher(), store, enforcer)

--- a/pkg/dispatchserver/images.go
+++ b/pkg/dispatchserver/images.go
@@ -65,8 +65,7 @@ func initImages(config *serverConfig, store entitystore.EntityStore) (http.Handl
 	api := operations.NewImageManagerAPI(swaggerSpec)
 
 	c := &imagemanager.ControllerConfig{
-		ResyncPeriod:      config.ResyncPeriod,
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
 	}
 
 	registryAuth := config.RegistryAuth

--- a/pkg/dispatchserver/services.go
+++ b/pkg/dispatchserver/services.go
@@ -83,8 +83,7 @@ func initServices(config *serverConfig, store entitystore.EntityStore, secretsCl
 
 	controller := servicemanager.NewController(
 		&servicemanager.ControllerConfig{
-			ResyncPeriod:      config.ResyncPeriod,
-			ZookeeperLocation: config.ZookeeperLocation,
+			ResyncPeriod: config.ResyncPeriod,
 		},
 		store,
 		k8sClient,

--- a/pkg/event-manager/controller.go
+++ b/pkg/event-manager/controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vmware/dispatch/pkg/entity-store"
 	"github.com/vmware/dispatch/pkg/event-manager/drivers"
 	"github.com/vmware/dispatch/pkg/event-manager/subscriptions"
-	"github.com/vmware/dispatch/pkg/zookeeper"
 )
 
 // Event manager constants
@@ -23,10 +22,8 @@ const (
 
 // EventControllerConfig defines configuration for controller
 type EventControllerConfig struct {
-	ResyncPeriod      time.Duration
-	WorkerNumber      int
-	ZookeeperLocation string
-	Driver            zookeeper.Driver
+	ResyncPeriod time.Duration
+	WorkerNumber int
 }
 
 // NewEventController creates a new controller to manage the reconciliation of event manager entities
@@ -40,11 +37,9 @@ func NewEventController(manager subscriptions.Manager, backend drivers.Backend, 
 	}
 
 	c := controller.NewController(controller.Options{
-		ResyncPeriod:      config.ResyncPeriod,
-		Workers:           config.WorkerNumber,
-		ServiceName:       "events",
-		ZookeeperLocation: config.ZookeeperLocation,
-		Driver:            config.Driver,
+		ResyncPeriod: config.ResyncPeriod,
+		Workers:      config.WorkerNumber,
+		ServiceName:  "events",
 	})
 
 	c.AddEntityHandler(drivers.NewEntityHandler(store, backend))

--- a/pkg/event-manager/controller_test.go
+++ b/pkg/event-manager/controller_test.go
@@ -9,39 +9,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-
 	"github.com/vmware/dispatch/pkg/entity-store"
 	mocks2 "github.com/vmware/dispatch/pkg/event-manager/drivers/mocks"
 	"github.com/vmware/dispatch/pkg/event-manager/subscriptions/entities"
 	"github.com/vmware/dispatch/pkg/event-manager/subscriptions/mocks"
 	helpers "github.com/vmware/dispatch/pkg/testing/api"
-	zkmock "github.com/vmware/dispatch/pkg/zookeeper/mocks"
 )
-
-const (
-	testZookeeperLocation = "zookeeper.zookeeper.svc.cluster.local"
-)
-
-func getTestDriver() *zkmock.Driver {
-	driver := &zkmock.Driver{}
-	driver.On("CreateNode", mock.Anything, mock.Anything).Return(nil)
-	driver.On("GetConnection").Return(nil)
-	driver.On("LockEntity", mock.Anything).Return("lock", true)
-	driver.On("ReleaseEntity", "lock").Return(nil)
-	driver.On("Close").Return(nil)
-	return driver
-}
 
 func TestControllerRun(t *testing.T) {
 	manager := &mocks.Manager{}
 	k8sBackend := &mocks2.Backend{}
 	es := helpers.MakeEntityStore(t)
 
-	controller := NewEventController(manager, k8sBackend, es, EventControllerConfig{
-		ZookeeperLocation: testZookeeperLocation,
-		Driver:            getTestDriver(),
-	})
+	controller := NewEventController(manager, k8sBackend, es, EventControllerConfig{})
 	controller.Start()
 	controller.Shutdown()
 }
@@ -51,10 +31,7 @@ func TestControllerRunWithSubs(t *testing.T) {
 	k8sBackend := &mocks2.Backend{}
 	es := helpers.MakeEntityStore(t)
 
-	controller := NewEventController(manager, k8sBackend, es, EventControllerConfig{
-		ZookeeperLocation: testZookeeperLocation,
-		Driver:            getTestDriver(),
-	})
+	controller := NewEventController(manager, k8sBackend, es, EventControllerConfig{})
 	defer controller.Shutdown()
 	controller.Start()
 

--- a/pkg/function-manager/controller.go
+++ b/pkg/function-manager/controller.go
@@ -25,8 +25,7 @@ import (
 
 // ControllerConfig is the function manager controller configuration
 type ControllerConfig struct {
-	ResyncPeriod      time.Duration
-	ZookeeperLocation string
+	ResyncPeriod time.Duration
 }
 
 type funcEntityHandler struct {
@@ -397,10 +396,9 @@ func (h *runEntityHandler) Error(ctx context.Context, obj entitystore.Entity) er
 func NewController(config *ControllerConfig, store entitystore.EntityStore, faas functions.FaaSDriver, runner functions.Runner, imgClient ImageGetter, imageBuilder functions.ImageBuilder) controller.Controller {
 
 	c := controller.NewController(controller.Options{
-		ResyncPeriod:      config.ResyncPeriod,
-		Workers:           1000, // want more functions concurrently? add more workers // TODO configure workers
-		ServiceName:       "functions",
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
+		Workers:      1000, // want more functions concurrently? add more workers // TODO configure workers
+		ServiceName:  "functions",
 	})
 	c.AddEntityHandler(&funcEntityHandler{Store: store, FaaS: faas, ImgClient: imgClient, ImageBuilder: imageBuilder})
 	c.AddEntityHandler(&runEntityHandler{Store: store, FaaS: faas, Runner: runner})

--- a/pkg/identity-manager/controller.go
+++ b/pkg/identity-manager/controller.go
@@ -15,11 +15,10 @@ import (
 )
 
 // NewIdentityController creates a new controller to manage the reconciliation of policy entities
-func NewIdentityController(store entitystore.EntityStore, enforcer *casbin.SyncedEnforcer, resync time.Duration, zookeeper string) controller.Controller {
+func NewIdentityController(store entitystore.EntityStore, enforcer *casbin.SyncedEnforcer, resync time.Duration) controller.Controller {
 	c := controller.NewController(controller.Options{
-		ResyncPeriod:      resync,
-		Workers:           5, // TODO: make this configurable
-		ZookeeperLocation: zookeeper,
+		ResyncPeriod: resync,
+		Workers:      5, // TODO: make this configurable
 	})
 
 	c.AddEntityHandler(&policyEntityHandler{store: store, enforcer: enforcer})

--- a/pkg/image-manager/controller.go
+++ b/pkg/image-manager/controller.go
@@ -20,8 +20,7 @@ import (
 
 // ControllerConfig defines the image manager controller configuration
 type ControllerConfig struct {
-	ResyncPeriod      time.Duration
-	ZookeeperLocation string
+	ResyncPeriod time.Duration
 }
 
 type baseImageEntityHandler struct {
@@ -188,10 +187,9 @@ func (h *imageEntityHandler) Error(ctx context.Context, obj entitystore.Entity) 
 // NewController creates a new image manager controller
 func NewController(config *ControllerConfig, store entitystore.EntityStore, baseImageBuilder *BaseImageBuilder, imageBuilder *ImageBuilder) controller.Controller {
 	c := controller.NewController(controller.Options{
-		ResyncPeriod:      config.ResyncPeriod,
-		Workers:           10, // want more functions concurrently? add more workers // TODO configure workers
-		ServiceName:       "images",
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
+		Workers:      10, // want more functions concurrently? add more workers // TODO configure workers
+		ServiceName:  "images",
 	})
 
 	c.AddEntityHandler(&baseImageEntityHandler{Store: store, Builder: baseImageBuilder})

--- a/pkg/service-manager/controller.go
+++ b/pkg/service-manager/controller.go
@@ -25,8 +25,7 @@ var serviceClassOrganizationID = "___global___"
 
 // ControllerConfig defines the image manager controller configuration
 type ControllerConfig struct {
-	ResyncPeriod      time.Duration
-	ZookeeperLocation string
+	ResyncPeriod time.Duration
 }
 
 type serviceClassEntityHandler struct {
@@ -468,9 +467,8 @@ func (h *serviceBindingEntityHandler) Error(ctx context.Context, obj entitystore
 // NewController creates a new service manager controller
 func NewController(config *ControllerConfig, store entitystore.EntityStore, brokerClient clients.BrokerClient) controller.Controller {
 	c := controller.NewController(controller.Options{
-		ResyncPeriod:      config.ResyncPeriod,
-		Workers:           10, // want more functions concurrently? add more workers // TODO configure workers
-		ZookeeperLocation: config.ZookeeperLocation,
+		ResyncPeriod: config.ResyncPeriod,
+		Workers:      10, // want more functions concurrently? add more workers // TODO configure workers
 	})
 
 	c.AddEntityHandler(&serviceClassEntityHandler{Store: store, BrokerClient: brokerClient})


### PR DESCRIPTION
Modifies the NewController method to act as a factory method. Returns a JungleController (DefaultController with Zookeeper dependencies removed) when no zookeeper path is provided. Returns the DefaultController otherwise.