### PR TITLE
Set restart policy to always in function and event driver containers

### DIFF
--- a/pkg/event-manager/drivers/docker_backend.go
+++ b/pkg/event-manager/drivers/docker_backend.go
@@ -118,7 +118,11 @@ func (d *dockerBackend) Deploy(ctx context.Context, driver *entities.Driver) err
 			},
 		}
 
-		hostConfig := &container.HostConfig{}
+		hostConfig := &container.HostConfig{
+			RestartPolicy: container.RestartPolicy{
+				Name: "always",
+			},
+		}
 
 		if driver.Expose {
 			config.ExposedPorts = nat.PortSet{

--- a/pkg/functions/docker/driver.go
+++ b/pkg/functions/docker/driver.go
@@ -98,6 +98,9 @@ func (d *Driver) Create(ctx context.Context, f *functions.Function) error {
 	}, &container.HostConfig{
 		NetworkMode:  "bridge",
 		PortBindings: nat.PortMap{functionAPIPort: []nat.PortBinding{{HostPort: "0"}}},
+		RestartPolicy: container.RestartPolicy{
+			Name: "always",
+		},
 	}, nil, containerName)
 	if err != nil {
 		return errors.Wrapf(err, "error creating container %s", containerName)


### PR DESCRIPTION
Setting `always` policy ensures containers are restarted after OVA is
rebooted.

Tested on Fusion, after reboot function and event drivers are up and
working properly