### PR TITLE
Fix image creation/deletion issue

### DIFF
--- a/e2e/tests/functions.bats
+++ b/e2e/tests/functions.bats
@@ -15,7 +15,7 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function node-hello-no-schema -o json | jq -r .status" "READY" 8 2
+    run_with_retry "dispatch get function node-hello-no-schema -o json | jq -r .status" "READY" 
 }
 
 @test "Create a function with duplicate name" {
@@ -28,7 +28,7 @@ load variables
 }
 
 @test "Execute node function no schema" {
-    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 10 5
+    run_with_retry "dispatch exec node-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell"  
 }
 
 @test "Delete node function no schema" {
@@ -36,7 +36,7 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get runs node-hello-no-schema -o json | jq '. | length'" 0 5 2
+    run_with_retry "dispatch get runs node-hello-no-schema -o json | jq '. | length'" 0 
 }
 
 @test "Create python function no schema" {
@@ -44,11 +44,11 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function python-hello-no-schema -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get function python-hello-no-schema -o json | jq -r .status" "READY" 
 }
 
 @test "Execute python function no schema" {
-    run_with_retry "dispatch exec python-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec python-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 
 }
 
 @test "Create powershell function no schema" {
@@ -56,29 +56,29 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function powershell-hello-no-schema -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function powershell-hello-no-schema -o json | jq -r .status" "READY" 
 }
 
 @test "Execute powershell function no schema" {
-    run_with_retry "dispatch exec powershell-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec powershell-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 
 }
 
 @test "Create powershell function with runtime deps" {
     skip "Skipped until #602 is resolved"
     run dispatch create image powershell-with-slack powershell-base --runtime-deps ${DISPATCH_ROOT}/examples/powershell/requirements.psd1
     assert_success
-    run_with_retry "dispatch get image powershell-with-slack -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get image powershell-with-slack -o json | jq -r .status" "READY" 
 
     run dispatch create function --image=powershell-with-slack powershell-slack ${DISPATCH_ROOT}/examples/powershell --handler=test-slack.ps1::handle
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function powershell-slack -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function powershell-slack -o json | jq -r .status" "READY" 
 }
 
 @test "Execute powershell with runtime deps" {
     skip "Skipped until #602 is resolved"
-    run_with_retry "dispatch exec powershell-slack --wait -o json | jq -r .output.result" "true" 5 2
+    run_with_retry "dispatch exec powershell-slack --wait -o json | jq -r .output.result" "true" 
 }
 
 @test "Create java function no schema" {
@@ -86,27 +86,27 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function java-hello-no-schema -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function java-hello-no-schema -o json | jq -r .status" "READY" 
 }
 
 @test "Execute java function no schema" {
-    run_with_retry "dispatch exec java-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec java-hello-no-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output" "Hello, Jon from Winterfell" 
 }
 
 @test "Create java function with runtime deps" {
     run dispatch create image java-with-deps java-base --runtime-deps ${DISPATCH_ROOT}/examples/java/hello-with-deps/pom.xml
     assert_success
-    run_with_retry "dispatch get image java-with-deps -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get image java-with-deps -o json | jq -r .status" "READY" 
 
     run dispatch create function --image=java-with-deps java-hello-with-deps ${DISPATCH_ROOT}/examples/java/hello-with-deps --handler=io.dispatchframework.examples.HelloWithDeps
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function java-hello-with-deps -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function java-hello-with-deps -o json | jq -r .status" "READY" 
 }
 
 @test "Execute java with runtime deps" {
-    run_with_retry "dispatch exec java-hello-with-deps --wait -o json | jq -r .output" "Hello, Someone from timezone UTC" 5 2
+    run_with_retry "dispatch exec java-hello-with-deps --wait -o json | jq -r .output" "Hello, Someone from timezone UTC" 
 }
 
 @test "Create java function with classes" {
@@ -114,28 +114,28 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function java-hello-with-classes -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function java-hello-with-classes -o json | jq -r .status" "READY" 
 }
 
 @test "Execute java with classes" {
-    run_with_retry "dispatch exec java-hello-with-classes --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec java-hello-with-classes --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 
 }
 
 @test "Create java function with spring support" {
     run dispatch create image java-spring java-base --runtime-deps ${DISPATCH_ROOT}/examples/java/spring-pom.xml
     assert_success
 
-    run_with_retry "dispatch get image java-spring -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get image java-spring -o json | jq -r .status" "READY" 
 
     run dispatch create function --image=java-spring spring-fn ${DISPATCH_ROOT}/examples/java/hello-with-deps --handler=io.dispatchframework.examples.HelloSpring
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function spring-fn -o json | jq -r .status" "READY" 20 2
+    run_with_retry "dispatch get function spring-fn -o json | jq -r .status" "READY" 
 }
 
 @test "Execute java with spring support" {
-    run_with_retry "dispatch exec spring-fn --input='{\"name\":\"Jon\", \"place\":\"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec spring-fn --input='{\"name\":\"Jon\", \"place\":\"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 
 }
 
 @test "Create node function with schema" {
@@ -143,11 +143,11 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function node-hello-with-schema -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get function node-hello-with-schema -o json | jq -r .status" "READY" 
 }
 
 @test "Execute node function with schema" {
-    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 5 2
+    run_with_retry "dispatch exec node-hello-with-schema --input='{\"name\": \"Jon\", \"place\": \"Winterfell\"}' --wait -o json | jq -r .output.myField" "Hello, Jon from Winterfell" 
 }
 
 @test "Validate schema errors" {
@@ -155,7 +155,7 @@ load variables
 }
 
 @test "Execute node function with input schema error" {
-    run_with_retry "dispatch exec node-hello-with-schema --wait -o json | jq -r .error.type" "InputError" 5 2
+    run_with_retry "dispatch exec node-hello-with-schema --wait -o json | jq -r .error.type" "InputError" 
 }
 
 @test "Create python function with runtime deps" {
@@ -163,11 +163,11 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function http -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get function http -o json | jq -r .status" "READY" 
 }
 
 @test "Execute python function with runtime deps" {
-    run_with_retry "dispatch exec http --wait -o json | jq -r .output.status" "200" 5 2
+    run_with_retry "dispatch exec http --wait -o json | jq -r .output.status" "200" 
 }
 
 @test "Create python function with invalid handler" {
@@ -175,8 +175,8 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function invalid -o json | jq -r .status" "ERROR" 5 2
-    run_with_retry "dispatch get function invalid -o json | jq -r '.reason | length'" "1" 5 2
+    run_with_retry "dispatch get function invalid -o json | jq -r .status" "ERROR" 
+    run_with_retry "dispatch get function invalid -o json | jq -r '.reason | length'" "1" 
 }
 
 @test "Create python function with logging" {
@@ -193,25 +193,25 @@ EOF
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function logger -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get function logger -o json | jq -r .status" "READY" 
 }
 
 @test "Execute python function with logging" {
-    run_with_retry "dispatch exec logger --wait -o json | jq -r \".logs.stderr | .[0]\"" "this goes to stderr" 5 2
-    run_with_retry "dispatch exec logger --wait -o json | jq -r \".logs.stdout | .[0]\"" "this goes to stdout" 5 2
+    run_with_retry "dispatch exec logger --wait -o json | jq -r \".logs.stderr | .[0]\"" "this goes to stderr" 
+    run_with_retry "dispatch exec logger --wait -o json | jq -r \".logs.stdout | .[0]\"" "this goes to stdout" 
 }
 
 @test "Execute function with a literal value payload" {
-    run_with_retry "dispatch exec http --input='42' --wait -o json | jq -r .output.status" "200" 5 2
+    run_with_retry "dispatch exec http --input='42' --wait -o json | jq -r .output.status" "200" 
 }
 
 @test "Update function python" {
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f function_update.yaml
     assert_success
 
-    run_with_retry "dispatch get function python-hello-no-schema -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get function python-hello-no-schema -o json | jq -r .status" "READY" 
 
-    run_with_retry "dispatch exec python-hello-no-schema --wait -o json | jq -r .output.myField" "Goodbye, Noone from Nowhere" 6 2
+    run_with_retry "dispatch exec python-hello-no-schema --wait -o json | jq -r .output.myField" "Goodbye, Noone from Nowhere"
 }
 
 @test "Delete functions" {

--- a/e2e/tests/images.bats
+++ b/e2e/tests/images.bats
@@ -16,7 +16,7 @@ load variables
 
     # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
     run_with_retry "dispatch get base-image base-nodejs -o json | jq -r .status" "INITIALIZED" 1 0
-    run_with_retry "dispatch get base-image base-nodejs -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get base-image base-nodejs -o json | jq -r .status" "READY"
 
     # Create base image "base-python3"
     run dispatch create base-image base-python3 $DOCKER_REGISTRY/$BASE_IMAGE_PYTHON3 --language python3
@@ -24,28 +24,28 @@ load variables
 
     # Ensure starting status is "INITIALIZED". Wait 20 seconds for status "READY"
     run_with_retry "dispatch get base-image base-python3 -o json | jq -r .status" "INITIALIZED" 1 0
-    run_with_retry "dispatch get base-image base-python3 -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get base-image base-python3 -o json | jq -r .status" "READY"
 
     # Create base image "base-powershell"
     run dispatch create base-image base-powershell $DOCKER_REGISTRY/$BASE_IMAGE_POWERSHELL --language powershell
     assert_success
 
     run_with_retry "dispatch get base-image base-powershell -o json | jq -r .status" "INITIALIZED" 1 0
-    run_with_retry "dispatch get base-image base-powershell -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get base-image base-powershell -o json | jq -r .status" "READY"
 
     # Create base image "base-java"
     run dispatch create base-image base-java $DOCKER_REGISTRY/$BASE_IMAGE_JAVA --language java
     assert_success
 
     run_with_retry "dispatch get base-image base-java -o json | jq -r .status" "INITIALIZED" 1 0
-    run_with_retry "dispatch get base-image base-java -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get base-image base-java -o json | jq -r .status" "READY"
 
     # Create fifth image with non-existing image. Check that get operation returns five images. Wait for "ERROR" status for missing image.
     run dispatch create base-image missing-image missing/image:latest --language nodejs
     assert_success
     run bash -c "dispatch get base-image -o json | jq '. | length'"
     assert_equal 5 $output
-    run_with_retry "dispatch get base-image missing-image -o json | jq -r .status" "ERROR" 30 2
+    run_with_retry "dispatch get base-image missing-image -o json | jq -r .status" "ERROR"
 }
 
 @test "Image creation" {
@@ -57,10 +57,10 @@ load variables
     assert_success
     run dispatch create image java base-java
     assert_success
-    run_with_retry "dispatch get image nodejs -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get image python3 -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get image powershell -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get image java -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get image nodejs -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get image python3 -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get image powershell -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get image java -o json | jq -r .status" "READY"
 }
 
 @test "Delete images" {
@@ -69,8 +69,7 @@ load variables
     for i in $output; do
         run dispatch delete image $i
     done
-    run_with_retry "dispatch get images -o json | jq '. | length'" 0 8 2
-    sleep 10
+    run_with_retry "dispatch get images -o json | jq '. | length'" 0
 }
 
 @test "Delete base images" {
@@ -79,8 +78,7 @@ load variables
     for i in $output; do
         run dispatch delete base-image $i
     done
-    run_with_retry "dispatch get base-images -o json | jq '. | length'" 0 16 2
-    sleep 10
+    run_with_retry "dispatch get base-images -o json | jq '. | length'" 0
 }
 
 @test "Batch load images" {
@@ -92,18 +90,18 @@ load variables
     run dispatch create --file=https://raw.githubusercontent.com/vmware/dispatch/master/examples/seed.yaml --work-dir=test_create_by_url
     assert_success
 
-    run_with_retry "dispatch get function hello-js -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get function hello-py -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get function http-py -o json | jq -r .status" "READY" 30 2
-    run_with_retry "dispatch get function hello-ps1 -o json | jq -r .status" "READY" 30 2
+    run_with_retry "dispatch get function hello-js -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get function hello-py -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get function http-py -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get function hello-ps1 -o json | jq -r .status" "READY"
 }
 
 @test "Update images" {
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f images_update.yaml
     assert_success
 
-    run_with_retry "dispatch get image python3 -o json | jq -r .status" "READY" 6 2
-    run_with_retry "dispatch get base-image nodejs-base -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get image python3 -o json | jq -r .status" "READY"
+    run_with_retry "dispatch get base-image nodejs-base -o json | jq -r .status" "READY"
 
     run_with_retry "dispatch get base-image nodejs-base -o json | jq -r .language" "python3" 1 0
     assert_success

--- a/e2e/tests/secrets.bats
+++ b/e2e/tests/secrets.bats
@@ -20,7 +20,7 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function i-have-a-default-secret -o json | jq -r .status" "READY" 15 2
+    run_with_retry "dispatch get function i-have-a-default-secret -o json | jq -r .status" "READY"
 }
 
 @test "Create function without a default secret" {
@@ -28,16 +28,16 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function i-have-a-secret -o json | jq -r .status" "READY" 8 2
+    run_with_retry "dispatch get function i-have-a-secret -o json | jq -r .status" "READY"
 }
 
 @test "Execute function with a default secret" {
-    run_with_retry "dispatch exec i-have-a-default-secret --wait -o json | jq -r .output.message" "The password is OpenSesame" 5 2
+    run_with_retry "dispatch exec i-have-a-default-secret --wait -o json | jq -r .output.message" "The password is OpenSesame"
 }
 
 @test "Execute function without a default secret" {
     run_with_retry "dispatch exec i-have-a-secret --wait -o json | jq -r .output.message" "I know nothing" 5 2
-    run_with_retry "dispatch exec i-have-a-secret --secret open-sesame --wait -o json | jq -r .output.message" "The password is OpenSesame" 5 2
+    run_with_retry "dispatch exec i-have-a-secret --secret open-sesame --wait -o json | jq -r .output.message" "The password is OpenSesame"
 }
 
 @test "Validate invalid secret errors" {
@@ -48,7 +48,7 @@ load variables
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f secret_update.yaml
     assert_success
 
-    run_with_retry "dispatch get secret open-sesame -o json | jq -r .secrets.password" "OpenSesameStreet" 5 2
+    run_with_retry "dispatch get secret open-sesame -o json | jq -r .secrets.password" "OpenSesameStreet"
 }
 
 @test "Delete secrets" {

--- a/e2e/tests/variables.bash
+++ b/e2e/tests/variables.bash
@@ -8,3 +8,5 @@
 : ${BASE_IMAGE_JAVA:="java-base:0.0.13"}
 : ${IMAGES_YAML:="images.yaml"}
 : ${DISPATCH_ORGANIZATION:=${DISPATCH_ORGANIZATION:-dispatch}}
+: ${RET_NR:=30}
+: ${WAIT_T:=2}

--- a/pkg/image-manager/handlers.go
+++ b/pkg/image-manager/handlers.go
@@ -251,9 +251,7 @@ func (h *Handlers) getBaseImages(params baseimage.GetBaseImagesParams, principal
 	var images []*BaseImage
 
 	var err error
-	opts := entitystore.Options{
-		Filter: entitystore.FilterExists(),
-	}
+	opts := entitystore.Options{}
 	err = h.Store.List(ctx, params.XDispatchOrg, opts, &images)
 	if err != nil {
 		log.Errorf("store error when listing base images: %+v", err)
@@ -425,9 +423,7 @@ func (h *Handlers) getImages(params image.GetImagesParams, principal interface{}
 	var images []*Image
 
 	var err error
-	opts := entitystore.Options{
-		Filter: entitystore.FilterExists(),
-	}
+	opts := entitystore.Options{}
 	opts.Filter, err = utils.ParseTags(opts.Filter, params.Tags)
 	if err != nil {
 		log.Errorf(err.Error())

--- a/pkg/image-manager/handlers_test.go
+++ b/pkg/image-manager/handlers_test.go
@@ -188,7 +188,6 @@ func TestBaseImageDeleteBaseImageByNameHandler(t *testing.T) {
 
 	getResponder = api.BaseImageGetBaseImagesHandler.Handle(get, "testCookie")
 	helpers.HandlerRequest(t, getResponder, &getBody, 200)
-	assert.Len(t, getBody, 0)
 }
 
 func TestImageAddImageHandler(t *testing.T) {
@@ -384,5 +383,4 @@ func TestImageDeleteImagesByNameHandler(t *testing.T) {
 
 	getResponder = api.ImageGetImagesHandler.Handle(get, "testCookie")
 	helpers.HandlerRequest(t, getResponder, &getBody, 200)
-	assert.Len(t, getBody, 0)
 }


### PR DESCRIPTION
There is a race condition with images where image might be in deleting
state, causing list API to not include it in the result, but also
not allowing to create a new one with the same name. This patch
attempts to fix it by always returning all images in the list, regardless of their
state, until the actual record is deleted from the database.

Also makes e2e number of retries and wait times configurable via global
variable (can still be specified in the retry function itself)