### PR TITLE
Fix docker registry and minio endpoints

### DIFF
--- a/scripts/values.sh
+++ b/scripts/values.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
 
-: ${DISPATCH_NAMESPACE:="dispatch"}
 : ${DISPATCH_SERVER_DOCKER_REPOSITORY:="vmware"}
 : ${VALUES_PATH:="values.yaml"}
 
@@ -9,11 +8,11 @@ image:
   host: ${DISPATCH_SERVER_DOCKER_REPOSITORY}
   tag: ${TAG}
 registry:
-  url: http://${DISPATCH_NAMESPACE}-docker-registry:5000/
-  repository: ${DISPATCH_NAMESPACE}-docker-registry:5000
+  url: http://dispatch-docker-registry:5000/
+  repository: dispatch-docker-registry:5000
 storage:
   minio:
-    address: ${DISPATCH_NAMESPACE}-minio:9000
+    address: dispatch-minio:9000
     username: ${MINIO_USERNAME}
     password: ${MINIO_PASSWORD}
 EOF


### PR DESCRIPTION
Values for Dispatch helm chart use hard-coded values for docker registry
and minio endpoints. The values.yaml should reflect that.