### PR TITLE
Correct link from Quick Start to Examples

### DIFF
--- a/docs/_front/quickstart.md
+++ b/docs/_front/quickstart.md
@@ -157,6 +157,6 @@ $ dispatch exec hello-world --input '{"name": "Jon", "place": "Winterfell"}' --w
 }
 ```
 
-Check out the [examples section]({{ '/documentation/documentation/examples/examples' | relative_url }}) for a full list of examples.
+Check out the [examples section]({{ '/documentation/examples/examples' | relative_url }}) for a full list of examples.
 
 Now go build something!


### PR DESCRIPTION
The current link was broken and results in a 404.