### PR TITLE
Fix redirect to latest ova

### DIFF
--- a/ci/s3/redirect.json
+++ b/ci/s3/redirect.json
@@ -11,7 +11,8 @@
                 "KeyPrefixEquals": "ova/dispatch-latest-solo.ova"
             },
             "Redirect": {
-                "ReplaceKeyWith": "ova/DISPATCH_OVA"
+                "ReplaceKeyWith": "ova/DISPATCH_OVA",
+                "HttpRedirectCode" : "302"
             }
         }
     ]


### PR DESCRIPTION
The redirect to the latest ova is done using s3 bucket routing rules. It redirects by default with HTTP code `301`. This results in a permanent cache for the link in the browser and will never redirect to new releases until you clear the cache. Hence, change it to `302` which implies a temporary redirect.

**Note: I already fixed the rules manually so this doesn't need a new release**