### PR TITLE
CLI completion for bash added.

### DIFF
--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -204,6 +204,7 @@ func NewCLI(in io.Reader, out, errOut io.Writer) *cobra.Command {
 	cmds.AddCommand(NewCmdManage(out, errOut))
 	cmds.AddCommand(NewCmdLog(out, errOut))
 	cmds.AddCommand(NewCmdContext(out, errOut))
+	cmds.AddCommand(NewCmdCompletion(out))
 	return cmds
 }
 

--- a/pkg/dispatchcli/cmd/completion.go
+++ b/pkg/dispatchcli/cmd/completion.go
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////
+// Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+///////////////////////////////////////////////////////////////////////
+
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vmware/dispatch/pkg/dispatchcli/i18n"
+)
+
+// NewCmdCompletion creates a completion command for CLI
+func NewCmdCompletion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: i18n.T("Generates bash completion scripts."),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmds.GenBashCompletion(os.Stdout)
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Fixes: #122

This is a minimal addition to support CLI completion for bash. More features (e.g., zsh support) can be implemented in the future. 