### PR TITLE
Add installer script/image for knative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ db.bolt
 /*tls.key
 ci-config.yml
 env.sh
+*key.json

--- a/images/knative-installer-gke/Dockerfile
+++ b/images/knative-installer-gke/Dockerfile
@@ -1,0 +1,31 @@
+from photon:latest
+
+RUN tdnf install -y \
+    go \
+    docker \
+    git \
+    tar \
+    gzip
+
+ENV GOPATH="/root/go"
+RUN go get github.com/google/go-containerregistry/cmd/ko
+
+RUN mkdir -p ${GOPATH}/src/github.com/knative && \
+    cd ${GOPATH}/src/github.com/knative && \
+    git clone https://github.com/knative/serving.git
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv kubectl /usr/local/bin/kubectl
+
+RUN curl -OL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-218.0.0-linux-x86_64.tar.gz && \
+    tar xzf google-cloud-sdk-218.0.0-linux-x86_64.tar.gz && \
+    mv google-cloud-sdk /usr/local/lib/google-cloud-sdk
+
+COPY setup_knative.sh /usr/local/bin/setup_knative
+RUN chmod +x /usr/local/bin/setup_knative
+
+ENV PATH="${GOPATH}/bin:/usr/local/lib/google-cloud-sdk/bin:${PATH}"
+ENTRYPOINT ["setup_knative"]
+CMD ["$@"]
+

--- a/images/knative-installer-gke/setup_knative.sh
+++ b/images/knative-installer-gke/setup_knative.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+PROJECT=${1}
+export K8S_CLUSTER_OVERRIDE="${2}"
+KEY_FILE=${3}
+
+REVISION=${4}
+: ${REVISION:=origin/master}
+
+cd ${GOPATH}/src/github.com/knative/serving
+git fetch origin
+git checkout ${REVISION}
+
+gcloud auth activate-service-account --key-file ${KEY_FILE}
+gcloud auth configure-docker -q
+
+SA_USER=$(gcloud config list account --format "value(core.account)")
+export K8S_USER_OVERRIDE="${SA_USER}"
+export KO_DOCKER_REPO="gcr.io/${PROJECT}"
+export DOCKER_REPO_OVERRIDE="${KO_DOCKER_REPO}"
+
+kubectl create clusterrolebinding cluster-admin-binding \
+    --clusterrole=cluster-admin \
+    --user="${K8S_USER_OVERRIDE}"
+
+kubectl apply -f ./third_party/istio-1.0.2/istio.yaml
+kubectl apply -f ./third_party/config/build/release.yaml
+
+ko apply -f config/

--- a/scripts/install-knative.py
+++ b/scripts/install-knative.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import subprocess
+import argparse
+import pathlib
+import json
+import os
+import sys
+
+def install():
+    parser = argparse.ArgumentParser(description='Install dispatch dependencies')
+    parser.add_argument("cluster", help="gke cluster name")
+    parser.add_argument("--gcloud-key", dest="gcloud_key", required=True, help="gcloud service account key (json format)")
+    parser.add_argument("--revision", dest="revision", default="origin/master", help="knative serving revision")
+    opts = parser.parse_args()
+
+    with open(opts.gcloud_key) as fh:
+        key_contents = json.load(fh)
+
+    home = pathlib.Path.home()
+
+    cmd = [
+        '/usr/local/bin/docker',
+        'run',
+        '-v',
+        '%s/.kube:/root/.kube' % home,
+        '-v',
+        '%s:/root/key.json' % os.path.abspath(opts.gcloud_key),
+        '-v',
+        '/var/run/docker.sock:/var/run/docker.sock',
+        'dispatchframework/knative-installer-gke:0.1',
+        key_contents["project_id"],
+        opts.cluster,
+        '/root/key.json',
+        opts.revision]
+
+    ret = subprocess.run(cmd)
+    sys.exit(ret.returncode)
+
+if __name__ == "__main__":
+    install()


### PR DESCRIPTION
Dispatch depends on a non-released version on knative.
The script and image make it easy to install on a gke
kubernetes cluster.

Signed-off-by: Berndt Jung <bjung@vmware.com>