### PR TITLE
Add Dispatch Solo OVA release pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,9 @@ cli-darwin:
 cli-linux:
 	GOOS=linux go build -ldflags "$(GO_LDFLAGS) $(CLI_LDFLAGS)" -o bin/$(CLI)-linux ./cmd/$(CLI)
 
+.PHONY: binaries
+binaries: linux darwin
+
 .PHONY: toolbox
 toolbox:
 	GOOS=linux go build -ldflags "$(GO_LDFLAGS) $(CLI_LDFLAGS)" -o bin/toolbox ./cmd/toolbox

--- a/ci/pipelines/ova-release.yml
+++ b/ci/pipelines/ova-release.yml
@@ -31,7 +31,7 @@ resources:
   source:
     initial_version: 0.0.1
     bucket: ((s3-ci-bucket-name))
-    key: solo-version
+    key: dispatch-solo-version
     region_name: ((s3-ci-bucket-region-name))
     access_key_id: ((s3-ci-bucket-access-key))
     secret_access_key: ((s3-ci-bucket-secret-key))
@@ -98,7 +98,7 @@ jobs:
       params:
         file: dispatch-logs/*.tar.gz
 
-- name: build-ova
+- name: release
   public: true
   plan:
   - get: version
@@ -108,6 +108,17 @@ jobs:
   - get: dispatch
     resource: dispatch-solo
     passed: [test-dispatch-solo]
+  - task: prepare-version
+    file: dispatch/ci/tasks/prepare-version.yml
+  - task: build-binaries
+    file: dispatch/ci/tasks/binaries.yml
+  - put: gh-release
+    params:
+      name: release-context/tag
+      tag: release-context/tag
+      commitish: release-context/branch
+      globs:
+      - dispatch-binaries/dispatch-*
   - task: build-ova
     file: dispatch/ci/tasks/build-ova.yml
     privileged: true

--- a/ci/tasks/binaries.yml
+++ b/ci/tasks/binaries.yml
@@ -11,6 +11,9 @@ inputs:
 - name: dispatch
   path: src/github.com/vmware/dispatch
 
+- name: release-context
+  optional: true
+
 outputs:
 - name: dispatch-binaries
 
@@ -22,6 +25,9 @@ run:
     set -e -u -x
 
     export GOPATH=$PWD
+    if [[ -e release-context/tag ]]; then
+      export VERSION=$(cat release-context/tag)
+    fi
     cd $GOPATH/src/github.com/vmware/dispatch
-    make linux
+    make binaries
     mv bin/* $GOPATH/dispatch-binaries/

--- a/ci/tasks/build-ova.yml
+++ b/ci/tasks/build-ova.yml
@@ -10,6 +10,9 @@ inputs:
 - name: dispatch
   path: src/github.com/vmware/dispatch
 
+- name: release-context
+  optional: true
+
 outputs:
 - name: dispatch-ova
 
@@ -53,6 +56,13 @@ run:
 
 
     export GOPATH=$PWD
+
+    export GOPATH=$PWD
+    if [[ -e release-context/tag ]]; then
+      export VERSION=$(cat release-context/tag)
+      export TAG=${VERSION}
+    fi
+
     cd $GOPATH/src/github.com/vmware/dispatch
     make ova-binaries
     pushd ova

--- a/ci/tasks/prepare-version.yml
+++ b/ci/tasks/prepare-version.yml
@@ -11,7 +11,7 @@ inputs:
 - name: version
 
 outputs:
-- name: build-context
+- name: release-context
 
 run:
   path: /bin/bash
@@ -21,4 +21,5 @@ run:
     set -e -x -u
 
     export IMAGE_TAG=v$(cat version/version)-solo
-    echo ${IMAGE_TAG} > build-context/tag
+    echo ${IMAGE_TAG} > release-context/tag
+    echo solo > release-context/branch

--- a/e2e/tests/apis.bats
+++ b/e2e/tests/apis.bats
@@ -12,11 +12,11 @@ load variables
 
     run dispatch create base-image base-nodejs $DOCKER_REGISTRY/$BASE_IMAGE_NODEJS6 --language nodejs
     assert_success
-    run_with_retry "dispatch get base-image base-nodejs -o json | jq -r .status" "READY" 8 2
+    run_with_retry "dispatch get base-image base-nodejs -o json | jq -r .status" "READY"
 
     run dispatch create image nodejs base-nodejs
     assert_success
-    run_with_retry "dispatch get image nodejs -o json | jq -r .status" "READY" 8 2
+    run_with_retry "dispatch get image nodejs -o json | jq -r .status" "READY"
 }
 
 @test "Create Functions for test" {
@@ -24,13 +24,13 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function func-nodejs -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get function func-nodejs -o json | jq -r .status" "READY"
 
     run dispatch create function --image=nodejs node-echo-back ${DISPATCH_ROOT}/examples/nodejs --handler=./debug.js
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get function node-echo-back -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get function node-echo-back -o json | jq -r .status" "READY"
 }
 
 @test "Test APIs with HTTP(S)" {
@@ -38,36 +38,36 @@ load variables
     echo_to_log
     assert_success
 
-    run_with_retry "dispatch get api api-test-http -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get api api-test-http -o json | jq -r .status" "READY"
 
     echo "${API_GATEWAY_HTTPS_HOST}"
 
     run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/http -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"HTTP\"
-        }' | jq -r .myField" "Hello, VMware from HTTP" 6 2
+        }' | jq -r .myField" "Hello, VMware from HTTP"
 
     run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/http -k -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"HTTPS\"
-        }' | jq -r .myField" "Hello, VMware from HTTPS" 6 2
+        }' | jq -r .myField" "Hello, VMware from HTTPS"
 }
 
 @test "Test APIs with HTTPS ONLY" {
     run dispatch create api api-test-https-only func-nodejs -m POST --https-only -p /https-only --auth public
     echo_to_log
     assert_success
-    run_with_retry "dispatch get api api-test-https-only -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get api api-test-https-only -o json | jq -r .status" "READY"
 
     run_with_retry "curl -s -X POST ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/https-only -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"HTTPS ONLY\"
-        }' | jq -r .message" "Please use HTTPS protocol" 6 2
+        }' | jq -r .message" "Please use HTTPS protocol"
 
     run_with_retry "curl -s -X POST ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/https-only -k -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"HTTPS ONLY\"
-        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY" 6 2
+        }' | jq -r .myField" "Hello, VMware from HTTPS ONLY"
 }
 
 @test "Test APIs with Kong Plugins" {
@@ -75,24 +75,24 @@ load variables
     run dispatch create api api-test func-nodejs -m GET -m DELETE -m POST -m PUT -p /hello --auth public
     echo_to_log
     assert_success
-    run_with_retry "dispatch get api api-test -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get api api-test -o json | jq -r .status" "READY"
 
     run dispatch create api api-echo node-echo-back -m GET -m DELETE -m POST -m PUT -p /echo --auth public
     echo_to_log
     assert_success
-    run_with_retry "dispatch get api api-echo -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get api api-echo -o json | jq -r .status" "READY"
 
     # "x-dispatch-blocking: true" is default header
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -d '{ \
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
-        }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 2
+        }' | jq -r .myField" "Hello, VMware from Palo Alto"
 
     # with "x-dispatch-blocking: false", it will not return an result
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-blocking: false' -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
-        }'" "" 6 2
+        }'" ""
 
     # with "x-dispatch-org: invalid", setting this header should have no effect as it's overwritten by the plugin.
     # if the plugin fails to overwrite this HEADER, it will allow end-users to switch orgs and this test should fail
@@ -100,59 +100,59 @@ load variables
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k -H \"Content-Type: application/json\" -H 'x-dispatch-org: invalid' -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
-        }' | jq -r .myField" "Hello, VMware from Palo Alto" 6 2
+        }' | jq -r .myField" "Hello, VMware from Palo Alto"
 
     # PUT with no content-type and no payload
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 2
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere"
 
     # PUT with json content-type and non-json payload
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
-        -H \"Content-Type: application/json\" -d \"not a json payload\" | jq -r .message" "request body is not json" 6 2
+        -H \"Content-Type: application/json\" -d \"not a json payload\" | jq -r .message" "request body is not json"
 
     # PUT with x-www-form-urlencoded content-type and x-www-form-urlencoded payload
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
-        -H \"Content-Type: application/x-www-form-urlencoded\" -d \"name=VMware&place=Palo Alto\" | jq -r .myField" "Hello, VMware from Palo Alto" 6 2
+        -H \"Content-Type: application/x-www-form-urlencoded\" -d \"name=VMware&place=Palo Alto\" | jq -r .myField" "Hello, VMware from Palo Alto"
 
     # PUT with non-supported content-type and payload
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k \
-        -H \"Content-Type: unsupported-content-type\" -d \"some payload\" | jq -r .message" "request body type is not supported: unsupported-content-type" 6 2
+        -H \"Content-Type: unsupported-content-type\" -d \"some payload\" | jq -r .message" "request body type is not supported: unsupported-content-type"
 
     # GET with parameters
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto" 6 2
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello?name=vmware\&place=PaloAlto -k | jq -r .myField" "Hello, vmware from PaloAlto"
 
     # GET without parameters
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 2
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere"
 
     # Test HTTP Context
-    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/echo -k | jq -r .context.httpContext.method" "PUT" 6 2
+    run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/echo -k | jq -r .context.httpContext.method" "PUT"
 }
 
 @test "Test APIs with CORS" {
     run dispatch create api api-test-cors func-nodejs -m POST -m PUT -p /cors --auth public --cors
     echo_to_log
     assert_success
-    run_with_retry "dispatch get api api-test-cors -o json | jq -r .status" "READY" 10 2
+    run_with_retry "dispatch get api api-test-cors -o json | jq -r .status" "READY"
 
     # contains "Access-Control-Allow-Origin: *"
     run_with_retry "curl -s -X PUT ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/cors -k -v -H \"Content-Type: application/json\" -d '{
             \"name\": \"VMware\",
             \"place\": \"Palo Alto\"
-        }' 2>&1 | grep -c \"Access-Control-Allow-Origin: *\"" 1 10 2
+        }' 2>&1 | grep -c \"Access-Control-Allow-Origin: *\"" 1
 }
 
 @test "Test API Updates" {
     run dispatch create api api-test-update func-nodejs -m GET -p /hello --auth public
     assert_success
-    run_with_retry "dispatch get api api-test-update -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get api api-test-update -o json | jq -r .status" "READY"
 
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTP_HOST}/${DISPATCH_ORGANIZATION}/hello -k | jq -r .myField" "Hello, Noone from Nowhere"
 
     # update path and https
     run dispatch update --work-dir ${BATS_TEST_DIRNAME} -f api_update.yaml
     assert_success
-    run_with_retry "dispatch get api api-test-update -o json | jq -r .status" "READY" 6 2
+    run_with_retry "dispatch get api api-test-update -o json | jq -r .status" "READY"
 
-    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/goodbye -k | jq -r .myField" "Hello, Noone from Nowhere" 6 5
+    run_with_retry "curl -s -X GET ${API_GATEWAY_HTTPS_HOST}/${DISPATCH_ORGANIZATION}/goodbye -k | jq -r .myField" "Hello, Noone from Nowhere"
 }
 
 @test "Cleanup" {


### PR DESCRIPTION
Fixes #663 
Fixes #664

Pipeline tracks version and triggers e2e tests for every version bump.
Revision that passes tests is then used to build an OVA. OVA is stored
on an S3 bucket. There is also a Github release created for that
version.

Also changes the API e2e tests to use default  timeout and retry values
(previous values were too low and caused tests failures despite the
gateway functioning correctly)

### Testing
tested via private pipeline https://ci.dispatchframework.io/teams/main/pipelines/kstepniewski-test-ova-release