### PR TITLE
Use UnixNano for run's executed and finished time

### DIFF
--- a/ci/pipelines/ova-release.yml
+++ b/ci/pipelines/ova-release.yml
@@ -99,7 +99,7 @@ jobs:
   on_failure:
     do:
     - task: Collect logs
-      file: dispatch/ci/e2e/collect-logs.yml
+      file: dispatch/ci/tasks/collect-logs.yml
     - put: logs-bucket
       params:
         file: dispatch-logs/*.tar.gz

--- a/pkg/dispatchcli/cmd/get_run.go
+++ b/pkg/dispatchcli/cmd/get_run.go
@@ -218,8 +218,8 @@ func formatRunOutput(out io.Writer, list bool, header bool, runs []v1.Run) error
 			run.Name.String(),
 			run.FunctionName,
 			string(run.Status),
-			time.Unix(run.ExecutedTime, 0).Local().Format(time.UnixDate),
-			time.Unix(run.FinishedTime, 0).Local().Format(time.UnixDate),
+			time.Unix(0, run.ExecutedTime).Local().Format(time.RFC3339Nano),
+			time.Unix(0, run.FinishedTime).Local().Format(time.RFC3339Nano),
 		})
 	}
 	table.Render()

--- a/pkg/function-manager/handlers.go
+++ b/pkg/function-manager/handlers.go
@@ -191,8 +191,8 @@ func runEntityToModel(f *functions.FnRun) *v1.Run {
 		tags = append(tags, &v1.Tag{Key: k, Value: v})
 	}
 	return &v1.Run{
-		ExecutedTime: f.CreatedTime.Unix(),
-		FinishedTime: f.FinishedTime.Unix(),
+		ExecutedTime: f.CreatedTime.UnixNano(),
+		FinishedTime: f.FinishedTime.UnixNano(),
 		Name:         strfmt.UUID(f.Name),
 		Blocking:     f.Blocking,
 		Input:        f.Input,


### PR DESCRIPTION
With dispatch solo the differences between times go below one second,
making it harder to differentiate and order runs. It was also causing e2e tests to fail randomly.

This patch changes the time sent over the wire from Unix to UnixNano
(from seconds since Jan 1 1970 to nanoseconds since Jan 1 1970).
_Note:_ This only changes the value exposed over the API, not the internally stored representation.

```
dispatch get runs
                   ID                  |      FUNCTION       | STATUS |            STARTED             |            FINISHED
-----------------------------------------------------------------------------------------------------------------------------------
  300d4303-b00d-4477-b595-6124376addcf | node-echo-back-6016 | READY  | 2018-11-29T00:03:31.470876867Z | 2018-11-29T00:03:31.474510739Z
  d2dc1c54-1ac1-4bc8-8987-ebc8b9779b64 | node-echo-back-6016 | READY  | 2018-11-29T00:03:31.110100254Z | 2018-11-29T00:03:31.162239329Z
```


Also fixed a typo in a release pipeline (already applied to concourse)