### PR TITLE
Workaround for ovfenv not working after a reboot

### DIFF
--- a/ova/bootable/build-app.sh
+++ b/ova/bootable/build-app.sh
@@ -35,13 +35,8 @@ chage -I -1 -m 0 -M 99999 -E -1 root
 log3 "configuring ${brprpl}UTC${reset} timezone"
 ln --force --symbolic /usr/share/zoneinfo/UTC /etc/localtime
 
-## TODO: This causes issues on photon 2.0, debug or remove permanently when root cause
-## is discovered
-#log3 "configuring ${brprpl}en_US.UTF-8${reset} locale"
-#/usr/bin/touch /etc/locale.conf
-#/bin/echo "LANG=en_US.UTF-8" > /etc/locale.conf
-#/bin/echo "en_US.UTF-8 UTF-8" > /etc/locale-gen.conf
-#/sbin/locale-gen.sh
+log3 "configuring ${brprpl}en_US.UTF-8${reset} locale"
+/bin/echo "LANG=en_US.UTF-8" > /etc/locale.conf
 
 log3 "configuring ${brprpl}haveged${reset}"
 systemctl enable haveged

--- a/ova/scripts/systemd/scripts/network-config.sh
+++ b/ova/scripts/systemd/scripts/network-config.sh
@@ -15,6 +15,11 @@
 
 network_conf_file=/etc/systemd/network/09-dispatch.network
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# shellcheck source=./ovfenv_wrapper.sh
+source "${SCRIPT_DIR}/ovfenv_wrapper.sh"
+
 mask2cdr () {
   set -- 0^^^128^192^224^240^248^252^254^ ${#1} ${1##*255.}
   set -- $(( ($2 - ${#3})*2 )) ${1%%${3%%.*}*}

--- a/ova/scripts/systemd/scripts/ovfenv_wrapper.sh
+++ b/ova/scripts/systemd/scripts/ovfenv_wrapper.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2017-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euf -o pipefail
+
+OVF_CACHE_DIR="/etc/vmware/ovfcache"
+
+mkdir -p ${OVF_CACHE_DIR}
+
+function ovfenv() {
+    # wrapper around ovfenv to cache values if ovfenv returns empty responses
+    local key=${2}
+    local ovf_available=""
+    local cache_file="${OVF_CACHE_DIR}/${key}"
+
+    if /usr/bin/ovfenv >/dev/null 2>&1; then
+        ovf_available="yes"
+    fi
+
+    if [[ $# -eq 4 ]]; then
+        # Write mode: --key key --set value
+        local value=${4}
+        if [[ -n ${ovf_available} ]]; then
+            /usr/bin/ovfenv --key "${key}" --set "${value}"
+        fi
+        echo "${value}" > "${cache_file}"
+    else
+        # read mode: --key key
+        if [[ -n ${ovf_available} ]]; then
+            # ovfenv works, read the value, cache it and return it
+            local value
+            value=$(/usr/bin/ovfenv --key "${key}")
+            echo "${value}" > "${cache_file}"
+            echo "${value}"
+        elif [[ -e ${cache_file} ]]; then
+            # ovfenv borked, use cache
+            cat "${cache_file}"
+        else
+            # oh well
+            echo ""
+        fi
+    fi
+}

--- a/ova/scripts/systemd/scripts/sshd_permitrootlogin.sh
+++ b/ova/scripts/systemd/scripts/sshd_permitrootlogin.sh
@@ -16,6 +16,11 @@
 # remove all default settings
 sed -i "/^PermitRootLogin.*/d" /etc/ssh/sshd_config
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# shellcheck source=./ovfenv_wrapper.sh
+source "${SCRIPT_DIR}/ovfenv_wrapper.sh"
+
 # TODO use environment file
 PERMIT="$(ovfenv --key appliance.permit_root_login)"
 


### PR DESCRIPTION
Add a wrapper around ovfenv that checks if ovf properties are properly
returned. If not, read the data from the cache stored on disk.

Fixes #754 
Fixes #747 

### Additional fixes:
- Correctly sets the locale
- creates firstboot file so that firstboot-only scripts do not execute
  again
- use `HOST` instead of `HOSTNAME` as `HOSTNAME` is a built-in variable

### Testing:
- tested in fusion 11.0.2
- tested on VMC