### PR TITLE
Fix fetching g/w https port in CLI

### DIFF
--- a/pkg/dispatchcli/cmd/cmd.go
+++ b/pkg/dispatchcli/cmd/cmd.go
@@ -41,8 +41,8 @@ type hostConfig struct {
 	Namespace      string `json:"namespace,omitempty"`
 	JSON           bool   `json:"-"`
 	Output         string `json:"-"`
-	APIHTTPSPort   int    `json:"api-https-port,omitempty"`
-	APIHTTPPort    int    `json:"api-http-port,omitempty"`
+	APIHTTPSPort   int    `mapstructure:"api-https-port" json:"api-https-port,omitempty"`
+	APIHTTPPort    int    `mapstructure:"api-http-port" json:"api-http-port,omitempty"`
 	Token          string `json:"-"`
 	ServiceAccount string `json:"serviceaccount,omitempty"`
 	JWTPrivateKey  string `json:"jwtprivatekey,omitempty"`


### PR DESCRIPTION
API G/W port is not displayed correctly in the CLI output as we fail to unmarshal correctly from dispatch config (Viper uses `mapstructure` tag)

Also, skip adding 443 to https URL's as that's the standard port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/dispatch/758)
<!-- Reviewable:end -->
