### PR TITLE
Rebuild API cache from entitystore

### DIFF
--- a/pkg/api-manager/gateway/local/gateway_test.go
+++ b/pkg/api-manager/gateway/local/gateway_test.go
@@ -28,7 +28,7 @@ func TestGatewayGetRequest(t *testing.T) {
 	fnClient.On("RunFunction", mock.Anything, mock.Anything, mock.Anything).Return(
 		&v1.Run{}, nil,
 	)
-	gw, err := NewGateway(fnClient)
+	gw, err := NewGateway(nil, fnClient)
 	assert.NoError(t, err)
 
 	api1 := &gateway.API{
@@ -71,7 +71,7 @@ func TestGatewayPostRequest(t *testing.T) {
 	fnClient.On("RunFunction", mock.Anything, mock.Anything, mock.Anything).Return(
 		&v1.Run{}, nil,
 	)
-	gw, err := NewGateway(fnClient)
+	gw, err := NewGateway(nil, fnClient)
 	assert.NoError(t, err)
 
 	api1 := &gateway.API{

--- a/pkg/api-manager/handlers.go
+++ b/pkg/api-manager/handlers.go
@@ -56,6 +56,10 @@ func apiModelOntoEntity(organizationID string, m *v1.API) *API {
 	} else {
 		uris = m.Uris
 	}
+	var methods []string
+	for _, method := range m.Methods {
+		methods = append(methods, strings.ToUpper(method))
+	}
 	e := API{
 		BaseEntity: entitystore.BaseEntity{
 			Name:           *m.Name,
@@ -70,7 +74,7 @@ func apiModelOntoEntity(organizationID string, m *v1.API) *API {
 			Enabled:        m.Enabled,
 			TLS:            m.TLS,
 			Hosts:          m.Hosts,
-			Methods:        m.Methods,
+			Methods:        methods,
 			Protocols:      m.Protocols,
 			URIs:           uris,
 			CORS:           m.Cors,

--- a/pkg/dispatchserver/local.go
+++ b/pkg/dispatchserver/local.go
@@ -75,7 +75,7 @@ func runLocal(config *serverConfig) {
 	functionsHandler, functionsShutdown := initFunctions(config, functionsDeps)
 	defer functionsShutdown()
 
-	gw, err := local.NewGateway(functions)
+	gw, err := local.NewGateway(store, functions)
 	if err != nil {
 		log.Fatalf("Error creating API Gateway: %v", err)
 	}


### PR DESCRIPTION
* API cache now works across restarts of dispatch server
* Ensure all HTTP methods are stored as uppercase

Fix #691 

Signed-off-by: Berndt Jung <bjung@vmware.com>