### PR TITLE
Add WithURL opt to driverclient

### DIFF
--- a/pkg/events/driverclient/http_test.go
+++ b/pkg/events/driverclient/http_test.go
@@ -4,3 +4,62 @@
 ///////////////////////////////////////////////////////////////////////
 
 package driverclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithNoOpts(t *testing.T) {
+	client, err := newHTTPClient()
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://localhost:8080/v1/event/ingest", client.getURL())
+}
+
+func TestWithGateway(t *testing.T) {
+	opt := WithGateway("172.17.0.1:8080")
+	client, err := newHTTPClient(opt)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://172.17.0.1:8080/v1/event/ingest", client.getURL())
+}
+
+func TestWithHost(t *testing.T) {
+	opt := WithHost("example.com")
+	client, err := newHTTPClient(opt)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://example.com:8080/v1/event/ingest", client.getURL())
+}
+
+func TestWithDefaultPort(t *testing.T) {
+	opt := WithPort("")
+	client, err := newHTTPClient(opt)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://localhost:8080/v1/event/ingest", client.getURL())
+}
+
+func TestWithPort(t *testing.T) {
+	opt := WithPort("8081")
+	client, err := newHTTPClient(opt)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://localhost:8081/v1/event/ingest", client.getURL())
+}
+
+func TestWithURL(t *testing.T) {
+	opt := WithURL("http://example.com/my/path")
+	client, err := newHTTPClient(opt)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	assert.Equal(t, "http://example.com/my/path", client.getURL())
+}


### PR DESCRIPTION
To make our event drivers compatible with knative container source, they must be able to send events to an HTTP URL. None of the current driverclient options allow that.