### PR TITLE
change events gateway flag in e2e

### DIFF
--- a/ci/e2e/run-tests.yml
+++ b/ci/e2e/run-tests.yml
@@ -40,7 +40,7 @@ run:
 
     cp dispatch-binaries/dispatch-server-linux /usr/local/bin/dispatch-server
 
-    dispatch-server --host 0.0.0.0 --port $INGRESS_PORT --gateway-port $API_GATEWAY_HTTP_PORT --api-endpoint 172.17.0.1:$INGRESS_PORT --debug > $(pwd)/tests-logs/server.log 2>&1 &
+    dispatch-server --host 0.0.0.0 --port $INGRESS_PORT --gateway-port $API_GATEWAY_HTTP_PORT --events-gateway 172.17.0.1:$INGRESS_PORT --debug > $(pwd)/tests-logs/server.log 2>&1 &
 
     sleep 5
 


### PR DESCRIPTION
#713 changed the flag name, but there was one place where it wasn't changed (e2e tests). This PR fixes that.

Also, should we run e2e on every PR in solo, given the tests run much shorter now? It's around ~14 minutes now (we could run automatically if there is a change in *.go or e2e files)